### PR TITLE
fix(parser): accept classical.music.apple.com + slug-less Share URLs (urgent live regression)

### DIFF
--- a/src-tauri/src/services/apple_music_api.rs
+++ b/src-tauri/src/services/apple_music_api.rs
@@ -394,22 +394,36 @@ pub async fn fetch_itunes_lookup(
 
 /// Parse an Apple Music URL to extract the storefront, content type, and IDs.
 ///
-/// Supports these URL patterns (`music.apple.com`, `classical.apple.com`,
-/// and legacy `itunes.apple.com`):
+/// Supports four domains (`music.apple.com`, `classical.apple.com`,
+/// `classical.music.apple.com`, and legacy `itunes.apple.com`) and two
+/// path styles:
+///
+/// - **Slugged** (classic): `{domain}/{sf}/{type}/{slug}/{id}` — the
+///   original music.apple.com share-link format.
+/// - **Slug-less** (new Apple Music Classical): `{domain}/{sf}/{type}/{id}` —
+///   Apple's native Classical app dropped the human-readable slug in
+///   2026 when Classical migrated to the `classical.music.apple.com`
+///   subdomain. The new Share links ship without a slug segment.
+///
+/// Examples:
 /// - `https://music.apple.com/us/album/album-name/1234567890`
 /// - `https://classical.apple.com/us/album/beethoven-symphony/1234567890`
+/// - `https://classical.music.apple.com/gb/album/1844602145`
+///   (new domain, no slug, no track ID)
+/// - `https://classical.music.apple.com/gb/album/1844602145?i=9876543210`
+///   (new domain, no slug, with track ID)
 /// - `https://itunes.apple.com/us/album/album-name/1234567890`
 /// - `https://music.apple.com/us/album/album-name/1234567890?i=9876543210`
 /// - `https://music.apple.com/us/song/song-name/9876543210`
 /// - `https://music.apple.com/us/music-video/video-name/1234567890`
 ///
-/// Apple Music Classical URLs (`classical.apple.com`) and legacy iTunes
-/// Store URLs (`itunes.apple.com`) share the same path structure as
-/// standard Apple Music URLs and are treated identically. The `itunes`
-/// alternation was added so iTunes URLs get the same metadata prefetch,
-/// storefront normalisation, and Tier 4 safety-net treatment as the
-/// other two domains (#548) — previously they passed host validation
-/// but failed every parser branch and reached GAMDL raw.
+/// All four domains share the same path structure (up to slug
+/// presence) and are parsed identically. The `itunes` alternation was
+/// added in #548 to close the same gap; the `classical\.music` branch
+/// added here closes the same gap for Apple's domain migration.
+/// Trailing query parameters beyond `?i=` (e.g. `?l=en-GB` locale
+/// hints) are ignored — the regexes stop capturing at the album /
+/// song / artist ID.
 ///
 /// For album URLs with `?i=` query parameter, both the album ID and the
 /// individual song ID are extracted.
@@ -430,48 +444,65 @@ pub fn parse_apple_music_url(url: &str) -> Option<ParsedAppleMusicUrl> {
     // queue restore). The .expect() on a LazyLock only runs once — a regex
     // compilation failure here indicates a code defect, not a runtime error.
 
-    // Match album URLs: /storefront/album/slug/album_id with optional ?i=song_id
-    // Accepts music.apple.com, classical.apple.com, and legacy
-    // itunes.apple.com domains. The `itunes` alternation closes the gap
-    // where iTunes URLs passed host validation but failed every parser
-    // branch and reached GAMDL raw with no metadata prefetch (#548).
+    // Domain alternation + optional slug segment.
+    //
+    // Domain alternation `(?:classical(?:\.music)?|music|itunes)\.apple\.com`
+    // matches four hostnames: `music.apple.com`, `classical.apple.com`,
+    // `classical.music.apple.com`, `itunes.apple.com`. The
+    // `classical(?:\.music)?` construct tries `classical.music` first
+    // (greedy), falls back to plain `classical` when the next chars
+    // aren't `.music` — so both Classical hostnames parse cleanly.
+    //
+    // Optional slug segment `(?:[^/]+/)?` matches both the classic
+    // `/album/slug/id` format and the new Apple Music Classical
+    // slug-less `/album/id` format. See function doc for the URL-shape
+    // migration that drove this change.
+    //
+    // The `itunes` alternation closes the gap where iTunes URLs passed
+    // host validation but failed every parser branch (#548); the
+    // `classical\.music` branch closes the equivalent gap for
+    // Apple's Classical domain migration.
+
+    // Match album URLs: /storefront/album/[slug/]album_id with optional ?i=song_id
     static ALBUM_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"https?://(?:classical|music|itunes)\.apple\.com/([a-z]{2})/album/[^/]+/(\d+)(?:\?i=(\d+))?",
+            r"https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com/([a-z]{2})/album/(?:[^/]+/)?(\d+)(?:\?i=(\d+))?",
         )
         .expect("Invalid album regex")
     });
 
