### PR TITLE
chore(scripts): remove unused variables flagged by CodeQL

### DIFF
--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -129,8 +129,6 @@ async function main() {
     const dir = resolve(TEMP_DIR, name.replace('.icns', '.iconset'));
     if (existsSync(dir)) rmSync(dir, { recursive: true });
     mkdirSync(dir, { recursive: true });
-    const map = [[16,16],[32,32],[32,64],[64,128],[128,256],[256,512],[512,1024]];
-    const names = ['icon_16x16','icon_16x16@2x','icon_32x32','icon_32x32@2x','icon_128x128','icon_128x128@2x','icon_256x256','icon_256x256@2x','icon_512x512','icon_512x512@2x'];
     const entries = [[16,'icon_16x16'],[32,'icon_16x16@2x'],[32,'icon_32x32'],[64,'icon_32x32@2x'],[128,'icon_128x128'],[256,'icon_128x128@2x'],[256,'icon_256x256'],[512,'icon_256x256@2x'],[512,'icon_512x512'],[1024,'icon_512x512@2x']];
     for (const [sz, fname] of entries) {
       execSync(`cp "${src(sz)}" "${resolve(dir, fname + '.png')}"`);

--- a/scripts/svg-to-apng.mjs
+++ b/scripts/svg-to-apng.mjs
@@ -99,8 +99,10 @@ async function main() {
         deviceScaleFactor: 1,
       });
 
-      // Build HTML with mode applied via query param
-      const modeParam = modeConfig.mode ? `?mode=${modeConfig.mode}` : '';
+      // Build HTML with mode applied via inline script (modeConfig.mode
+      // is referenced directly in the <script> block below, not via a
+      // query param on the SVG — kept as inline JS for Puppeteer's
+      // `setContent` flow).
       const html = `<!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## Summary

Cleans up three unused-variable Note-level findings raised by CodeQL on `main` (findings #16/#17/#18 in the Code Scanning dashboard). All three are stale declarations with zero runtime impact.

| File | Line | Variable | Why it was unused |
|---|---|---|---|
| `scripts/generate-icons.mjs` | 132 | `const map` | Superseded by `const entries` on the very next line |
| `scripts/generate-icons.mjs` | 133 | `const names` | Filename list that was never consumed |
| `scripts/svg-to-apng.mjs` | 103 | `const modeParam` | Built as a `?mode=...` query string, but the HTML template below uses `modeConfig.mode` directly in an inline `<script>` block — the param was never interpolated |

## Test plan

- [x] `node --check scripts/generate-icons.mjs` — clean
- [x] `node --check scripts/svg-to-apng.mjs` — clean
- [ ] Manual run of the icon generator produces identical output (not run in-session; these scripts need `sharp` + `iconutil` + Puppeteer)
- [ ] CodeQL rescan on this PR clears findings #16/#17/#18

## Risk

Zero. Dead locals only — no exports, no side effects, no references anywhere else in the repo (verified by `grep`). Output icons and APNGs are unaffected.

https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZkza8Axks7rh5rJ7e68nB)_