### PR TITLE
fix: component Update All button now actually updates binary tools

### DIFF
--- a/src-tauri/src/commands/dependencies.rs
+++ b/src-tauri/src/commands/dependencies.rs
@@ -462,10 +462,17 @@ pub async fn install_dependency(app: AppHandle, name: String) -> Result<String, 
     // Delegates to dependency_manager which handles platform-specific
     // URL resolution, download, archive extraction, and binary verification.
     log::info!("Installing dependency: {name}");
-    emit_app_log(&app, &format!("Installing {name}..."));
-    let result = dependency_manager::install_tool(&app, &name).await?;
-    emit_app_log(&app, &format!("{name} installed"));
-    Ok(result)
+    emit_app_log(&app, &format!("Updating {name}..."));
+    match dependency_manager::install_tool(&app, &name).await {
+        Ok(result) => {
+            emit_app_log(&app, &format!("{name} updated successfully"));
+            Ok(result)
+        }
+        Err(e) => {
+            emit_app_log(&app, &format!("Failed to update {name}: {e}"));
+            Err(e)
+        }
+    }
 }
 
 /// A single component version entry for the About screen and Activity Log.

--- a/src-tauri/src/commands/updates.rs
+++ b/src-tauri/src/commands/updates.rs
@@ -161,10 +161,18 @@ pub async fn upgrade_gamdl(app: AppHandle) -> Result<String, String> {
 pub async fn upgrade_pip_engine(app: AppHandle, package: String) -> Result<String, String> {
     log::info!("Upgrading {package}...");
     emit_app_log(&app, &format!("Upgrading {package}..."));
-    let version = crate::services::pip_engine_service::install_pip_engine(&app, &package).await?;
-    log::info!("{package} upgraded to {version}");
-    emit_app_log(&app, &format!("{package} upgraded to v{version}"));
-    Ok(version)
+    match crate::services::pip_engine_service::install_pip_engine(&app, &package).await {
+        Ok(version) => {
+            log::info!("{package} upgraded to {version}");
+            emit_app_log(&app, &format!("{package} upgraded to v{version}"));
+            Ok(version)
+        }
+        Err(e) => {
+            log::error!("Failed to upgrade {package}: {e}");
+            emit_app_log(&app, &format!("Failed to upgrade {package}: {e}"));
+            Err(e)
+        }
+    }
 }
 
 /// Returns the update status for a specific component by name.

--- a/src-tauri/src/services/update_checker.rs
+++ b/src-tauri/src/services/update_checker.rs
@@ -104,6 +104,10 @@ pub struct ComponentUpdate {
     /// Used by the frontend to call `upgrade_pip_engine` with the correct identifier
     /// (display names like "OF-Scraper" don't match PyPI package names).
     pub pip_package: Option<String>,
+    /// Canonical tool ID for binary tools (e.g., "ffmpeg", "nm3u8dlre").
+    /// Used by the frontend to call `install_dependency` to re-download and
+    /// upgrade the tool. Only set for external binary tools, not pip engines.
+    pub tool_id: Option<String>,
 }
 
 /// Combined update status for all components.
@@ -504,13 +508,13 @@ pub async fn check_all_updates(app: &AppHandle, check_pre_releases: bool) -> Upd
     // Compares installed tool versions (from tool-versions.toml minimums)
     // against the latest GitHub release for tools that have known repos.
     let tool_checks = [
-        ("ffmpeg", "BtbN/FFmpeg-Builds"),
-        ("nm3u8dlre", "nilaoda/N_m3u8DL-RE"),
+        ("ffmpeg", "BtbN/FFmpeg-Builds", "FFmpeg"),
+        ("nm3u8dlre", "nilaoda/N_m3u8DL-RE", "N_m3u8DL-RE"),
     ];
-    for (tool_id, repo) in &tool_checks {
+    for (tool_id, repo, display_name) in &tool_checks {
         let binary = crate::services::dependency_manager::get_tool_binary_path(app, tool_id);
         if binary.exists() {
-            match check_github_tool_update(app, tool_id, repo).await {
+            match check_github_tool_update(app, tool_id, repo, display_name).await {
                 Ok(update) => components.push(update),
                 Err(e) => {
                     log::debug!("Tool update check failed for {tool_id}: {e}");
@@ -633,6 +637,7 @@ async fn check_gamdl_update(app: &AppHandle) -> Result<ComponentUpdate, String> 
         is_prerelease: false,
         tag_name: None,
         pip_package: Some("gamdl".to_string()),
+        tool_id: None,
     })
 }
 
@@ -704,6 +709,7 @@ async fn check_app_update(
                 is_prerelease: false,
                 tag_name: None,
                 pip_package: None,
+                tool_id: None,
             });
         }
         return Err(format!("GitHub API returned HTTP {}", response.status()));
@@ -734,6 +740,7 @@ async fn check_app_update(
                 is_prerelease: false,
                 tag_name: None,
                 pip_package: None,
+                tool_id: None,
             });
         }
         // Index 0 is the newest release (may be a pre-release).
@@ -865,6 +872,7 @@ fn parse_release_from_response(
             Some(raw_tag.to_string())
         },
         pip_package: None,
