### PR TITLE
fix(activity-log): stable key + stable measureElement to prevent row overlap (#575)

### DIFF
--- a/src/components/download/ActivityLog.tsx
+++ b/src/components/download/ActivityLog.tsx
@@ -169,6 +169,49 @@ export function ActivityLog() {
     });
   }, [entries, searchQuery, showSystem, showDownload, showVerbose]);
 
+  /*
+   * Stable height-measurement callback. Wrapped in `useCallback` so the
+   * virtualizer's internal config doesn't thrash its reference identity
+   * on every render — rapid log bursts at ~60 flushes/sec (per
+   * App.tsx's RAF batching) produce a lot of renders, and a fresh
+   * `measureElement` closure on each one was observed to interact
+   * with the measurement cache in ways that produce the overlapping-
+   * text regression reported in #575.
+   */
+  const measureElement = useCallback(
+    (element: Element | null | undefined) =>
+      element?.getBoundingClientRect().height ?? 26,
+    [],
+  );
+
+  /*
+   * Stable per-item key. This is the critical fix for #575: without
+   * `getItemKey`, TanStack virtual keys its measurement cache by
+   * positional index. When the entry list shifts (10,000-entry
+   * trimming cap triggering, filter toggles changing `filteredEntries.length`,
+   * RAF-batched bursts prepending new entries), cached row heights
+   * attach to the wrong entries and the resulting `translateY()`
+   * offsets overlap adjacent rows.
+   *
+   * Keying by the entry's stable `_id` means a measurement made for
+   * entry id=1234 stays attached to entry id=1234 regardless of what
+   * position it currently occupies in the filtered list. Entries
+   * without an `_id` fall back to the index — that path is only
+   * reached if an upstream emitter skips the auto-increment, which
+   * shouldn't happen in normal flow.
+   *
+   * #442 (closed 2026-04-12) was the original fix for the same
+   * symptom but only added `measureElement`; it didn't add the
+   * stable-key layer, which is why this class of bug regressed
+   * under real workloads (200-track box set on external USB, per #575
+   * repro). This commit is the belt-and-braces completion of #442's
+   * fix.
+   */
+  const getItemKey = useCallback(
+    (index: number) => filteredEntries[index]?._id ?? index,
+    [filteredEntries],
+  );
+
   /** Virtualizer for efficient rendering of large entry lists.
    * Uses dynamic height measurement so wrapped multi-line entries
    * don't overlap with subsequent rows. */
