### PR TITLE
fix(parser): accept Apple Music Classical `/recording/` URLs as submittable (revert #573 rejection UX)

### DIFF
--- a/src/components/download/DownloadForm.tsx
+++ b/src/components/download/DownloadForm.tsx
@@ -147,7 +147,7 @@ const CONTENT_TYPE_ICONS: Record<AppleMusicContentType, typeof Music> = {
   'music-video': Video, // Music video URL
   artist: User, // Artist page URL
   library: Library, // Personal library URL
-  recording: Music, // Apple Music Classical recording (currently unsupported for download)
+  recording: Music, // Apple Music Classical recording (a specific performance of a work)
   unknown: HelpCircle, // Unrecognised or unparseable URL
 };
 
@@ -851,19 +851,10 @@ export function DownloadForm() {
 
           {/*
            * Validation feedback messages (mutually exclusive):
-           *  - Specific error text for recognised-but-unsupported content types
-           *    (currently just `recording` — see url-parser.ts), so the user
-           *    gets actionable guidance rather than "your URL is invalid".
-           *  - Generic red error text when the input is recognised as Apple
-           *    Music but classifies as unknown.
+           *  - Red error text when the input has text but URL is invalid.
            *  - Grey helper text when the input is empty (shows supported types).
            */}
-          {urlInput && !canSubmit && !isMultiUrl && urlContentType === 'recording' && (
-            <p className="text-xs text-status-error">
-              Apple Music Classical <em>recording</em> URLs aren't supported yet. Open the recording in Apple Music Classical, then use <strong>Go to Album</strong> and share that URL instead.
-            </p>
-          )}
-          {urlInput && !canSubmit && !isMultiUrl && urlContentType !== 'recording' && (
+          {urlInput && !canSubmit && !isMultiUrl && (
             <p className="text-xs text-status-error">Please enter a valid Apple Music URL</p>
           )}
           {urlInput && !canSubmit && isMultiUrl && (

--- a/src/lib/url-parser.test.ts
+++ b/src/lib/url-parser.test.ts
@@ -281,12 +281,15 @@ describe('getContentTypeLabel', () => {
 /*
  * Apple Music Classical recording URLs — see url-parser.ts for the path
  * shape documentation. The parser must:
- *   1. Recognise the content type as `recording` (so the UI can show a
- *      specific "use the album URL instead" message rather than the
- *      generic "invalid URL" error).
- *   2. Mark `isValid: false` (so the submit button stays disabled and
- *      the UI doesn't pass the URL downstream — GAMDL's URL vocabulary
- *      doesn't include `/recording/` paths).
+ *   1. Recognise the content type as `recording`.
+ *   2. Mark `isValid: true` so the URL can be submitted like any other
+ *      Apple Music URL. Earlier behaviour (#573) rejected recording
+ *      URLs on the grounds that GAMDL can't handle them, but that was
+ *      reversed 2026-04-23 after reviewer feedback: the correct UX is
+ *      to accept what the user pasted and let the pipeline give a
+ *      clear outcome. With #567's broadened empty-output guard, a URL
+ *      GAMDL can't parse fails cleanly rather than cascading into
+ *      false lyrics-companion "success" lines.
  */
 describe('parseAppleMusicUrl - classical recording URLs', () => {
   it('classifies recording URLs as `recording` content type', () => {
@@ -296,23 +299,25 @@ describe('parseAppleMusicUrl - classical recording URLs', () => {
     expect(result.contentType).toBe('recording');
   });
 
-  it('marks recording URLs as NOT submittable', () => {
-    // This is the critical guard — even though the URL is recognised as
-    // Apple Music, it cannot be downloaded yet.
+  it('marks recording URLs as submittable', () => {
+    // Reversed from the #573 behaviour: recording URLs now pass the
+    // validator so the user isn't asked to re-navigate for a different
+    // link. GAMDL may still fail on the URL — that failure is handled
+    // cleanly by the #567 empty-output enrichment guard.
     const result = parseAppleMusicUrl(
       'https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808'
     );
-    expect(result.isValid).toBe(false);
+    expect(result.isValid).toBe(true);
   });
 
-  it('classifies recording URL with locale query param', () => {
+  it('classifies recording URL with locale query param as submittable', () => {
     // Real-world URL shape from Apple Music Classical Share → Copy Link,
     // captured 2026-04-23.
     const result = parseAppleMusicUrl(
       'https://classical.music.apple.com/gb/recording/gustav-mahler-1860-pp1-1452377808?l=en-GB'
     );
     expect(result.contentType).toBe('recording');
-    expect(result.isValid).toBe(false);
+    expect(result.isValid).toBe(true);
   });
 
   it('does not misclassify album URLs as recordings', () => {

--- a/src/lib/url-parser.ts
+++ b/src/lib/url-parser.ts
@@ -81,21 +81,21 @@ export function parseAppleMusicUrl(url: string): ParsedUrl {
   const contentType = detectContentType(trimmed);
 
   /*
-   * A URL is submittable only if we could classify it into a *downloadable*
-   * content type. `recording` is a new Apple Music Classical entity (a
-   * specific performance of a work) — recognised so the UI can show a
-   * specific actionable message, but NOT submittable because GAMDL's URL
-   * vocabulary doesn't yet include `/recording/` paths. Blocking the
-   * submit avoids the misleading-success UX bug documented in #548 / #567
-   * where an unparseable URL lands GAMDL at "Could not parse ..., skipping"
-   * while the activity log claims lyrics companions succeeded.
+   * A URL is valid (submittable) if it classifies into a known content
+   * type — including `recording`. An earlier iteration (#573) rejected
+   * `recording` URLs on the grounds that GAMDL's URL vocabulary doesn't
+   * include `/recording/` paths, but that was reverted 2026-04-23: the
+   * correct UX is to accept what the user pasted and let the pipeline
+   * give a clear outcome. With #567's broadened empty-output guard now
+   * on main, a URL GAMDL can't handle fails cleanly (single
+   * "Enrichment skipped — primary download produced no output files"
+   * line instead of cascading false-success noise), so the rationale
+   * for pre-emptive rejection no longer holds.
    */
-  const isSubmittable = contentType !== 'unknown' && contentType !== 'recording';
-
   return {
     url: trimmed,
     contentType,
-    isValid: isSubmittable,
+    isValid: contentType !== 'unknown',
   };
 }
 


### PR DESCRIPTION
## Summary

Reverses the reject-at-validator UX from #573 for Apple Music Classical `/recording/` URLs. Recording URLs are now treated like any other recognised Apple Music URL — the user can paste and submit, GAMDL attempts the download, the pipeline gives a clean outcome.

## Reviewer feedback that drove this change

> *"why are we showing a notice/error for Apple Music Classical /recording/ URLs if theyre valid? why not just accept them? Asking the user to enter another is not user friendly!"*

Fair call. Two things changed since #573 that make pre-emptive rejection the wrong UX:

1. **PR #582** (currently in CI) broadened #567's guard from *"skip lyrics companion when primary produced no audio"* to *"skip the ENTIRE enrichment pipeline when primary produced zero output files"*. So if GAMDL rejects a recording URL, the user now sees **one** clean `Enrichment skipped — primary download produced no output files` activity-log line instead of 5+ cascading fake "success" lines.
2. **Recording URLs ARE Apple Music Classical URLs** — the user's mental model is that if they copied the link from the Apple Music Classical app, it should work. Forcing them to navigate back to the app and find the containing album URL is paternalistic UX.

## Changes

### `src/lib/url-parser.ts`

`parseAppleMusicUrl()`: removes the `contentType !== 'recording'` exclusion from the `isValid` calculation. Recording URLs now return `isValid: true`. The docstring block explaining the old rationale is replaced with the new one.

**Before** (merged in #573):
```ts
const isSubmittable = contentType !== 'unknown' && contentType !== 'recording';
return { url: trimmed, contentType, isValid: isSubmittable };
```

**After**:
```ts
return { url: trimmed, contentType, isValid: contentType !== 'unknown' };
```

### `src/components/download/DownloadForm.tsx`

Drops the recording-specific error-message branch from the validation-feedback block (no longer shown since submit is allowed):

```tsx
// REMOVED:
{urlInput && !canSubmit && !isMultiUrl && urlContentType === 'recording' && (
  <p className="text-xs text-status-error">
    Apple Music Classical <em>recording</em> URLs aren't supported yet...
  </p>
)}
```

Also updates the `recording` icon registry comment from "(currently unsupported for download)" to "(a specific performance of a work)" so future readers see the current state.

### `src/lib/url-parser.test.ts`

Updates the two `isValid: false` assertions to `isValid: true` and renames one test from `marks recording URLs as NOT submittable` to `marks recording URLs as submittable`. Rewrites the describe-block docstring to reflect the reversed rationale.

## What remains from #573

- ✅ **`recording` in the `AppleMusicContentType` union** — kept, so the badge UI renders "Classical Recording" when pasted.
- ✅ **`CONTENT_TYPE_LABELS` / `CONTENT_TYPE_ICONS` entries** — kept.
- ✅ **`detectContentType()` recognising `/recording/`** — kept, so the classification is still correct for telemetry / display.
- ✅ **`getContentTypeLabel('recording')` returns "Classical Recording"** — kept.
- ❌ **`isValid: false` for recording** — reverted. This is the UX fix.
- ❌ **Recording-specific error message in DownloadForm** — removed.

## What happens now when a user pastes a recording URL

1. Frontend classifies as `contentType: 'recording'`, `isValid: true`.
2. Submit button is enabled; user clicks Download.
3. URL submitted to backend via `start_download` IPC.
4. Backend host allowlist accepts `classical.music.apple.com` (shipped in PR #565).
5. `parse_apple_music_url()` returns `None` (no backend regex branch for `/recording/` — intentional; see #573 "Backend parser — intentionally NOT touched" section).
6. `normalize_apple_music_url()` returns the URL unchanged.
7. `start_download`'s `#549` catch-all emits `WARN: Unrecognised Apple Music URL shape` activity log.
8. URL passed to GAMDL subprocess.
9. GAMDL likely emits `Could not parse URL, skipping`.
10. MeedyaDL's "no output files" detection fires at `download_queue.rs:4894`.
11. With PR #582's #567 broadening, no cascading false-success noise — **one clean activity-log line** tells the user enrichment was skipped because no files were produced.

Net UX: user pastes URL → sees clean failure message if GAMDL can't handle it, or success if it ever learns to. No extra UI friction.

## Related

- **#573** — the PR this reverses the UX of.
- **#567** (broadened) — the misleading-success bug whose fix (PR #582) makes this UX change safe.
- **#582** — empty-output guard PR; **must merge before this** or this PR's UX is worse than #573's (users would see cascading false-success noise on recording URL failures).
- **#547** — Classical audit; users can now paste recording URLs from the app directly.

## Merge order

1. Wait for **#582** to merge (skip-all-enrichments-on-empty-output + timeout scaling). Without #582, reverting #573's rejection causes a UX regression — recording URLs hit the original misleading-success cascade.
2. Then merge **this PR** to unblock recording URL acceptance.

## Local verification

```
tsc --noEmit                 ✓ clean
npx vitest run (all files)   303 tests passed across 19 files
```

## Risk

Low. Only changes the `isValid` flag for one specific content-type branch + removes one UI message. Backend untouched. Every existing URL shape behaves identically.

## Test plan (post-merge, requires #582 also merged)

- [ ] Paste a recording URL (`classical.music.apple.com/gb/recording/...`) — submit button enables.
- [ ] Click Download — activity log shows GAMDL attempt, fails cleanly with a single "Enrichment skipped — primary download produced no output files" line. No fake "Lyrics companion (lrc) downloaded" lines.
- [ ] Paste a recording URL with `?l=en-GB` locale query — same as above.
- [ ] Paste an album URL on `classical.music.apple.com` — still works (no regression).

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_