### PR TITLE
fix(ux): missing 'to' in untested-GAMDL warning message

### DIFF
--- a/src/components/updates/UpdatesPage.tsx
+++ b/src/components/updates/UpdatesPage.tsx
@@ -396,7 +396,7 @@ export function UpdatesPage() {
                   <p className="text-[11px] text-status-warning mb-3">
                     This GAMDL release was published after MeedyaDL&apos;s last compatibility verification.
                     The upgrade is installable, but compatibility with MeedyaDL&apos;s functionality isn&apos;t
-                    guaranteed — install at your own risk, or wait for the next MeedyaDL version validate it.
+                    guaranteed — install at your own risk, or wait for the next MeedyaDL version to validate it.
                   </p>
                 )}
 


### PR DESCRIPTION
One-word typo fix in [UpdatesPage.tsx#L399](src/components/updates/UpdatesPage.tsx#L399).

**Before**:

> install at your own risk, or wait for the next MeedyaDL version validate it.

**After**:

> install at your own risk, or wait for the next MeedyaDL version *to* validate it.

Spotted during the orphan-branch audit at the end of the seven-channel ladder work — the original \`chore/claude-shared-memory\` branch had two unpushed local commits attempting earlier wording iterations on this same paragraph (\`56f4f66\`, \`0907e38\`) but they were superseded by an upstream rewrite that introduced this typo. Net effect: nobody else pushed the fix, so it sat live for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)