-    // Match song URLs: /storefront/song/slug/song_id
+    // Match song URLs: /storefront/song/[slug/]song_id
     static SONG_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"https?://(?:classical|music|itunes)\.apple\.com/([a-z]{2})/song/[^/]+/(\d+)")
-            .expect("Invalid song regex")
+        Regex::new(
+            r"https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com/([a-z]{2})/song/(?:[^/]+/)?(\d+)",
+        )
+        .expect("Invalid song regex")
     });
 
-    // Match music-video URLs: /storefront/music-video/slug/video_id
+    // Match music-video URLs: /storefront/music-video/[slug/]video_id
     static MV_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"https?://(?:classical|music|itunes)\.apple\.com/([a-z]{2})/music-video/[^/]+/(\d+)",
+            r"https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com/([a-z]{2})/music-video/(?:[^/]+/)?(\d+)",
         )
         .expect("Invalid music-video regex")
     });
 
-    // Match artist URLs: /storefront/artist/slug/artist_id
+    // Match artist URLs: /storefront/artist/[slug/]artist_id
     static ARTIST_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"https?://(?:classical|music|itunes)\.apple\.com/([a-z]{2})/artist/[^/]+/(\d+)",
+            r"https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com/([a-z]{2})/artist/(?:[^/]+/)?(\d+)",
         )
         .expect("Invalid artist regex")
     });
 
-    // Match catalog playlist URLs: /storefront/playlist/slug/pl.xxxxx
+    // Match catalog playlist URLs: /storefront/playlist/[slug/]pl.xxxxx
     // Library playlists (/library/playlist/...) are intentionally NOT
     // matched here — they need a different endpoint and Music-User-Token
     // auth. Callers that need to detect library playlists should do so
     // via a separate check before calling this parser.
     static PLAYLIST_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"https?://(?:classical|music|itunes)\.apple\.com/([a-z]{2})/playlist/[^/]+/(pl\.[a-zA-Z0-9._-]+)",
+            r"https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com/([a-z]{2})/playlist/(?:[^/]+/)?(pl\.[a-zA-Z0-9._-]+)",
         )
         .expect("Invalid playlist regex")
     });
@@ -1317,7 +1348,8 @@ pub async fn fetch_music_video_relations(
 /// 2. OS locale — fast, no network, uses `detect_storefront()` from login_window_service
 /// 3. Fallback — defaults to "us" (Apple's own redirect default)
 ///
-/// Also supports `classical.apple.com` and `itunes.apple.com` domains.
+/// Also supports `classical.apple.com`, `classical.music.apple.com`,
+/// and legacy `itunes.apple.com` domains.
 ///
 /// # Arguments
 /// * `url` - The Apple Music URL to normalize
@@ -1364,7 +1396,7 @@ fn detect_non_geographic_url(url: &str) -> Option<(&str, &str)> {
     // The rest of the URL after group 1 starts with /{content_type}/...
     static NON_GEO_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r"^(https?://(?:classical|music|itunes)\.apple\.com)/(album|song|playlist|music-video|artist)(/.*)?$",
+            r"^(https?://(?:classical(?:\.music)?|music|itunes)\.apple\.com)/(album|song|playlist|music-video|artist)(/.*)?$",
         )
         .expect("Invalid non-geographic URL regex")
     });
