### PR TITLE
feat: syllable-lyrics follow-up enhancements

### DIFF
--- a/src-tauri/src/commands/gamdl.rs
+++ b/src-tauri/src/commands/gamdl.rs
@@ -991,6 +991,61 @@ pub async fn check_redownload_status(
     }))
 }
 
+/// Fetches syllable-level (word-by-word) TTML lyrics for a single song from
+/// the Apple Music API.
+///
+/// **Frontend caller:** `fetchSyllableLyrics(storefront, songId)` in `src/lib/tauri-commands.ts`
+///
+/// Requires MusicKit credentials (Team ID, Key ID, private key) and a valid
+/// `media-user-token` cookie for subscriber authentication. Returns the raw
+/// TTML XML string if available, or `None` if the song has no syllable-level
+/// lyrics.
+///
+/// # Arguments
+/// * `app` - Tauri `AppHandle` for settings and keychain access.
+/// * `storefront` - Apple Music storefront code (e.g., "us", "gb").
+/// * `song_id` - Numeric Apple Music song ID.
+///
+/// # Returns
+/// * `Ok(Some(String))` - TTML XML lyrics content.
+/// * `Ok(None)` - No syllable-level lyrics available for this song.
+/// * `Err(String)` - Credentials missing, expired cookies, or API error.
+#[tauri::command]
+pub async fn fetch_syllable_lyrics(
+    app: AppHandle,
+    storefront: String,
+    song_id: String,
+) -> Result<Option<String>, String> {
+    use crate::services::{apple_music_api, config_service};
+
+    // Resolve MusicKit credentials and generate JWT
+    let settings = config_service::load_settings(&app).unwrap_or_default();
+    let private_key = apple_music_api::get_private_key_from_keychain()
+        .map_err(|e| format!("Keychain error: {e}"))?;
+    let jwt = apple_music_api::resolve_musickit_developer_token(
+        settings.musickit_team_id.as_deref(),
+        settings.musickit_key_id.as_deref(),
+        private_key.as_deref(),
+    )
+    .map_err(|e| format!("JWT error: {e}"))?
+    .ok_or(
+        "MusicKit credentials not configured. Set up Team ID, Key ID, and private key in Settings > Advanced > API Credentials."
+    )?;
+
+    // Extract media-user-token from cookies file
+    let cookies_path = settings.cookies_path.as_deref().ok_or(
+        "Apple Music cookies not configured. Import cookies from your browser in Settings > Authentication.",
+    )?;
+    let music_user_token = apple_music_api::extract_media_user_token(cookies_path)
+        .map_err(|e| format!("Cookie error: {e}"))?
+        .ok_or(
+            "Apple Music subscriber token not found or expired. Re-import cookies from your browser in Settings > Authentication."
+        )?;
+
+    // Fetch syllable lyrics from the Apple Music API
+    apple_music_api::fetch_syllable_lyrics(&jwt, &storefront, &song_id, &music_user_token).await
+}
+
 /// Information about a previous download of the same URL.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RedownloadInfo {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1011,6 +1011,8 @@ pub fn run() {
             commands::gamdl::import_manifest,
             // Smart re-download detection (#263)
             commands::gamdl::check_redownload_status,
+            // Syllable-level lyrics fetch (#306)
+            commands::gamdl::fetch_syllable_lyrics,
             // Credential storage commands
             commands::credentials::store_credential,
             commands::credentials::get_credential,

--- a/src-tauri/src/services/apple_music_api.rs
+++ b/src-tauri/src/services/apple_music_api.rs
@@ -52,6 +52,11 @@ use serde::{Deserialize, Serialize};
 /// be extracted from binaries and should be scoped/rotated operationally.
 const EMBEDDED_MUSICKIT_DEVELOPER_TOKEN: Option<&str> = option_env!("MUSICKIT_DEVELOPER_TOKEN");
 
+/// The cookie name used by Apple Music's web client to store the subscriber
+/// authentication token. Shared across modules that need to detect or extract
+/// this cookie (login window webview, Netscape cookie file parsing).
+pub const MEDIA_USER_TOKEN_COOKIE_NAME: &str = "media-user-token";
+
 // ============================================================
 // Public Types
 // ============================================================
@@ -1102,7 +1107,7 @@ pub fn extract_media_user_token(cookies_path: &str) -> Result<Option<String>, St
             continue;
         }
         let fields: Vec<&str> = line.split('\t').collect();
