### PR TITLE
chore(deps): ignore RUSTSEC-2026-0097 with tracked-upstream rationale (#562)

### DIFF
--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -37,16 +37,27 @@ all-features = true
 # @see https://embarkstudios.github.io/cargo-deny/checks/advisories.html
 # @see https://github.com/RustSec/advisory-db
 [advisories]
-# Ignore unmaintained crate advisories that come from Tauri's transitive
-# dependencies. Tauri 2.x still uses GTK3 bindings on Linux, which the gtk-rs
-# team has archived in favour of gtk4-rs. These are outside our control and
-# will be resolved when Tauri migrates to GTK4. Similarly, several other
-# unmaintained crates (derivative, fxhash, instant, proc-macro-error, unic-*)
-# are transitive dependencies from Tauri, tao, or wry that we cannot update
-# independently.
+# Ignore policy — two narrow carve-outs:
 #
-# All entries below are "unmaintained" advisories (not security vulnerabilities).
-# If a genuine security vulnerability appears, it will NOT be ignored.
+#   (a) Unmaintained-crate advisories that come from Tauri's transitive
+#       dependencies. Tauri 2.x still uses GTK3 bindings on Linux, which
+#       the gtk-rs team has archived in favour of gtk4-rs. These are
+#       outside our control and will be resolved when Tauri migrates to
+#       GTK4. Similarly, several other unmaintained crates (derivative,
+#       fxhash, instant, proc-macro-error, unic-*) are transitive
+#       dependencies from Tauri, tao, or wry that we cannot update
+#       independently.
+#
+#   (b) Security advisories whose vulnerable code path is demonstrably
+#       unreachable in MeedyaDL's build/runtime AND that are tracked
+#       upstream (Tauri or the intermediate crate) for permanent fix.
+#       Each (b) entry MUST cite (i) the specific trigger conditions
+#       from the advisory that do not apply to our usage, (ii) an
+#       internal tracker issue, and (iii) the upstream tracker once
+#       filed. An (b) entry without all three is not acceptable.
+#
+# If a genuine security vulnerability with a reachable code path
+# appears, it will NOT be ignored — fix it, don't hide it.
 ignore = [
     # GTK3 bindings (Tauri Linux dependency — awaiting Tauri GTK4 migration)
     "RUSTSEC-2024-0411", # cairo-rs — unmaintained
@@ -75,6 +86,26 @@ ignore = [
 
     # paste — unmaintained (transitive dependency from lofty, used for ReplayGain tagging)
     "RUSTSEC-2024-0436", # paste — unmaintained (archived by dtolnay, no security issue)
+
+    # Security advisories with demonstrably unreachable code paths (carve-out
+    # (b) in the policy comment above). Each entry MUST cite the specific
+    # advisory trigger conditions that do NOT apply to our usage, an internal
+    # tracker issue, and an upstream tracker URL.
+
+    # RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc — `rand 0.7.3` soundness.
+    # Chain: tauri-utils 2.8.3 → kuchikiki 0.8.8-speedreader → selectors 0.24.0
+    # → phf_codegen 0.8.0 → phf_generator 0.8.0 → rand 0.7.3 (build-only).
+    # Advisory trigger requires ALL of: `log` + `thread_rng` features; a
+    # custom `log::Log` implementation; that logger calls `rand::rng()` →
+    # `TryRng` on `ThreadRng`; ThreadRng reseeding during logger callback
+    # (every 64 kB of rand output); trace-level logging active. None of
+    # these conditions are met by `phf_codegen`'s build-time PHF-seeding
+    # use of `rand`. Shipping MeedyaDL binary does not link against
+    # `rand 0.7.3` (runtime uses rand 0.8.6 / 0.9.4 only). `rand 0.7.x`
+    # has no backported fix — patch requires 0.8 API. Internal tracker:
+    # #562. Upstream tracker: (to be filed against tauri-apps/tauri — see
+    # ready-to-paste template in #562 body).
+    "RUSTSEC-2026-0097", # rand — soundness; build-only, conditions not met (see #562)
 ]
 
 # ============================================================


### PR DESCRIPTION
## Summary

Adds `RUSTSEC-2026-0097` ([GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc)) to `deny.toml`'s ignore list under a new **security-advisory-with-unreachable-code-path** carve-out, tracked internally by **#562**.

## Why ignore rather than patch

The vulnerable crate (`rand 0.7.3`) enters our build graph only as a build-only transitive via:

```
rand 0.7.3  [build-only]
└── phf_generator 0.8.0
    └── phf_codegen 0.8.0
        └── selectors 0.24.0
            └── kuchikiki 0.8.8-speedreader
                └── tauri-utils 2.8.3
                    └── tauri-build 2.5.6  /  tauri 2.10.3
```

The [advisory](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) requires **all** of these conditions to trigger the UB:

1. `log` + `thread_rng` features enabled,
2. A custom `log::Log` implementation registered,
3. That logger calls `rand::rng()` → `TryRng` methods on `ThreadRng`,
4. `ThreadRng` reseeds during the logger callback (every 64 kB of rand output),
5. Trace-level logging active.

`phf_codegen`'s compile-time PHF-seeding usage of `rand` meets **zero** of these conditions. The shipping MeedyaDL binary does not link against `rand 0.7.3` at all (runtime uses `rand 0.8.6` / `rand 0.9.4` only). `rand 0.7.x` has no backported fix — the patch requires the 0.8 API, and no further 0.7.x releases will be made.

Consumers cannot patch the chain without forking an intermediate crate (adds long-term maintenance burden, provides zero runtime-security benefit).

## Policy change

Previously `deny.toml` said:

> All entries below are "unmaintained" advisories (not security vulnerabilities). If a genuine security vulnerability appears, it will NOT be ignored.

This PR narrows that blanket rule to a two-carve-out policy:

- **(a) Unmaintained-crate advisories** from Tauri-transitive deps (existing rule, unchanged).
- **(b) Security advisories with demonstrably unreachable code paths** AND an internal tracker AND an upstream tracker. Each (b) entry MUST cite (i) the advisory's trigger conditions that don't apply, (ii) the internal tracker, (iii) the upstream tracker once filed.

Genuine vulnerabilities with reachable code paths remain non-ignorable. The new rationale comment spells this out explicitly.

## Internal tracker

**#562** holds the permanent record: exposure analysis, why we can't patch locally, removal criteria (Tauri ships the chain upgrade → we delete the ignore + close #562), and a ready-to-paste template for filing the upstream issue against `tauri-apps/tauri`.

## Test plan

- [ ] CI `cargo deny check` passes on this branch (the ignore takes effect).
- [ ] Dependabot alert #30 remains visible in the GitHub UI (we're not dismissing it — the intent is the build-time CI gate doesn't fail, while the alert stays visible to anyone reading security dashboards).
- [ ] No Rust source or behaviour changes in this PR.

## Removal criteria

When Tauri upgrades `kuchikiki` / `selectors` / `phf` such that `rand 0.7.3` no longer appears in `cargo tree -i rand@0.7.3`, remove the `RUSTSEC-2026-0097` entry from `deny.toml` and close #562.

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_