@@ -177,7 +220,8 @@ export function ActivityLog() {
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 26, // text-xs + leading-relaxed + py-0.5 + border (single-line estimate)
     overscan: 50, // render 50 extra rows above/below viewport
-    measureElement: (element) => element?.getBoundingClientRect().height ?? 26,
+    measureElement,
+    getItemKey,
   });
 
   /**


### PR DESCRIPTION
## Summary

Closes **#575**. Fixes the activity-log overlapping-text regression captured live 2026-04-23 during the Beethoven box-set download. The virtualiser was laying out rows at stale `translateY()` offsets during burst log ingestion, producing visual overlap between consecutive entries whose wrapped heights didn't match what the cache thought they should be.

#442 (closed 2026-04-12) was the original fix for the same symptom — it added `measureElement` so that dynamic row heights were actually measured. That fix was necessary but not sufficient; under real workloads the bug recurs because TanStack virtual's measurement cache is keyed by **index** by default, and indices shift whenever the filtered entry list changes.

## Root cause analysis

Two related gaps in the `useVirtualizer` config in `src/components/download/ActivityLog.tsx`:

### Gap 1 — no `getItemKey`

Without `getItemKey`, TanStack virtual uses the positional index as the cache key. Every time the entry list changes position:

- **10 000-entry trimming cap** (per CLAUDE.md) — oldest entries drop, remaining entries shift down by N.
- **Filter toggles** (System / Download / Verbose) — `filteredEntries.length` changes; a row that was index 47 in the all-visible set is index 12 in the filtered set.
- **RAF-batched bursts** — App.tsx feeds entries in batches at ~60 flushes/sec; during a dense burst (200+ entries/sec from MediaInfo codec detection on a 200-track album) the virtualiser sees rapid `count` deltas.

Every shift invalidates the index→height mapping. Cached heights for entry-at-index-47 get applied to the new-entry-at-index-47, which has completely different content (and therefore different wrapped height). `translateY(row.start)` for subsequent rows computes using stale heights, and rows overlap.

### Gap 2 — inline `measureElement`

```typescript
// Before:
const virtualizer = useVirtualizer({
  ...
  measureElement: (element) => element?.getBoundingClientRect().height ?? 26,
});
```

Inline arrow function — re-created on every render. At 60 flushes/sec, that's 60 new function references per second, each one syncing into the virtualiser's internal config. TanStack's behaviour when the `measureElement` reference changes is to re-walk its cache; in a tight burst scenario this was observed to interact with the index-based keying to produce worse overlap than either issue alone.

## Fix

- **`getItemKey`** added, wrapped in `useCallback`. Keys by `filteredEntries[index]?._id` (the stable auto-incrementing ID set by `activityStore.addEntries()` per CLAUDE.md), falls back to index when `_id` is absent (defensive; shouldn't trigger in normal flow).
- **`measureElement`** extracted from the inline config and wrapped in `useCallback([])`. One stable function for the component's lifetime.

Full change is **45 lines added, 1 removed, single file**:

```typescript
const measureElement = useCallback(
  (element: Element | null | undefined) =>
    element?.getBoundingClientRect().height ?? 26,
  [],
);

const getItemKey = useCallback(
  (index: number) => filteredEntries[index]?._id ?? index,
  [filteredEntries],
);

const virtualizer = useVirtualizer({
  count: filteredEntries.length,
  getScrollElement: () => scrollRef.current,
  estimateSize: () => 26,
  overscan: 50,
  measureElement,
  getItemKey,
});
```

No other changes. `estimateSize`, `overscan`, JSX row rendering (still uses `ref={virtualizer.measureElement}`), CSS classes, filter logic, and App.tsx's RAF batching are all left alone.

## Why this completes #442's intended fix

#442 added the missing `measureElement` option. That made the virtualiser *capable* of measuring dynamic heights, but the measurements were then stored against volatile keys. The fix works when the entry list is static, but fails under the exact workloads MeedyaDL encounters in practice — box-set downloads, external USB filesystems, MediaInfo verbose streams. This PR is the belt-and-braces completion: dynamic measurements stored against stable keys.

## Local verification

```
tsc --noEmit                 ✓ clean
npx vitest run (all files)   303 tests passed across 19 files
```

## Post-merge test plan

Reproducing the original #575 observation requires the exact conditions captured 2026-04-23:

- Output path on an external exFAT / FAT32 / HFS USB drive (forces macOS to create `._*` AppleDouble sidecars, which inflate the ffprobe-failure log volume and trigger the rapid-burst path).
- Verbose activity log enabled.
- 100+ track album download (forces MediaInfo codec detection to iterate many files rapidly).
- Watch Activity Log during enrichment phase — no row overlap should occur.

Complementary: rapidly toggle the System / Download / Verbose filter buttons during a dense burst — the old bug would show overlap during the filter transition; the new fix should not.

## Known limitations

- `_id` is expected to be present on every entry (set by `activityStore.addEntries()`). If an upstream emitter ever bypasses that path, the fallback to positional index means the fix degrades gracefully to the pre-#575 behaviour for those entries — same as today, no worse.
- No automated visual regression test added in this PR. `src/components/download/ActivityLog.test.tsx` does not exist; adding one is a reasonable follow-up but requires a jsdom setup that can measure `getBoundingClientRect()` realistically, which is non-trivial. Manual repro is the near-term validation path.

## Related

- **#442** — original fix for overlapping text. Necessary but incomplete.
- **#575** — this PR closes it.
- **CLAUDE.md** — "Activity Log" + "Activity Log Memory Optimization (#370)" sections document the infrastructure this PR builds on.
- **#577** — `ffprobe` on AppleDouble sidecars. Fixing that separately will reduce log-burst density, which reduces the pressure on the virtualiser — complementary fixes.

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_