-        if fields.len() >= 7 && fields[5] == "media-user-token" {
+        if fields.len() >= 7 && fields[5] == MEDIA_USER_TOKEN_COOKIE_NAME {
             let value = fields[6].trim();
             if value.is_empty() {
                 continue;
@@ -1759,5 +1764,115 @@ FJPkH0mNKDTBHi2UUm8qku8mDfB7vmFMjIbzhMqurhYu6/mjzGKIADEv\n\
         let sf = resolve_storefront_sync();
         assert_eq!(sf.len(), 2);
         assert!(sf.chars().all(|c| c.is_ascii_lowercase()));
+    }
+
+    // ----------------------------------------------------------
+    // extract_media_user_token tests
+    // ----------------------------------------------------------
+
+    #[test]
+    fn extract_token_from_valid_cookies_file() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_valid");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             .apple.com\tTRUE\t/\tTRUE\t0\tmedia-user-token\tABCDEF123456\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), Some("ABCDEF123456".to_string()));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_token_returns_none_when_missing() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             .apple.com\tTRUE\t/\tTRUE\t0\tother-cookie\tvalue123\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_token_returns_none_for_expired_cookie() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_expired");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        // Expiry in the past (epoch 1000)
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             .apple.com\tTRUE\t/\tTRUE\t1000\tmedia-user-token\tEXPIRED_TOKEN\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_token_accepts_session_cookie_zero_expiry() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_session");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        // Expiry of 0 = session cookie, should be accepted
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             .apple.com\tTRUE\t/\tTRUE\t0\tmedia-user-token\tSESSION_TOKEN\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), Some("SESSION_TOKEN".to_string()));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_token_skips_empty_value() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             .apple.com\tTRUE\t/\tTRUE\t0\tmedia-user-token\t\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_token_errors_on_missing_file() {
+        let result = extract_media_user_token("/nonexistent/path/cookies.txt");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_token_skips_comments_and_blank_lines() {
+        let dir = std::env::temp_dir().join("meedyadl_test_cookies_comments");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cookies.txt");
+        std::fs::write(
+            &path,
+            "# Netscape HTTP Cookie File\n\
+             # This is a comment\n\
+             \n\
+             .apple.com\tTRUE\t/\tTRUE\t0\tmedia-user-token\tTOKEN_AFTER_COMMENTS\n",
+        )
+        .unwrap();
+        let result = extract_media_user_token(path.to_str().unwrap());
+        assert_eq!(result.unwrap(), Some("TOKEN_AFTER_COMMENTS".to_string()));
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -4102,15 +4102,25 @@ pub fn process_queue(
                                     .ok()
                                     .flatten();
 
-                                    // Extract Music-User-Token from cookies for subscriber-only endpoint
-                                    let music_user_token = enrich_settings
-                                        .cookies_path
-                                        .as_deref()
-                                        .and_then(|p| {
-                                            super::apple_music_api::extract_media_user_token(p)
-                                                .ok()
-                                                .flatten()
-                                        });
+                                    // Extract Music-User-Token from cookies for subscriber-only endpoint.
+                                    // Emit to activity log if the token is expired so the user knows
+                                    // to re-import cookies (instead of a silent skip or HTTP 401).
+                                    let music_user_token = if let Some(p) = enrich_settings.cookies_path.as_deref() {
+                                        match super::apple_music_api::extract_media_user_token(p) {
+                                            Ok(Some(token)) => Some(token),
+                                            Ok(None) => {
+                                                emit_download_log(
+                                                    &enrich_app,
+                                                    &enrich_dl_id,
+                                                    "Word-level lyrics skipped: Apple Music cookies expired or missing. Re-import from your browser.",
+                                                );
+                                                None
+                                            }
+                                            Err(_) => None,
+                                        }
+                                    } else {
+                                        None
+                                    };
 
                                     if let (Some(jwt), Some(token)) = (jwt, music_user_token) {
                                         // Scan existing TTML files to find which tracks lack word-level timing
@@ -4257,6 +4267,7 @@ pub fn process_queue(
                                             }
                                         }
                                     } else {
+                                        set_label("Skipping word-level lyrics (no credentials)");
                                         log::debug!(
                                             "Syllable-lyrics skipped for {enrich_dl_id}: MusicKit JWT or Music-User-Token unavailable"
                                         );

--- a/src-tauri/src/services/login_window_service.rs
+++ b/src-tauri/src/services/login_window_service.rs
@@ -83,8 +83,8 @@ const LOGIN_WINDOW_LABEL: &str = "apple-login";
 const APPLE_MUSIC_URL: &str = "https://music.apple.com";
 
 /// The cookie name that indicates a successful Apple Music login.
-/// This is Apple's primary authentication token for Apple Music.
-const AUTH_COOKIE_NAME: &str = "media-user-token";
+/// Reuses the shared constant from `apple_music_api` to avoid duplication.
+const AUTH_COOKIE_NAME: &str = super::apple_music_api::MEDIA_USER_TOKEN_COOKIE_NAME;
 
 /// Apple Music domains to filter cookies for (same as `cookie_service`).
 /// Only cookies matching these domains are saved to the cookies file.


### PR DESCRIPTION
## Summary

- Add 7 unit tests for `extract_media_user_token()` cookie parsing
- Add activity log entries when cookies are expired or missing during syllable-lyrics fetch
- Add progress bar label for the credential skip path (prevents stale UI text)
- Deduplicate `media-user-token` cookie name constant across `apple_music_api` and `login_window_service`
- Add `fetch_syllable_lyrics` IPC command for standalone lyrics fetching from frontend

## Test plan

- [ ] Verify unit tests pass for cookie extraction (valid, expired, missing, session, empty, comments)
- [ ] Confirm activity log shows message when cookies are expired during enrichment
- [ ] Confirm progress bar updates when syllable-lyrics is skipped due to missing credentials
- [ ] Verify `fetch_syllable_lyrics` IPC command is callable from frontend

Resolves #306

https://claude.ai/code/session_01GXBuQ5GFs1SnCYFQeACLjN