### PR TITLE
ci+docs: harden changelog push race + document GHAS posture (#544, #564)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -146,10 +146,31 @@ jobs:
       # any workflows for this push, providing a second layer of infinite loop prevention.
       #
       # @see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+      # Push is wrapped in a pull-rebase + bounded retry loop to survive the
+      # race where another workflow (e.g. release-please, or a concurrent
+      # changelog run from a fast-follow merge) lands on main between our
+      # checkout and our push. Without the loop, the push is rejected as
+      # non-fast-forward and the job fails cosmetically even though the next
+      # successful run regenerates CHANGELOG.md from scratch anyway.
+      # See https://github.com/MWBMPartners/MeedyaDL/issues/544 for the trigger run.
       - name: Commit changelog
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git diff --staged --quiet || git commit -m "docs: update CHANGELOG.md [skip ci]"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changelog changes to commit."
+            exit 0
+          fi
+          git commit -m "docs: update CHANGELOG.md [skip ci]"
+          for attempt in 1 2 3; do
+            if git pull --rebase --autostash origin main && git push; then
+              echo "Changelog pushed on attempt $attempt."
+              exit 0
+            fi
+            sleep_seconds=$((attempt * 2))
+            echo "Push attempt $attempt failed; retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+          done
+          echo "Push failed after 3 attempts." >&2
+          exit 1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,9 +22,10 @@ Running MeedyaDL with components **outside** the listed ranges (e.g. a manually 
 If you discover a security vulnerability in MeedyaDL, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue** for security vulnerabilities.
-2. **Email**: Send details to the repository maintainers via the email listed in the GitHub organisation profile.
-3. **Include**: A description of the vulnerability, steps to reproduce, and any potential impact.
-4. **Response time**: We aim to acknowledge reports within 48 hours and provide a fix within 7 days for critical issues.
+2. **Preferred — GitHub Private Vulnerability Reporting**: submit a report via [the MeedyaDL private advisory form](https://github.com/MWBMPartners/MeedyaDL/security/advisories/new). This keeps the report invisible to the public, lets us collaborate on a fix in a private fork, and issues a CVE on publication.
+3. **Alternative — Email**: send details to the repository maintainers via the email listed on the [MWBMPartners GitHub organisation profile](https://github.com/MWBMPartners).
+4. **Include**: a description of the vulnerability, steps to reproduce, affected MeedyaDL version(s), and any potential impact.
+5. **Response time**: we aim to acknowledge reports within 48 hours and provide a fix within 7 days for critical issues.
 
 ## Security Measures
 
@@ -43,7 +44,9 @@ MeedyaDL implements the following security measures:
 - **SHA-256 checksum verification** for downloaded dependencies
 - **GitHub Actions hardening**: all actions pinned to immutable commit SHAs
 - **cargo-deny** licence scanning and source allowlisting in CI (org-level `[sources.allow-org]`)
-- **CodeQL** static analysis for JavaScript/TypeScript and GitHub Actions
+- **CodeQL** static analysis for JavaScript/TypeScript and GitHub Actions, with the `security-and-quality` query suite enabled
+- **GitHub Advanced Security features**: Private Vulnerability Reporting, secret scanning + push protection, and Dependabot security updates are enabled on the repository
+- **Dependabot version updates** — weekly PRs for npm and cargo ecosystems (security updates are delivered immediately out-of-schedule)
 - **Activity log memory bounds** — capped at 10,000 entries to prevent unbounded WebView memory growth
 - **Updater artifact signing** — `.app.tar.gz.sig` signature files verified by Tauri updater before installation
 


### PR DESCRIPTION
## Summary

- **#544**: wrap the `changelog.yml` final `git push` in a `git pull --rebase --autostash` + 3-attempt retry loop (2s / 4s / 6s backoff). Concurrent pushes to `main` (release-please merges, fast-follow changelog runs) no longer surface cosmetic non-fast-forward failures. Clean exit when there are no staged changes.
- **#564**: advertise GitHub Private Vulnerability Reporting as the preferred disclosure channel in `SECURITY.md`'s "Reporting a Vulnerability" section, and add the now-enabled GHAS features (PVR, secret scanning + push protection, Dependabot security updates) and the CodeQL `security-and-quality` query suite to the security measures list.

## Scope notes on #564

- CodeQL quality-queries already landed in an earlier PR (`codeql.yml:62`).
- The four GHAS toggles are server-side repo settings — this PR documents that they're enabled, but the actual enablement is admin-only via `gh api repos/... -X PATCH`. Verify with `gh api repos/MWBMPartners/MeedyaDL --jq '.security_and_analysis'`.

## Closes

- Closes #544
- Closes #564

## Test plan

- [ ] Confirm `changelog.yml` still parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/changelog.yml'))"` passes locally).
- [ ] Trigger the Changelog workflow manually (`gh workflow run "Changelog" --ref main`) after merge and confirm it completes cleanly on a quiet `main`.
- [ ] On the next concurrent push race, confirm the retry loop absorbs the non-fast-forward and lands the commit without a red X.
- [ ] Confirm the PVR link in `SECURITY.md` resolves to the repo's `/security/advisories/new` form.

## Out of scope (flagged for follow-ups)

- `SECURITY.md` "Supported Versions" table still lists 0.29.x — stale against current 0.44.x.
- `.github/dependabot.yml` does not yet monitor the `github-actions` ecosystem, which would pair well with our SHA-pinned actions policy.


---
_Generated by [Claude Code](https://claude.ai/code/session_014kDmSYgXn3rvHwAkPEezog)_