### PR TITLE
docs(lyrics): document sidecar regeneration policy (#550)

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -2094,3 +2094,19 @@ Returns "Too many requests. Please wait N seconds" when exceeded.
 
 On save: SHA-256 digest written to companion `settings.json.sha256` file.
 On load: digest verified. Mismatch logs a warning but settings are still loaded (user may have intentionally edited). Missing checksum file (pre-upgrade settings) is accepted and a checksum generated for next time.
+
+## Lyric Sidecar Regeneration Policy (#550)
+
+Lyric/subtitle generators run on every enrichment pass (first download, companion pass, retry, manifest re-import). The write policy is non-uniform today:
+
+| Generator                  | File               | Source (`src-tauri/src/services/`)          | Existing file behaviour                                                                 |
+| -------------------------- | ------------------ | ------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Enhanced LRC converter     | `.lrc`             | `enhanced_lyrics_service.rs:191`            | **Overwrites** — no `exists()` guard                                                    |
+| Rich SRT generator         | `.srt`             | `rich_srt_service.rs:132`                   | **Overwrites** by design (including GAMDL's plain `.srt`)                               |
+| Syllable-lyrics upgrade    | `.ttml`            | `download_queue.rs:~5594` and `~5618`       | **Overwrites** when Apple Music's `/syllable-lyrics` returns a word-level version       |
+| WebVTT generator           | `.vtt`             | `webvtt_service.rs:85-87`                   | **Skips** (`if vtt_path.exists() { continue; }`)                                        |
+| ASS generator              | `.ass`             | `ass_subtitle_service.rs:91-95`             | **Skips** (`if ass_path.exists() { continue; }`)                                        |
+
+**Status: documented, not changed.** The audit in #550 considered four options (status quo with docs / content-hash skip / opt-in preservation / `.bak` backup) and settled on documented-status-quo. The overwriting generators are idempotent converters whose inputs (TTML from GAMDL, TTML from `/syllable-lyrics`) are themselves refreshed from upstream, so overwriting is the correct default for the 95% case — first-time generation and upstream content updates. The asymmetry between `.lrc`/`.srt` (overwrite) and `.vtt`/`.ass` (skip) is historical; it's called out in `help/lyrics-and-metadata.md` so users with hand-edited sidecars can work around it (rename to a non-generator extension, disable the generator, or copy the file before re-running enrichment).
+
+**If that policy changes**, the canonical touch points are the `std::fs::write` calls above and the two syllable-lyrics upgrade sites in `download_queue.rs`. A future hash-skip guard would live inline at each site (the existing idempotency means a content hash compare would be cheap); a preserve-user-edits toggle would need a new setting keyed off file mtime vs. an internal "generated-by-MeedyaDL" sentinel.

--- a/help/lyrics-and-metadata.md
+++ b/help/lyrics-and-metadata.md
@@ -181,6 +181,28 @@ Lyric sidecar files are saved in the same directory as the downloaded audio or v
 
 This convention ensures that most media players will automatically detect and load the lyrics or subtitles when you play the corresponding file.
 
+### Lyric Sidecar Regeneration
+
+Every time enrichment runs on a download folder — the first download, any companion pass, and any retry or re-import via `.meedyadl` manifest — MeedyaDL's lyric/subtitle generators run again. Whether the regenerated file replaces or preserves an existing sidecar depends on which generator produced it:
+
+| Generator              | Extension   | Behaviour on re-run                                                                                                   |
+| ---------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| Enhanced LRC converter | `.lrc`      | **Overwrites** any existing file.                                                                                     |
+| Rich SRT generator     | `.srt`      | **Overwrites** any existing file (including GAMDL's plain `.srt`; the rich variant with styling tags replaces it).    |
+| Syllable-lyrics upgrade | `.ttml`    | **Overwrites** GAMDL's TTML when a word-level version is fetched from Apple Music's `/syllable-lyrics` endpoint.       |
+| WebVTT generator       | `.vtt`      | **Skips** if the file already exists.                                                                                 |
+| ASS generator          | `.ass`      | **Skips** if the file already exists.                                                                                 |
+
+**Implication for users who edit sidecars manually:** `.lrc`, `.srt`, and upgraded `.ttml` files written by MeedyaDL are not treated as user data — any edits you make to them may be silently replaced on the next enrichment run (re-download, companion download, or manifest re-import). If you want to keep hand-edited lyrics or subtitles, either:
+
+- Rename the file to a variant the generators don't touch (e.g., `Song Title.user.lrc`), OR
+- Disable the corresponding generator in **Settings > Lyrics** before re-running enrichment, OR
+- Copy the edited file elsewhere before triggering another enrichment pass.
+
+`.vtt` and `.ass` sidecars are safe to edit in place — the generators detect the existing file and skip it.
+
+This behaviour is intentional: the generators are idempotent converters whose inputs (TTML, SRT) are themselves refreshed from upstream, so overwriting is the correct default for the 95% case (first-time generation and upstream content updates). The asymmetry between `.lrc`/`.srt` (overwrite) and `.vtt`/`.ass` (skip) is historical; if you'd prefer a uniform guard, file an issue.
+
 ---
 
 ## Metadata Embedding


### PR DESCRIPTION
## Summary

Resolves #550 by adopting **Option A** (documented status quo) — no behaviour change, just closes the knowledge gap about which sidecar generators overwrite vs. skip.

## What the audit actually found

The issue body claims all four lyric/subtitle writers overwrite unconditionally. On inspection, only two do:

| Generator                  | File    | Write behaviour on re-run                                |
| -------------------------- | ------- | -------------------------------------------------------- |
| Enhanced LRC converter     | `.lrc`  | **Overwrites** — `enhanced_lyrics_service.rs:191`        |
| Rich SRT generator         | `.srt`  | **Overwrites** by design — `rich_srt_service.rs:132`     |
| Syllable-lyrics upgrade    | `.ttml` | **Overwrites** — `download_queue.rs:~5594/~5618`         |
| WebVTT generator           | `.vtt`  | **Skips** — `webvtt_service.rs:85-87` has `exists()` guard |
| ASS generator              | `.ass`  | **Skips** — `ass_subtitle_service.rs:91-95` has `exists()` guard |

The asymmetry is historical, not deliberate. Both behaviours are defensible (overwrite = always-fresh; skip = preserve hand edits), but the lack of uniformity wasn't discoverable without reading four source files.

## Changes

- **`help/lyrics-and-metadata.md`** — new "Lyric Sidecar Regeneration" section with a per-generator behaviour table, user-facing implications, and three workarounds for users who edit sidecars manually (rename to a non-generator extension, disable the generator, or copy before re-running enrichment).
- **`DEV_NOTES.md`** — new "Lyric Sidecar Regeneration Policy (#550)" section documenting the exact file:line anchors and what a future uniformity fix would need to touch.

## What's explicitly not in this PR

- No behaviour change — `.lrc` and `.srt` still overwrite, `.vtt` and `.ass` still skip.
- Option B (content-hash skip), Option C (opt-in preservation), Option D (`.bak` backup) all deferred; if a user reports a real-world complaint about silently lost edits, the DEV_NOTES anchors make Option B a small follow-up.

## Test plan

- [x] Built locally via plain `cargo check` — no code touched, nothing to regress.
- [ ] Manual read-through of rendered help markdown in-app (deferred — no running GUI this session).

Closes #550


---
_Generated by [Claude Code](https://claude.ai/code/session_01By6gAkpgqVWzctft4LH3Mp)_