@@ -2254,6 +2286,96 @@ mod tests {
         assert_eq!(parsed.song_id.unwrap(), "9876543210");
     }
 
+    // Apple Music Classical domain migration (2026): Apple moved Classical
+    // under the `music.apple.com` subdomain hierarchy and dropped the slug
+    // segment from Share-link URLs. These tests lock in parser support for
+    // the new `classical.music.apple.com` domain and the slug-less
+    // `/album/{id}` / `/song/{id}` / etc. path style. Regression canary
+    // against Apple's UI rolling the change back.
+
+    #[test]
+    fn parse_new_classical_album_url_without_slug() {
+        // Real-world URL shape captured 2026-04-23 from Apple Music
+        // Classical app's Share → Copy Link.
+        let url = "https://classical.music.apple.com/gb/album/1844602145";
+        let parsed = parse_apple_music_url(url).expect("new classical URL should parse");
+        assert_eq!(parsed.storefront, "gb");
+        assert_eq!(parsed.content_type, "album");
+        assert_eq!(parsed.album_id, "1844602145");
+        assert!(parsed.song_id.is_none());
+    }
+
+    #[test]
+    fn parse_new_classical_album_url_with_locale_query() {
+        // `?l=en-GB` locale hint appended by Apple's new Share UI.
+        // Regex must not capture it as a song ID.
+        let url = "https://classical.music.apple.com/gb/album/1844602145?l=en-GB";
+        let parsed = parse_apple_music_url(url).expect("?l= query should not block parsing");
+        assert_eq!(parsed.storefront, "gb");
+        assert_eq!(parsed.album_id, "1844602145");
+        assert!(parsed.song_id.is_none(), "song_id should be None; ?l= is a locale hint");
+    }
+
+    #[test]
+    fn parse_new_classical_album_url_with_track_id() {
+        let url = "https://classical.music.apple.com/gb/album/1844602145?i=1844602150";
+        let parsed = parse_apple_music_url(url).expect("?i= form must still work");
+        assert_eq!(parsed.album_id, "1844602145");
+        assert_eq!(parsed.song_id.as_deref(), Some("1844602150"));
+    }
+
+    #[test]
+    fn parse_new_classical_song_url_without_slug() {
+        let url = "https://classical.music.apple.com/us/song/9876543210";
+        let parsed = parse_apple_music_url(url).expect("new classical song URL should parse");
+        assert_eq!(parsed.content_type, "song");
+        assert_eq!(parsed.song_id.as_deref(), Some("9876543210"));
+    }
+
+    #[test]
+    fn parse_new_classical_music_video_url_without_slug() {
+        let url = "https://classical.music.apple.com/us/music-video/1234567890";
+        let parsed = parse_apple_music_url(url).expect("new classical MV URL should parse");
+        assert_eq!(parsed.content_type, "music-video");
+        assert_eq!(parsed.album_id, "1234567890");
+    }
+
+    #[test]
+    fn parse_new_classical_artist_url_without_slug() {
+        let url = "https://classical.music.apple.com/us/artist/123456789";
+        let parsed = parse_apple_music_url(url).expect("new classical artist URL should parse");
+        assert_eq!(parsed.content_type, "artist");
+        assert_eq!(parsed.artist_id.as_deref(), Some("123456789"));
+    }
+
+    #[test]
+    fn parse_new_classical_playlist_url_without_slug() {
+        let url = "https://classical.music.apple.com/us/playlist/pl.u-ABCDefgh123456";
+        let parsed = parse_apple_music_url(url).expect("new classical playlist URL should parse");
+        assert_eq!(parsed.content_type, "playlist");
+        assert_eq!(parsed.playlist_id.as_deref(), Some("pl.u-ABCDefgh123456"));
+    }
+
+    #[test]
+    fn parse_new_classical_album_url_with_slug_still_works() {
+        // If Apple keeps emitting slugged URLs for backward compat,
+        // the slug-optional regex must still accept them on the new
+        // hostname.
+        let url = "https://classical.music.apple.com/us/album/beethoven-9-symphonies/1844602145";
+        let parsed = parse_apple_music_url(url).expect("slugged form on new domain must still parse");
+        assert_eq!(parsed.album_id, "1844602145");
+    }
+
+    #[test]
+    fn parse_classic_slugless_form_on_music_apple_com() {
+        // If Apple rolls the slug-less format out to the main
+        // music.apple.com domain, the parser should keep up.
+        // Defensive coverage — may or may not exist in the wild yet.
+        let url = "https://music.apple.com/us/album/1649434004";
+        let parsed = parse_apple_music_url(url).expect("slugless form on music.apple.com should parse");
+        assert_eq!(parsed.album_id, "1649434004");
+    }
+
     // Legacy iTunes Store URLs (#548). Before the alternation was extended
     // to include `itunes`, these passed host validation but failed every
     // parser branch and reached GAMDL raw with no MeedyaDL metadata
