### PR TITLE
fix(ci): remove duplicate `fi` in update-security-policy workflow

### DIFF
--- a/.github/workflows/update-security-policy.yml
+++ b/.github/workflows/update-security-policy.yml
@@ -87,7 +87,6 @@ jobs:
               "| ${BASE}       | :white_check_mark: |" \
               "| != ${BASE}    | :x:                |")
           fi
-          fi
 
           # Write the generated block to a temp file so the next step can
           # splice it into SECURITY.md without escaping headaches.


### PR DESCRIPTION
## Summary

The `Compute supported-versions table` step in `.github/workflows/update-security-policy.yml` has a stray duplicate `fi` immediately after the `if/else/fi` block. With `set -euo pipefail` the shell exits with code 2 (`syntax error near unexpected token \`fi\``), failing every Update Security Policy run.

Symptom: Update Security Policy runs #3, #4, #5 all failed at the same step with `Process completed with exit code 2.`, on both the `push` trigger (release-please commit `c028772`) and the `release: published` trigger for `v0.49.0`.

## Fix

Delete the duplicate `fi` (1-line removal). The YAML still parses; SECURITY.md still has the BEGIN/END `supported-versions` sentinels the splice step expects.

## Test plan

- [ ] After merge, manually re-run `Update Security Policy` against `main` (`workflow_dispatch`) and confirm the job goes green.
- [ ] On the next release publish or `package.json` push, confirm the workflow no-ops cleanly (or commits an updated table without erroring).


---
_Generated by [Claude Code](https://claude.ai/code/session_016noZdBRJvtFUS6fHQqC1gw)_