### PR TITLE
fix(ux): replace "Pre-flight checks passed" jargon with plain-English activity log (#578)

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -4238,6 +4238,17 @@ pub fn process_queue(
 
                 let settings = load_settings_for_queue(&app);
 
+                // Tell the user we're about to verify the prerequisites.
+                // The old wording ("Pre-flight checks passed") was flagged
+                // in #578 as jargon — even dev-literate users couldn't tell
+                // whether something had broken or succeeded. Emitting a
+                // user-facing "Checking..." line before the result gives
+                // the activity log a clear question-and-answer shape.
+                emit_app_log(
+                    &app,
+                    "Checking internet connection, output folder, and account...",
+                );
+
                 // Run internet + wrapper checks concurrently (both are HTTP GETs)
                 let internet_future =
                     crate::services::health_check_service::check_internet_connectivity();
@@ -4313,7 +4324,11 @@ pub fn process_queue(
                     if let Some(w) = warning {
                         any_warnings = true;
                         log::warn!("Pre-flight warning ({check:?}): {}", w.message);
-                        emit_app_log(&app, &format!("Pre-flight: {}", w.message));
+                        // Warnings keep the "Pre-flight:" prefix — the word
+                        // "warning" is more useful context than the technical
+                        // phrase on the all-OK path, and the preflight-warning
+                        // event below drives a user-visible toast regardless.
+                        emit_app_log(&app, &format!("Pre-flight warning: {}", w.message));
                         let _ = app.emit("preflight-warning", &w);
                     } else {
                         // Check passed — dismiss any stale toast for this check type
@@ -4324,7 +4339,18 @@ pub fn process_queue(
                     }
                 }
                 if !any_warnings {
-                    emit_app_log(&app, "Pre-flight checks passed");
+                    // Plain-English all-clear message (#578). Describes what
+                    // was verified and what happens next, so the user — dev
+                    // or otherwise — doesn't have to infer the outcome from
+                    // the phrase "Pre-flight checks passed". The explicit
+                    // enumeration of the three verified prerequisites matches
+                    // the "Checking..." line that fired at the start so the
+                    // activity-log pair reads as a coherent question-and-
+                    // answer.
+                    emit_app_log(
+                        &app,
+                        "Ready to download — internet, output folder, and account all verified",
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes **#578**. Replaces the jargon-first `[System] Pre-flight checks passed` activity-log message with plain-English before/after pair so users know what was verified and what happens next.

## Reviewer feedback

> *"It needs to be something meaningful to the end user! This is partly why even I (as a dev) thought something was broken when the progress bars disappeared. For a moment I didn't realise this vague statement meant ALL actions completed successfully."*

## Changes

Three string tweaks in the pre-flight block of `services/download_queue.rs`:

### 1. New "before" message

Emitted at the moment pre-flight checks begin, so the activity log has a clear question-and-answer shape:

```
[System] Checking internet connection, output folder, and account...
```

### 2. "All-clear" message

```diff
- [System] Pre-flight checks passed
+ [System] Ready to download — internet, output folder, and account all verified
```

Leads with the user-facing action ("Ready to download"), enumerates the verified prerequisites in plain English, no aviation jargon.

### 3. Warning message prefix

```diff
- [System] Pre-flight: {message}
+ [System] Pre-flight warning: {message}
```

Kept the "Pre-flight" prefix because adding "warning" makes it explicit that this is a problem the user should act on; removing the prefix entirely would drop useful context. (The backend `preflight-warning` event that drives the user-visible toast is also left alone — it's a wire-protocol identifier, not a UI string.)

## Not in scope

- Broader audit of every `[System]` activity-log string for similar jargon (the issue body mentions this as a follow-up). Done separately if the pattern recurs.
- The Rust `log::warn!` line keeps the old phrasing — that's aimed at log-file inspection for support / dev debugging, not the user-facing activity log.

## Before / after (typical happy path)

**Before**:
```
[System] Pre-flight checks passed
```

**After**:
```
[System] Checking internet connection, output folder, and account...
[System] Ready to download — internet, output folder, and account all verified
```

The pair reads naturally, is self-explanatory, and matches the length/tone of the rest of the `[System]` log entries (startup banner, config dump, etc.).

## Local verification

```
cargo clippy -- -D warnings  ✓ clean
cargo test --lib services::download_queue::tests  120 passed
```

## Risk

Trivial. Three user-facing string edits, one new emit site, no logic changes, no event shape changes. Existing `preflight-warning` / `preflight-cleared` event names untouched; frontend listeners unaffected.

## Related

- **#578** — closed by this PR.
- **#574** / **#576** / **#585** / **#591** — same RC polish theme ("make the activity log make sense").

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_