@@ -2676,6 +2798,24 @@ FJPkH0mNKDTBHi2UUm8qku8mDfB7vmFMjIbzhMqurhYu6/mjzGKIADEv\n\
         assert!(result.starts_with("https://itunes.apple.com/"));
         assert!(result.contains("/album/some-album/1234567890"));
         assert_ne!(result, url);
+    }
+
+    #[test]
+    fn normalize_new_classical_url_without_storefront() {
+        // The new Classical domain must also get storefront injection
+        // when the URL arrives in the non-geographic shape.
+        let url = "https://classical.music.apple.com/album/1844602145";
+        let result = normalize_apple_music_url(url);
+        assert!(result.starts_with("https://classical.music.apple.com/"));
+        assert!(result.contains("/album/1844602145"));
+        assert_ne!(result, url, "storefront should be injected");
+    }
+
+    #[test]
+    fn normalize_new_classical_url_with_storefront_unchanged() {
+        // Already has a storefront → returned unchanged (parser matches).
+        let url = "https://classical.music.apple.com/gb/album/1844602145";
+        assert_eq!(normalize_apple_music_url(url), url);
     }
 
     #[test]

--- a/src/lib/url-parser.test.ts
+++ b/src/lib/url-parser.test.ts
@@ -59,6 +59,23 @@ describe('isAppleMusicUrl', () => {
     expect(isAppleMusicUrl('https://itunes.apple.com/us/album/test/123')).toBe(true);
   });
 
