### PR TITLE
feat(parser): recognise Apple Music Classical `/recording/` URLs with helpful error message

### DIFF
--- a/src/components/download/DownloadForm.tsx
+++ b/src/components/download/DownloadForm.tsx
@@ -147,6 +147,7 @@ const CONTENT_TYPE_ICONS: Record<AppleMusicContentType, typeof Music> = {
   'music-video': Video, // Music video URL
   artist: User, // Artist page URL
   library: Library, // Personal library URL
+  recording: Music, // Apple Music Classical recording (currently unsupported for download)
   unknown: HelpCircle, // Unrecognised or unparseable URL
 };
 
@@ -162,6 +163,7 @@ const CONTENT_TYPE_LABELS: Record<AppleMusicContentType, string> = {
   'music-video': 'Music Video',
   artist: 'Artist',
   library: 'Library',
+  recording: 'Classical Recording',
   unknown: 'Unknown',
 };
 
@@ -849,10 +851,19 @@ export function DownloadForm() {
 
           {/*
            * Validation feedback messages (mutually exclusive):
-           *  - Red error text when the input has text but URL is invalid.
+           *  - Specific error text for recognised-but-unsupported content types
+           *    (currently just `recording` — see url-parser.ts), so the user
+           *    gets actionable guidance rather than "your URL is invalid".
+           *  - Generic red error text when the input is recognised as Apple
+           *    Music but classifies as unknown.
            *  - Grey helper text when the input is empty (shows supported types).
            */}
-          {urlInput && !canSubmit && !isMultiUrl && (
+          {urlInput && !canSubmit && !isMultiUrl && urlContentType === 'recording' && (
+            <p className="text-xs text-status-error">
+              Apple Music Classical <em>recording</em> URLs aren't supported yet. Open the recording in Apple Music Classical, then use <strong>Go to Album</strong> and share that URL instead.
+            </p>
+          )}
+          {urlInput && !canSubmit && !isMultiUrl && urlContentType !== 'recording' && (
             <p className="text-xs text-status-error">Please enter a valid Apple Music URL</p>
           )}
           {urlInput && !canSubmit && isMultiUrl && (

--- a/src/lib/url-parser.test.ts
+++ b/src/lib/url-parser.test.ts
@@ -265,7 +265,7 @@ describe('non-geographic URLs (no storefront code)', () => {
  * test serves as a safety net against accidental typos in the labels.
  */
 describe('getContentTypeLabel', () => {
-  /** Exhaustively tests all seven content type variants */
+  /** Exhaustively tests all content type variants */
   it('returns correct labels for all content types', () => {
     expect(getContentTypeLabel('song')).toBe('Song');
     expect(getContentTypeLabel('album')).toBe('Album');
@@ -273,7 +273,56 @@ describe('getContentTypeLabel', () => {
     expect(getContentTypeLabel('music-video')).toBe('Music Video');
     expect(getContentTypeLabel('artist')).toBe('Artist');
     expect(getContentTypeLabel('library')).toBe('Library');
+    expect(getContentTypeLabel('recording')).toBe('Classical Recording');
     expect(getContentTypeLabel('unknown')).toBe('Unknown');
+  });
+});
+
+/*
+ * Apple Music Classical recording URLs — see url-parser.ts for the path
+ * shape documentation. The parser must:
+ *   1. Recognise the content type as `recording` (so the UI can show a
+ *      specific "use the album URL instead" message rather than the
+ *      generic "invalid URL" error).
+ *   2. Mark `isValid: false` (so the submit button stays disabled and
+ *      the UI doesn't pass the URL downstream — GAMDL's URL vocabulary
+ *      doesn't include `/recording/` paths).
+ */
+describe('parseAppleMusicUrl - classical recording URLs', () => {
+  it('classifies recording URLs as `recording` content type', () => {
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808'
+    );
+    expect(result.contentType).toBe('recording');
+  });
+
+  it('marks recording URLs as NOT submittable', () => {
+    // This is the critical guard — even though the URL is recognised as
+    // Apple Music, it cannot be downloaded yet.
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808'
+    );
+    expect(result.isValid).toBe(false);
+  });
+
+  it('classifies recording URL with locale query param', () => {
+    // Real-world URL shape from Apple Music Classical Share → Copy Link,
+    // captured 2026-04-23.
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808?l=en-GB'
+    );
+    expect(result.contentType).toBe('recording');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('does not misclassify album URLs as recordings', () => {
+    // Regression canary — `/album/` URLs must NOT accidentally hit the
+    // `recording` branch if someone refactors the detection order.
+    const result = parseAppleMusicUrl(
+      'https://classical.music.apple.com/gb/album/1844602145'
+    );
+    expect(result.contentType).toBe('album');
+    expect(result.isValid).toBe(true);
   });
 });
 

--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -80,11 +80,22 @@ export function parseAppleMusicUrl(url: string): ParsedUrl {
   /* Step 3: Analyze the URL path to determine content type */
   const contentType = detectContentType(trimmed);
 
+  /*
+   * A URL is submittable only if we could classify it into a *downloadable*
+   * content type. `recording` is a new Apple Music Classical entity (a
+   * specific performance of a work) — recognised so the UI can show a
+   * specific actionable message, but NOT submittable because GAMDL's URL
+   * vocabulary doesn't yet include `/recording/` paths. Blocking the
+   * submit avoids the misleading-success UX bug documented in #548 / #567
+   * where an unparseable URL lands GAMDL at "Could not parse ..., skipping"
+   * while the activity log claims lyrics companions succeeded.
+   */
+  const isSubmittable = contentType !== 'unknown' && contentType !== 'recording';
+
   return {
     url: trimmed,
     contentType,
-    /* A URL is valid only if we could classify it into a known content type */
-    isValid: contentType !== 'unknown',
+    isValid: isSubmittable,
   };
 }
 
@@ -191,6 +202,24 @@ function detectContentType(url: string): AppleMusicContentType {
       return 'library';
     }
 
+    /*
+     * Apple Music Classical recording URLs (`classical.music.apple.com`).
+     * A "recording" is a specific performance of a classical work — e.g.
+     * Beethoven's 5th as performed by Karajan / Berliner Philharmoniker
+     * in 1977, distinct from the album release that contains it. The
+     * path shape is `/recording/{composer-year-piece}-{id}` (example:
+     * `/gb/recording/gustav-mahler-1860-pp1-1452377808?l=en-GB`).
+     *
+     * Recognised here so the UI can surface a specific "not yet
+     * supported — use the album URL instead" message rather than the
+     * generic "Please enter a valid Apple Music URL". Marked
+     * non-submittable in `parseAppleMusicUrl()` to block downloads —
+     * GAMDL's URL vocabulary does not include `/recording/` paths.
+     */
+    if (path.includes('/recording/')) {
+      return 'recording';
+    }
+
     /* No recognized content type path segment found */
     return 'unknown';
   } catch {
@@ -226,6 +255,8 @@ export function getContentTypeLabel(contentType: AppleMusicContentType): string 
       return 'Artist';
     case 'library':
       return 'Library';
+    case 'recording':
+      return 'Classical Recording';
     default:
       return 'Unknown';
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1240,6 +1240,7 @@ export type AppleMusicContentType =
   | 'music-video'
   | 'artist'
   | 'library'
+  | 'recording'
   | 'unknown';
 
 /**


### PR DESCRIPTION
## Summary

Apple Music Classical's 2026 rollout introduced a new content type, `/recording/`, which represents a specific performance of a classical work (distinct from the album release that contains it). User encountered it whilst collecting #547 audit data on 2026-04-23 — the URL they pasted was:

```
https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808?l=en-GB
```

**Current behaviour on `main`**: frontend `detectContentType()` doesn't recognise `/recording/`, returns `'unknown'`, and the UI shows the generic red error *"Please enter a valid Apple Music URL"* — no actionable guidance.

**New behaviour with this PR**: recording URLs are classified as a new content type, `recording`. `parseAppleMusicUrl()` marks them `isValid: false` so the submit button stays disabled. The DownloadForm shows a specific actionable message:

> *"Apple Music Classical **recording** URLs aren't supported yet. Open the recording in Apple Music Classical, then use **Go to Album** and share that URL instead."*

## Why not pass to GAMDL and let it try?

GAMDL's URL regex vocabulary does not include `/recording/`. Attempting to download would hit the exact misleading-success bug documented in #567 / #568: GAMDL emits *"Could not parse URL, skipping"*, exits 0, MeedyaDL's lyrics companion pipeline runs and claims success, but no files land on disk. Frontend rejection with a helpful message is the honest UX until we know how to handle recordings properly.

If we ever add a proper `/recording/` download pipeline (e.g. by resolving recording → album via the Apple Music Catalog API and rewriting the URL), flipping `isValid: true` re-enables submission — the type system is already in place.

## Changes

### `src/types/index.ts`
Add `recording` to the `AppleMusicContentType` union.

### `src/lib/url-parser.ts`
- `detectContentType()`: recognise `/recording/` path segment and return `'recording'`.
- `parseAppleMusicUrl()`: new `isSubmittable` guard that excludes `recording` (and still excludes `unknown`) from `isValid: true`. Detailed docstring explaining why.
- `getContentTypeLabel()`: add `"Classical Recording"` label for the new type.

### `src/components/download/DownloadForm.tsx`
- `CONTENT_TYPE_ICONS` / `CONTENT_TYPE_LABELS` registries: add entries for `recording`.
- Validation feedback block: when `urlContentType === 'recording'`, show the specific actionable message; generic "Please enter a valid Apple Music URL" still fires for truly unrecognised URLs.

### `src/lib/url-parser.test.ts`
Four new tests in a dedicated `parseAppleMusicUrl - classical recording URLs` describe block:

1. `classifies recording URLs as 'recording' content type`
2. `marks recording URLs as NOT submittable` (the critical guard)
3. `classifies recording URL with locale query param` (real-world shape, `?l=en-GB`)
4. `does not misclassify album URLs as recordings` (regression canary against detection-order mistakes)

Plus an extended assertion on the existing `getContentTypeLabel` exhaustive test.

## Backend parser — intentionally NOT touched

Recording URLs are blocked at the frontend now, so they never reach the Rust side during normal flow. If a recording URL bypasses the frontend (deep-link, drag-drop, manifest import), the existing `#549 catch-all WARN` in `start_download` will flag it. Adding a backend regex branch for `/recording/` would add complexity with no observed benefit — keeping the surface small.

## Local verification

```
tsc --noEmit                   ✓ clean
npx vitest run url-parser      49 tests passed (45 existing + 4 new)
npx vitest run (all files)     303 tests passed across 19 files
```

## Risk

Very low. Purely additive frontend classification:

- Existing URL shapes still parse identically (unchanged detection order; `/recording/` check inserted *after* the other 6 path-type checks).
- No backend changes.
- New content type exclusion from `isValid` means one specific URL shape is *rejected* rather than *accepted* — strictly safer than current behaviour (which was also rejecting it, just with a worse message).

## Test plan (post-merge)

- [ ] Paste the URL from the bug report — UI shows the specific "Go to Album" message instead of "Please enter a valid Apple Music URL".
- [ ] Paste any `/album/` URL on `classical.music.apple.com` — still works (no regression).
- [ ] Paste the recording URL with whitespace around it — still detected and rejected correctly (trim still runs first).
- [ ] Unblocks #547 repro — users can now share-link to a recording, see the helpful message, tap "Go to Album" in the app, and get the album URL for the actual download.

## Out of scope

- Downloading classical recordings. Separate future work; needs Apple Music Catalog API investigation (`/v1/catalog/{sf}/recordings/{id}?include=albums`?) to resolve recording → album before GAMDL handoff.
- Other Classical-specific path segments (`/work/`, `/composer/`, `/ensemble/`, `/conductor/`). These haven't appeared in the wild yet; if they do, the #549 catch-all WARN will flag them and we can extend the same pattern.

## Related

- **#547** — manual repro blocked on this URL shape being unparseable; clicking "Go to Album" per the new error message produces a URL that works.
- **#567** — why we block at validator instead of passing through (misleading-success bug).
- **#568** — similar rationale for rewriting iTunes URLs rather than passing them raw.
- **#549** — catch-all WARN in `start_download` for any URL that bypasses frontend validation.

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_