+        tool_id: None,
     }
 }
 
@@ -975,6 +983,7 @@ async fn check_github_tool_update(
     app: &AppHandle,
     tool_id: &str,
     github_repo: &str,
+    display_name: &str,
 ) -> Result<ComponentUpdate, String> {
     // Reuse the centralized dependency-manager logic so each tool uses its
     // configured version flag and parser instead of assuming `--version`.
@@ -1031,17 +1040,18 @@ async fn check_github_tool_update(
     };
 
     Ok(ComponentUpdate {
-        name: tool_id.to_string(),
+        name: display_name.to_string(),
         current_version,
         latest_version,
         update_available,
         is_compatible: true,
-        description: None,
-        release_url: None,
+        description: Some(format!("Newer version of {display_name} available")),
+        release_url: Some(format!("https://github.com/{github_repo}/releases/latest")),
         release_body: None,
         is_prerelease: false,
         tag_name: None,
         pip_package: None,
+        tool_id: Some(tool_id.to_string()),
     })
 }
 
@@ -1084,6 +1094,7 @@ async fn check_python_update(app: &AppHandle) -> Result<ComponentUpdate, String>
         is_prerelease: false,
         tag_name: None,
         pip_package: None,
+        tool_id: None,
     })
 }
 
@@ -1168,6 +1179,7 @@ async fn check_pip_engine_update(
         is_prerelease: false,
         tag_name: None,
         pip_package: Some(pip_package.to_string()),
+        tool_id: None,
     })
 }
 

--- a/src/components/updates/UpdatesPage.tsx
+++ b/src/components/updates/UpdatesPage.tsx
@@ -206,23 +206,45 @@ export function UpdatesPage() {
                     variant="primary"
                     size="sm"
                     icon={<RefreshCw size={12} />}
-                    onClick={() => {
-                      // Upgrade all engine updates using the pip_package identifier
-                      const engines = activeUpdates.filter(
-                        (c) => !CORE_COMPONENTS.includes(c.name) && c.pip_package
+                    onClick={async () => {
+                      const components = activeUpdates.filter(
+                        (c) => !CORE_COMPONENTS.includes(c.name) && (c.pip_package || c.tool_id)
                       );
-                      Promise.all(
-                        engines.map((e) =>
-                          import('@/lib/tauri-commands').then(({ upgradePipEngine }) =>
-                            upgradePipEngine(e.pip_package!)
-                          )
-                        )
-                      )
-                        .then(() => {
-                          addToast('Components updated successfully', 'success');
-                          checkForUpdates().catch(() => {});
+                      if (components.length === 0) {
+                        addToast('No updatable components found', 'info');
+                        return;
+                      }
+
+                      let successCount = 0;
+                      let failCount = 0;
+
+                      const results = await Promise.allSettled(
+                        components.map(async (c) => {
+                          if (c.pip_package) {
+                            const { upgradePipEngine } = await import('@/lib/tauri-commands');
+                            return upgradePipEngine(c.pip_package);
+                          } else if (c.tool_id) {
+                            const { installDependency } = await import('@/lib/tauri-commands');
+                            return installDependency(c.tool_id);
+                          }
+                          throw new Error(`No upgrade method for ${c.name}`);
                         })
-                        .catch(() => addToast('Some component updates failed', 'error'));
+                      );
+
+                      for (const r of results) {
+                        if (r.status === 'fulfilled') successCount++;
+                        else failCount++;
+                      }
+
+                      if (failCount === 0) {
+                        addToast(`${successCount} component${successCount > 1 ? 's' : ''} updated successfully`, 'success');
+                      } else if (successCount === 0) {
+                        addToast(`Failed to update ${failCount} component${failCount > 1 ? 's' : ''}`, 'error');
+                      } else {
+                        addToast(`${successCount} updated, ${failCount} failed`, 'warning');
+                      }
+
+                      checkForUpdates().catch(() => {});
                     }}
                   >
                     Update All

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1436,6 +1436,8 @@ export interface ComponentUpdate {
   tag_name: string | null;
   /** PyPI package name for pip-based engines (e.g., "ofscraper", "votify"), or null for non-pip components */
   pip_package: string | null;
+  /** Canonical tool ID for binary tools (e.g., "ffmpeg", "nm3u8dlre"), or null for non-tool components */
+  tool_id: string | null;
 }
 
 /**


### PR DESCRIPTION
The "Update All" button for component updates was silently succeeding without updating anything. Root cause: the 2 updates shown (FFmpeg, N_m3u8DL-RE) are binary tools with pip_package=null, so the pip-only filter excluded them — Promise.all([]) resolved as instant "success".

Changes:
- Add tool_id field to ComponentUpdate struct for binary tool identity
- Update All handler now uses installDependency() for binary tools alongside upgradePipEngine() for pip packages
- Use Promise.allSettled for granular success/failure reporting
- Add proper display names for tools (FFmpeg, N_m3u8DL-RE)
- Add activity log entries for update success/failure in both install_dependency and upgrade_pip_engine commands
- Add release URLs and descriptions for tool update cards

https://claude.ai/code/session_01MVGopVBSUPhKAbbfnoHyG7