+  /** Accepts legacy Apple Music Classical domain */
+  it('accepts classical.apple.com URLs', () => {
+    expect(isAppleMusicUrl('https://classical.apple.com/us/album/test/123')).toBe(true);
+  });
+
+  /** Accepts current Apple Music Classical domain (post-2026 migration) */
+  it('accepts classical.music.apple.com URLs', () => {
+    expect(isAppleMusicUrl('https://classical.music.apple.com/gb/album/1844602145')).toBe(true);
+  });
+
+  /** Accepts slug-less Classical URL with locale query — the real live shape */
+  it('accepts classical.music.apple.com URLs with slug-less path + locale query', () => {
+    expect(
+      isAppleMusicUrl('https://classical.music.apple.com/gb/album/1844602145?l=en-GB')
+    ).toBe(true);
+  });
+
   /** Ensures non-Apple domains are rejected, even if the path looks valid */
   it('rejects non-Apple Music URLs', () => {
     expect(isAppleMusicUrl('https://example.com/music')).toBe(false);
@@ -199,6 +216,36 @@ describe('non-geographic URLs (no storefront code)', () => {
     );
     expect(result.contentType).toBe('album');
     expect(result.isValid).toBe(true);
+  });
+
+  // Apple Music Classical domain migration (2026) — Apple moved Classical
+  // to `classical.music.apple.com` and dropped the slug segment from
+  // Share-link URLs. The frontend parser must classify both the new
+  // hostname and the slug-less path shape.
+
+  it('classifies new classical.music.apple.com album URLs (slug-less)', () => {
+    const result = parseAppleMusicUrl('https://classical.music.apple.com/gb/album/1844602145');
+    expect(result.isValid).toBe(true);
+    expect(result.contentType).toBe('album');
+  });
+
+  it('classifies new classical.music.apple.com album URL with ?l= locale query', () => {
+    // The real-world shape captured from the Apple Music Classical app
+    // Share → Copy Link, 2026-04-23.
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/album/1844602145?l=en-GB'
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.contentType).toBe('album');
+  });
+
+  it('classifies new classical.music.apple.com song URL with ?i= track id', () => {
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/album/1844602145?i=1844602150'
+    );
+    expect(result.isValid).toBe(true);
+    // contentType is 'song' when `?i=` is present on an album URL (per detectContentType).
+    expect(result.contentType).toBe('song');
   });
 
   it('detects song URL path without storefront', () => {

--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -98,7 +98,12 @@ export function parseAppleMusicUrl(url: string): ParsedUrl {
  *
  * Accepted domains:
  * - `music.apple.com` - Current Apple Music web player domain
- * - `classical.apple.com` - Apple Music Classical domain
+ * - `classical.apple.com` - Legacy Apple Music Classical domain
+ * - `classical.music.apple.com` - Current Apple Music Classical domain
+ *   (Apple moved Classical under music.apple.com's subdomain hierarchy
+ *   in 2026; the app now shares Share-link format with `music.apple.com`
+ *   but drops the slug segment: `/album/{id}` instead of
+ *   `/album/{slug}/{id}`)
  * - `itunes.apple.com` - Legacy iTunes Store domain (still used in some links)
  *
  * @param url - The URL string to validate
@@ -110,10 +115,11 @@ export function isAppleMusicUrl(url: string): boolean {
   try {
     /* Use the URL constructor for standards-compliant URL parsing */
     const parsed = new URL(url);
-    /* Check hostname against both the current and legacy Apple Music domains */
+    /* Check hostname against the current and legacy Apple Music domains */
     return (
       parsed.hostname === 'music.apple.com' ||
       parsed.hostname === 'classical.apple.com' ||
+      parsed.hostname === 'classical.music.apple.com' ||
       parsed.hostname === 'itunes.apple.com'
     );
   } catch {
@@ -235,7 +241,7 @@ export function getContentTypeLabel(contentType: AppleMusicContentType): string 
  * (e.g., music.youtube.com before youtube.com).
  */
 const SERVICE_DOMAINS: Array<{ service: MediaServiceId; domains: string[] }> = [
-  { service: 'apple-music', domains: ['music.apple.com', 'classical.apple.com', 'itunes.apple.com'] },
+  { service: 'apple-music', domains: ['classical.music.apple.com', 'music.apple.com', 'classical.apple.com', 'itunes.apple.com'] },
   { service: 'youtube-music', domains: ['music.youtube.com'] },
   { service: 'youtube', domains: ['youtube.com', 'youtu.be'] },
   { service: 'spotify', domains: ['open.spotify.com'] },


### PR DESCRIPTION
## Urgent production regression fix

Apple migrated Apple Music Classical to the `classical.music.apple.com` subdomain in 2026 and dropped the slug segment from Share-link URLs. **Current state on `main`**: pasting a Classical Share link into MeedyaDL is rejected with `"Please enter a valid Apple Music URL"` — classical downloads via the native Share button are unreachable.

Captured live 2026-04-23 from the Apple Music Classical app Share → Copy Link:

```
https://classical.music.apple.com/gb/album/1844602145?l=en-GB
```

Two axes of breakage:

1. **Domain**: `classical.apple.com` → `classical.music.apple.com` (a sub-subdomain of `music.apple.com`).
2. **Path shape**: `/album/{slug}/{id}` → `/album/{id}` — the human-readable slug is gone.

Cosmetically there's also a `?l=en-GB` locale hint our `?i=` capture group harmlessly ignores.

## Changes

### Frontend (`src/lib/url-parser.ts`)

- `isAppleMusicUrl()` adds `classical.music.apple.com` to the accepted hostname list.
- `SERVICE_DOMAINS` routing list gets the same domain so `detectService()` returns `apple-music`.

### Backend (`src-tauri/src/services/apple_music_api.rs`)

All five entity regexes (album, song, music-video, artist, catalog-playlist) + `NON_GEO_RE` updated:

- Domain alternation `(?:classical|music|itunes)` → `(?:classical(?:\.music)?|music|itunes)`. Covers all four hostnames: `music.apple.com`, `classical.apple.com`, `classical.music.apple.com`, `itunes.apple.com`.
- Slug segment `[^/]+/` → `(?:[^/]+/)?`, making it optional. Both classic `/album/slug/id` and new `/album/id` forms parse.
- Docstrings on `parse_apple_music_url` and `normalize_apple_music_url` updated.

### Backend (`src-tauri/src/commands/gamdl.rs`)

**No change** — `SUPPORTED_HOSTS` already allows subdomains via `strip_suffix` at line 174, so `classical.music.apple.com` passes host validation. Only the parser regexes needed fixing.

## Test coverage

**Rust** — 9 new tests in `apple_music_api::tests`:

- `parse_new_classical_album_url_without_slug`
- `parse_new_classical_album_url_with_locale_query` (`?l=en-GB`)
- `parse_new_classical_album_url_with_track_id` (`?i=`)
- `parse_new_classical_song_url_without_slug`
- `parse_new_classical_music_video_url_without_slug`
- `parse_new_classical_artist_url_without_slug`
- `parse_new_classical_playlist_url_without_slug`
- `parse_new_classical_album_url_with_slug_still_works` (defensive — if Apple keeps emitting slugged URLs for back-compat, we're covered)
- `parse_classic_slugless_form_on_music_apple_com` (defensive — if Apple rolls slug-less out to main domain, we're covered)

Plus 2 normalize tests:

- `normalize_new_classical_url_without_storefront` — storefront injection on the new domain
- `normalize_new_classical_url_with_storefront_unchanged` — idempotency check

**TypeScript** — 4 new tests in `url-parser.test.ts`:

- `accepts classical.apple.com URLs` (filled in missing legacy coverage while I was there)
- `accepts classical.music.apple.com URLs`
- `accepts classical.music.apple.com URLs with slug-less path + locale query` (the live shape)
- `classifies new classical.music.apple.com album URLs (slug-less)`
- `classifies new classical.music.apple.com album URL with ?l= locale query`
- `classifies new classical.music.apple.com song URL with ?i= track id`

## Local verification

```
cargo clippy -- -D warnings  ✓ clean
cargo test --lib services::apple_music_api::tests  65 passed, 0 failed
npx vitest run url-parser.test.ts  45 passed
```

## Risk

Low. All changes are additive in regex alternation (existing URL shapes still parse identically; new shapes gain coverage). No behaviour change for the three hostnames that were already supported. Regex correctness is covered by the existing 65-test suite plus the new 9 tests.

## Related

- **#547** — Apple Music Classical movement-title collision audit was blocked on this same regression (can't paste a Classical URL to reproduce). With this PR merged, the #547 repro is unblocked.
- **#560** — independent PR with orthogonal classical-URL diagnostic logging. No conflict; this fix landing on main first will cleanly merge into #560.

## Test plan (post-merge)

- [ ] Paste the URL from the original bug report into MeedyaDL — download starts (auth permitting)
- [ ] Paste a slugged classical URL from the old app — still parses
- [ ] Paste a regular `music.apple.com` URL — no regression
- [ ] Proceed with #547 manual repro (unblocked)

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_