### PR TITLE
Five user-reported fixes: toasts, notifications, fallback, tracebacks, revival

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -1590,6 +1590,11 @@ impl DownloadQueue {
                 // any recognized pattern; they're logged for debugging but
                 // don't affect queue item state.
                 process::GamdlOutputEvent::Unknown { .. } => {}
+                // Traceback frames from upstream Python noise (#660). They
+                // do not represent a state transition — the actual exception
+                // summary line is captured separately via the Error variant
+                // (PYTHON_EXCEPTION_REGEX).
+                process::GamdlOutputEvent::TracebackFrame { .. } => {}
             }
         }
     }
@@ -7801,7 +7806,15 @@ async fn run_download_with_events(
                                 line: clean_line.clone(),
                                 timestamp: chrono::Utc::now().to_rfc3339(),
                             };
-                            let _ = app.emit("activity-log", &log_event);
+                            // Suppress Python traceback noise from the user-
+                            // facing activity-log feed when verbose is off
+                            // (#660). The disk writer below still records
+                            // the line so support requests stay debuggable.
+                            let is_traceback_noise =
+                                process::is_python_traceback_noise(&clean_line);
+                            if verbose || !is_traceback_noise {
+                                let _ = app.emit("activity-log", &log_event);
+                            }
                             // Mirror to on-disk log (#541) for post-hoc diagnosis.
                             crate::utils::activity_log::write_to_disk(&log_event);
                         }
@@ -7964,7 +7977,14 @@ async fn run_download_with_events(
                                 line: clean_line.clone(),
                                 timestamp: chrono::Utc::now().to_rfc3339(),
                             };
-                            let _ = app.emit("activity-log", &log_event);
+                            // Suppress Python traceback noise from the
+                            // user-facing activity-log feed in non-verbose
+                            // mode (#660). Disk mirror is unaffected.
+                            let is_traceback_noise =
+                                process::is_python_traceback_noise(&clean_line);
+                            if verbose || !is_traceback_noise {
+                                let _ = app.emit("activity-log", &log_event);
+                            }
                             // Mirror to on-disk log (#541).
                             crate::utils::activity_log::write_to_disk(&log_event);
                         }

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -1600,8 +1600,26 @@ impl DownloadQueue {
     }
 
     /// Marks a download as errored and sets the error message.
+    ///
+    /// Refuses to overwrite a `Cancelled` or `Complete` terminal state
+    /// (#661). The cancellation path explicitly transitions an active
+    /// item to `Cancelled` first, and a late-arriving error from a
+    /// subprocess that was being torn down must not flip that to
+    /// `Error`. Likewise, a `Complete` item should not regress to
+    /// `Error` if a tail-end async task fails after enrichment ended.
     pub fn set_error(&mut self, download_id: &str, error: &str) {
         if let Some(item) = self.items.iter_mut().find(|i| i.status.id == download_id) {
+            if matches!(
+                item.status.state,
+                DownloadState::Cancelled | DownloadState::Complete
+            ) {
+                log::debug!(
+                    "set_error skipped for {} — already in terminal state {:?}",
+                    download_id,
+                    item.status.state,
+                );
+                return;
+            }
             item.status.state = DownloadState::Error;
             item.status.error = Some(error.to_string());
         }
@@ -1650,8 +1668,27 @@ impl DownloadQueue {
     /// Marks a download as complete (#416).
     /// Clears processing label and speed/ETA to prevent stale data
     /// appearing in the UI after completion.
+    ///
+    /// Refuses to overwrite an `Error` or `Cancelled` terminal state
+    /// (#661). The completion task at the bottom of the per-item
+    /// pipeline always calls `set_complete` after the post-companion
+    /// advisory pass, even if the download itself failed minutes
+    /// earlier — without this guard, failed items would silently
+    /// "revive" to Complete in the UI, contradicting both the in-app
+    /// error toast and the prior activity-log error entry.
     pub fn set_complete(&mut self, download_id: &str) {
         if let Some(item) = self.items.iter_mut().find(|i| i.status.id == download_id) {
+            if matches!(
+                item.status.state,
+                DownloadState::Error | DownloadState::Cancelled
+            ) {
+                log::debug!(
+                    "set_complete skipped for {} — already in terminal state {:?}",
+                    download_id,
+                    item.status.state,
+                );
+                return;
+            }
             item.status.state = DownloadState::Complete;
             item.status.progress = 100.0;
             item.status.processing_label = None;
@@ -7072,11 +7109,17 @@ pub fn process_queue(
                                         timeout_mins,
                                         completion_dl_id,
                                     );
+                                    // Wording corrected for #661 — set_complete()
+                                    // does not run until *after* the post-companion
+                                    // advisory pass below, which can take many more
+                                    // minutes on large box sets. Saying "marking
+                                    // complete" here misled users into thinking the
+                                    // item was already done.
                                     emit_download_log(
                                         &completion_app,
                                         &completion_dl_id,
                                         &format!(
-                                            "⚠ Companion downloads timed out after {timeout_mins} minutes — marking complete"
+                                            "⚠ Companion downloads timed out after {timeout_mins} minutes — skipping remaining companions; final tag pass still to run"
                                         ),
                                     );
                                     handle.abort();
@@ -7102,6 +7145,17 @@ pub fn process_queue(
                                             .and_then(|i| i.status.output_path.clone())
                                     };
                                     if let Some(output_dir) = advisory_path {
+                                        // Make the long, otherwise-silent advisory
+                                        // pass visible in the activity log (#661).
+                                        // On large box sets this can run for many
+                                        // minutes; without a marker, users could
+                                        // not tell whether MeedyaDL was hung or
+                                        // working.
+                                        emit_download_log(
+                                            &completion_app,
+                                            &completion_dl_id,
+                                            "Final tag pass: applying [Explicit]/[Clean] suffixes…",
+                                        );
                                         let dir_for_advisory = {
                                             let p = std::path::Path::new(&output_dir);
                                             if p.is_dir() {
@@ -9707,6 +9761,97 @@ mod tests {
         let mut queue = DownloadQueue::new();
         // Should not panic
         queue.set_complete("nonexistent");
+    }
+
+    /// Verifies that set_complete() refuses to overwrite a terminal Error
+    /// state — the "revival" bug from #661.
+    ///
+    /// The completion task at the bottom of the per-item pipeline always
+    /// calls set_complete after the post-companion advisory pass, even if
+    /// the download itself failed minutes earlier. Without this guard,
+    /// failed items would silently appear as Complete in the UI,
+    /// contradicting the prior error toast and activity-log entry.
+    #[test]
+    fn set_complete_does_not_revive_errored_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+
+        queue.set_error(&id, "primary download failed");
+        queue.set_complete(&id); // Late completion-task pass — must be a no-op.
+
+        let statuses = queue.get_status();
+        assert_eq!(
+            statuses[0].state,
+            DownloadState::Error,
+            "set_complete must not transition Error -> Complete (#661)"
+        );
+        assert_eq!(
+            statuses[0].error.as_deref(),
+            Some("primary download failed"),
+            "the original error message must be preserved"
+        );
+    }
+
+    /// Verifies that set_complete() refuses to overwrite a Cancelled state.
+    /// Mirrors the Error guard — both are terminal and must not regress.
+    #[test]
+    fn set_complete_does_not_revive_cancelled_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+
+        queue.cancel(&id);
+        queue.set_complete(&id);
+
+        let statuses = queue.get_status();
+        assert_eq!(
+            statuses[0].state,
+            DownloadState::Cancelled,
+            "set_complete must not transition Cancelled -> Complete (#661)"
+        );
+    }
+
+    /// Verifies that set_error() refuses to overwrite a Cancelled state.
+    /// A user-initiated cancellation must not be downgraded to "Error" by a
+    /// late-arriving subprocess error during teardown.
+    #[test]
+    fn set_error_does_not_overwrite_cancelled_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+
+        queue.cancel(&id);
+        queue.set_error(&id, "stderr noise after cancellation");
+
+        let statuses = queue.get_status();
+        assert_eq!(
+            statuses[0].state,
+            DownloadState::Cancelled,
+            "set_error must not transition Cancelled -> Error (#661)"
+        );
+        // The cancellation path leaves error=None; the late set_error must
+        // not poison that field with subprocess teardown noise.
+        assert!(
+            statuses[0].error.is_none(),
+            "Cancelled items must not gain an error message after the fact"
+        );
+    }
+
+    /// Verifies that set_error() refuses to overwrite a Complete state.
+    /// A successful download must not regress to Error if some tail-end
+    /// async task fails after enrichment ended.
+    #[test]
+    fn set_error_does_not_overwrite_complete_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+
+        queue.set_complete(&id);
+        queue.set_error(&id, "late-arriving enrichment failure");
+
+        let statuses = queue.get_status();
+        assert_eq!(
+            statuses[0].state,
+            DownloadState::Complete,
+            "set_error must not transition Complete -> Error (#661)"
+        );
     }
 
     // ==========================================================

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -204,6 +204,15 @@ fn send_desktop_notification(app: &AppHandle, title: &str, body: &str) {
         return;
     }
 
+    // Respect the user's notification style preference (#658).
+    // The backend used to fire native notifications regardless of style, which
+    // contradicted the `in_app_only` choice and gave the impression that the
+    // setting did nothing. Skip the OS notification when the user picked
+    // `in_app_only` — the in-app toast path is unaffected.
+    if settings.notification_style == "in_app_only" {
+        return;
+    }
+
     // Only send notifications when the window is NOT focused.
     if let Some(window) = app.get_webview_window("main") {
         if window.is_focused().unwrap_or(false) {

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -3897,6 +3897,37 @@ async fn detect_actual_primary_codec(
 /// will be re-attempted and companions will fire on the final outcome).
 /// Spawns companion downloads and returns a JoinHandle that resolves when
 /// all companion tiers have completed. Returns None if no companions are needed.
+/// Handle returned by [`spawn_companion_downloads`].
+///
+/// Wraps the spawned task's `JoinHandle` together with an
+/// [`Arc<AtomicBool>`] cooperative-cancel flag (#663). The completion
+/// task that supervises the companion deadline must set `aborted` to
+/// `true` *before* calling `handle.abort()` so the *synchronous* parts
+/// of the companion pipeline (notably [`run_companion_lyrics_conversion`]
+/// and its multi-minute `find_dirs_with_ttml` recursion) can bail at
+/// their next loop boundary.
+///
+/// `tokio::task::JoinHandle::abort()` only takes effect at an `.await`
+/// point; it cannot preempt a sync function. Without this flag, an
+/// already-aborted companion task can keep emitting `Companion: …`
+/// activity-log events for 10+ minutes after the timeout fires —
+/// the user-visible "spring back to life" symptom.
+pub(crate) struct CompanionTaskHandle {
+    handle: tokio::task::JoinHandle<()>,
+    aborted: Arc<AtomicBool>,
+}
+
+impl CompanionTaskHandle {
+    /// Signals the companion task to stop processing at the next
+    /// cooperative checkpoint *and* aborts the async runtime task.
+    /// Both signals are required: the flag handles sync code, the
+    /// abort handles async code awaiting on subprocess I/O.
+    pub(crate) fn abort(&mut self) {
+        self.aborted.store(true, Ordering::Relaxed);
+        self.handle.abort();
+    }
+}
+
 // The argument list is long because this function is the seam between
 // the queue's per-download state (app, queue, dl_id, urls, shutdown),
 // the GAMDL invocation context (primary codec, base options,
@@ -3915,7 +3946,7 @@ fn spawn_companion_downloads(
     shutdown: &ShutdownSignal,
     force_all_suffixes: bool,
     available_audio_traits: &[String],
-) -> Option<tokio::task::JoinHandle<()>> {
+) -> Option<CompanionTaskHandle> {
     let companion_settings = load_settings_for_queue(app);
     let raw_tiers = plan_companions(
         &companion_settings.companion_mode,
@@ -3960,6 +3991,13 @@ fn spawn_companion_downloads(
         let comp_base_opts = companion_base_options.clone();
         let comp_dl_id = dl_id.to_string();
         let comp_shutdown = shutdown.clone();
+        // Per-task cooperative-cancel flag (#663). The completion task
+        // sets this to `true` before calling `handle.abort()` so the
+        // synchronous `run_companion_lyrics_conversion` and the tier
+        // loop can bail out at their next loop boundary instead of
+        // emitting activity-log events for many minutes after abort.
+        let comp_aborted = Arc::new(AtomicBool::new(false));
+        let aborted_for_task = comp_aborted.clone();
 
         emit_download_log(
             app,
@@ -3993,6 +4031,21 @@ fn spawn_companion_downloads(
                 // Check for app shutdown between tiers
                 if comp_shutdown.is_triggered() {
                     log::info!("Companion downloads stopping early (app shutting down)");
+                    return;
+                }
+                // Cooperative-cancel check (#663). If the completion
+                // task fired the deadline timeout while we were in
+                // sync code, leave before launching another GAMDL.
+                if aborted_for_task.load(Ordering::Relaxed) {
+                    log::info!(
+                        "Companion downloads aborted via cooperative flag for {comp_dl_id} — \
+                         skipping remaining tiers"
+                    );
+                    emit_download_log(
+                        &comp_app,
+                        &comp_dl_id,
+                        "Companion task aborted — skipping remaining post-processing",
+                    );
                     return;
                 }
 
@@ -4169,6 +4222,7 @@ fn spawn_companion_downloads(
                                     output_dir,
                                     artist_hint.as_deref(),
                                     album_hint.as_deref(),
+                                    &aborted_for_task,
                                 );
                             }
 
@@ -4232,7 +4286,10 @@ fn spawn_companion_downloads(
                 }
             }
         });
-        Some(handle)
+        Some(CompanionTaskHandle {
+            handle,
+            aborted: comp_aborted,
+        })
     };
 
     /// Runs lyrics format conversion on a companion download's output directory.
@@ -4253,11 +4310,18 @@ fn spawn_companion_downloads(
         output_dir: &str,
         artist_hint: Option<&str>,
         album_hint: Option<&str>,
+        aborted: &Arc<AtomicBool>,
     ) {
         let settings = load_settings_for_queue(app);
         let base = std::path::Path::new(output_dir);
 
         if !base.is_dir() {
+            return;
+        }
+        // Cooperative-cancel checkpoint #1 (#663). Bail before the
+        // potentially-multi-minute recursive directory walk if the
+        // completion task already fired the deadline.
+        if aborted.load(Ordering::Relaxed) {
             return;
         }
 
@@ -4299,6 +4363,19 @@ fn spawn_companion_downloads(
         }
 
         for album_dir in &album_dirs {
+            // Cooperative-cancel checkpoint #2 (#663). Without this,
+            // the loop would emit `Companion: converted N TTML…`
+            // entries for every album dir even after the completion
+            // task aborted us — the symptom from the captured logs.
+            if aborted.load(Ordering::Relaxed) {
+                log::info!(
+                    "Companion lyrics conversion aborted for {dl_id} — \
+                     processed {}/{} album dirs",
+                    album_dirs.iter().position(|p| p == album_dir).unwrap_or(0),
+                    album_dirs.len(),
+                );
+                return;
+            }
             let dir_str = album_dir.to_string_lossy();
 
             // Enhanced LRC: TTML → word-by-word LRC
@@ -7100,9 +7177,12 @@ pub fn process_queue(
                             }
                             // Wait for companion downloads with the same scaled timeout
                             if let Some(mut handle) = companion_handle {
-                                if tokio::time::timeout(enrichment_timeout, &mut handle)
-                                    .await
-                                    .is_err()
+                                if tokio::time::timeout(
+                                    enrichment_timeout,
+                                    &mut handle.handle,
+                                )
+                                .await
+                                .is_err()
                                 {
                                     log::warn!(
                                         "Companion downloads timed out after {} minutes for {}",
@@ -7122,8 +7202,13 @@ pub fn process_queue(
                                             "⚠ Companion downloads timed out after {timeout_mins} minutes — skipping remaining companions; final tag pass still to run"
                                         ),
                                     );
+                                    // CompanionTaskHandle::abort() sets the
+                                    // cooperative-cancel flag *and* aborts the
+                                    // async task (#663) — both are needed because
+                                    // the lyrics-conversion path is sync and
+                                    // ignores tokio's abort by itself.
                                     handle.abort();
-                                    let _ = handle.await;
+                                    let _ = handle.handle.await;
                                 }
                             }
 

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -232,6 +232,39 @@ pub fn strip_ansi_codes(input: &str) -> String {
     ANSI_ESCAPE_REGEX.replace_all(input, "").to_string()
 }
 
+/// Returns `true` when `line` is part of a Python traceback that the
+/// activity-log feed should hide in non-verbose mode (#660).
+///
+/// This is the cheap (string-ops-only) twin of the [`parse_gamdl_output`]
+/// Priority 3c branch: it lets the stdout/stderr readers gate the
+/// per-line `activity-log` Tauri event without paying the full parser
+/// cost twice. The on-disk activity-log writer still records the line
+/// regardless of verbose mode, so the forensic record stays complete.
+///
+/// Detected forms:
+///   - the bare `Traceback (most recent call last):` header,
+///   - a `File "<path>", line N, in <fn>` stack-frame line,
+///   - a caret highlight line (`^^^^^^^^^^`).
+///
+/// The actual exception summary line (`TypeError: ...`) is *not* matched
+/// here — that one is meaningful and must remain visible.
+pub fn is_python_traceback_noise(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed == "Traceback (most recent call last):" {
+        return true;
+    }
+    if trimmed.starts_with("File \"")
+        && trimmed.contains("\", line ")
+        && trimmed.contains(", in ")
+    {
+        return true;
+    }
+    trimmed.chars().all(|c| c == '^')
+}
+
 // ============================================================
 // Event types emitted to the frontend
 // ============================================================
@@ -307,6 +340,27 @@ pub enum GamdlOutputEvent {
         /// The raw output line that couldn't be categorized
         raw: String,
     },
+
+    /// A line that is part of a Python traceback emitted by GAMDL or one of
+    /// its dependencies — the `Traceback (most recent call last):` header,
+    /// a `File "..."` stack frame, or a caret highlight line (`^^^^^^^^`).
+    ///
+    /// Tracebacks originate inside upstream Python code (gamdl, httpx,
+    /// async_lru, etc.) and MeedyaDL cannot prevent them being printed.
+    /// What MeedyaDL **can** do is stop misclassifying the header as an
+    /// `Error` event (Priority 7's `traceback` keyword used to do that)
+    /// and instead route this noise to a dedicated variant that the
+    /// activity-log consumer only forwards to the user-visible feed when
+    /// `verbose_activity_log` is enabled (#660).
+    ///
+    /// The actual exception summary (e.g. `TypeError: ...`) is still
+    /// captured by [`PYTHON_EXCEPTION_REGEX`] and emitted as `Error`, so
+    /// the user always sees the meaningful one-line error even when the
+    /// surrounding frames are suppressed.
+    TracebackFrame {
+        /// The raw frame / header line as printed by Python.
+        raw: String,
+    },
 }
 
 /// Parses a single line of GAMDL output into a structured event.
@@ -318,7 +372,9 @@ pub enum GamdlOutputEvent {
 /// 1. Download progress (yt-dlp format)
 /// 2. Download completion (yt-dlp format)
 /// 3. Track information (GAMDL "Getting song/track" lines)
+/// 3c. Python traceback frames (header / `File "..."` / caret lines) — #660
 /// 4. Explicit errors (ERROR/Error prefix)
+/// 4b. Python exception summary line (`TypeError: ...`)
 /// 5. Post-processing steps (Remuxing/Tagging/Embedding)
 /// 6. File save completion (Saved to ...)
 /// 7. Common error patterns (case-insensitive "failed", "not found", etc.)
@@ -432,6 +488,24 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
         };
     }
 
+    // Priority 3c: Python traceback noise (#660).
+    // Detect three benign forms that should never be rendered as an Error:
+    //   - the `Traceback (most recent call last):` header,
+    //   - a `File "<path>", line N, in <fn>` stack-frame line,
+    //   - a caret highlight line (`^^^^^^^^^^^^`).
+    // The actual exception summary (`TypeError: ...`) is handled below by
+    // PYTHON_EXCEPTION_REGEX and still surfaces as a real Error event.
+    if trimmed == "Traceback (most recent call last):"
+        || (trimmed.starts_with("File \"")
+            && trimmed.contains("\", line ")
+            && trimmed.contains(", in "))
+        || (!trimmed.is_empty() && trimmed.chars().all(|c| c == '^'))
+    {
+        return GamdlOutputEvent::TracebackFrame {
+            raw: trimmed.to_string(),
+        };
+    }
+
     // Priority 4: Explicit error messages with ERROR/Error prefix
     if let Some(captures) = ERROR_PREFIX_REGEX.captures(trimmed) {
         let message = captures
@@ -495,26 +569,24 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
     //   - "format is not available" -- GAMDL 2.8.x: "Requested format is not available"
     //   - "skipping"         -- GAMDL: track skipped due to format/codec issues
     //   - "no entry"         -- missing archive entries or config keys
-    //   - "traceback"        -- Python stack traces from GAMDL/yt-dlp
     //   - "exception"        -- Python exception messages
+    //
+    // The `traceback` keyword used to live here too, but the bare
+    // `Traceback (most recent call last):` header is just the start of a
+    // multi-line Python trace, not an error itself — the actual exception
+    // is caught by Priority 4b (PYTHON_EXCEPTION_REGEX) and the header is
+    // now classified as `TracebackFrame` by Priority 3c (#660). Keeping
+    // `traceback` here would re-emit the header as a duplicate Error event
+    // alongside the legitimate exception line.
     let lower = trimmed.to_lowercase();
-    // Skip traceback frame lines: lines starting with `File "` are Python stack
-    // frames (e.g., `File "httpx/_transports/default.py", line 118, in map_httpcore_exceptions`).
-    // These are NOT error messages and should not be captured, even if they contain
-    // keywords like "exception" in function names (e.g., `map_httpcore_exceptions`).
-    // The actual exception line (e.g., `httpx.ConnectError: ...`) is handled by
-    // Priority 4b (PYTHON_EXCEPTION_REGEX) above.
-    let is_traceback_frame = lower.starts_with("file \"");
-    if !is_traceback_frame
-        && (lower.contains("failed")
-            || lower.contains("not found")
-            || lower.contains("permission denied")
-            || lower.contains("codec not available")
-            || lower.contains("format is not available")
-            || lower.contains("skipping")
-            || lower.contains("no entry")
-            || lower.contains("traceback")
-            || lower.contains("exception"))
+    if lower.contains("failed")
+        || lower.contains("not found")
+        || lower.contains("permission denied")
+        || lower.contains("codec not available")
+        || lower.contains("format is not available")
+        || lower.contains("skipping")
+        || lower.contains("no entry")
+        || lower.contains("exception")
     {
         return GamdlOutputEvent::Error {
             message: trimmed.to_string(),
@@ -934,14 +1006,69 @@ mod tests {
     }
 
     #[test]
-    fn parses_keyword_error_traceback() {
+    fn parses_traceback_header_as_traceback_frame() {
+        // The bare `Traceback (most recent call last):` header used to be
+        // promoted to an Error event by Priority 7's `traceback` keyword,
+        // which produced a duplicate red entry in the Activity Log next
+        // to the genuine exception line (PYTHON_EXCEPTION_REGEX). It now
+        // reaches the dedicated TracebackFrame variant so the consumer
+        // can suppress it from the user-facing feed in non-verbose mode
+        // while still mirroring the line to the on-disk log (#660).
         let line = "Traceback (most recent call last):";
         match parse_gamdl_output(line) {
-            GamdlOutputEvent::Error { message } => {
-                assert!(message.contains("Traceback"));
+            GamdlOutputEvent::TracebackFrame { raw } => {
+                assert_eq!(raw, line);
             }
-            other => panic!("Expected Error, got {:?}", other),
+            other => panic!("Expected TracebackFrame, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn parses_traceback_file_frame_as_traceback_frame() {
+        // Stack-frame lines from upstream Python (gamdl, httpx, async_lru,
+        // etc.) used to fall through to `Unknown` and were silently
+        // dropped — a quiet win — but the explicit classification makes
+        // the contract testable and documents the suppression intent.
+        let line = r#"File "/path/to/gamdl/cli/cli.py", line 272, in main"#;
+        match parse_gamdl_output(line) {
+            GamdlOutputEvent::TracebackFrame { raw } => {
+                assert_eq!(raw, line);
+            }
+            other => panic!("Expected TracebackFrame, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_traceback_caret_line_as_traceback_frame() {
+        let line = "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^";
+        match parse_gamdl_output(line) {
+            GamdlOutputEvent::TracebackFrame { raw } => {
+                assert_eq!(raw, line);
+            }
+            other => panic!("Expected TracebackFrame, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn is_python_traceback_noise_recognises_three_forms() {
+        assert!(is_python_traceback_noise("Traceback (most recent call last):"));
+        assert!(is_python_traceback_noise(
+            r#"  File "/foo/bar.py", line 10, in baz"#
+        ));
+        assert!(is_python_traceback_noise("^^^^"));
+        assert!(is_python_traceback_noise("    ^^^^^^^^^^^^^^^^"));
+    }
+
+    #[test]
+    fn is_python_traceback_noise_rejects_meaningful_lines() {
+        // These three are precisely the lines we *do* want to keep visible.
+        assert!(!is_python_traceback_noise(
+            "TypeError: 'NoneType' object has no attribute 'foo'"
+        ));
+        assert!(!is_python_traceback_noise("Downloading album..."));
+        assert!(!is_python_traceback_noise(
+            "[INFO     12:34:56] [Track 1/12] Downloading \"Hello\""
+        ));
     }
 
     #[test]

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -372,9 +372,9 @@ pub enum GamdlOutputEvent {
 /// 1. Download progress (yt-dlp format)
 /// 2. Download completion (yt-dlp format)
 /// 3. Track information (GAMDL "Getting song/track" lines)
-/// 3c. Python traceback frames (header / `File "..."` / caret lines) — #660
+///    - 3c. Python traceback frames (header / `File "..."` / caret lines) — #660
 /// 4. Explicit errors (ERROR/Error prefix)
-/// 4b. Python exception summary line (`TypeError: ...`)
+///    - 4b. Python exception summary line (`TypeError: ...`)
 /// 5. Post-processing steps (Remuxing/Tagging/Embedding)
 /// 6. File save completion (Saved to ...)
 /// 7. Common error patterns (case-insensitive "failed", "not found", etc.)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -524,6 +524,36 @@ function App() {
       } catch {
         /* Non-fatal: version check failure shouldn't block app startup */
       }
+
+      /*
+       * Notification permission preflight (#658).
+       *
+       * On macOS, `requestPermission()` only triggers the system prompt the
+       * first time it is called for a bundle ID. If the user dismissed (not
+       * granted, not denied) the prompt during a prior session, every later
+       * call resolves silently with `'default'` and `sendNotification()` is
+       * a no-op — which is why users on Native + In-app saw no notifications.
+       *
+       * Requesting permission once at startup forces a predictable, visible
+       * prompt and also lets us log the resolved status to the WebView
+       * console for debugging. Skipped when the user picked `in_app_only`.
+       */
+      const notifStyle =
+        useSettingsStore.getState().settings.notification_style ?? 'native_and_in_app';
+      if (notifStyle !== 'in_app_only') {
+        try {
+          const { isPermissionGranted, requestPermission } = await import(
+            '@tauri-apps/plugin-notification'
+          );
+          const granted = await isPermissionGranted();
+          if (!granted) {
+            const result = await requestPermission();
+            console.info(`[notification] startup permission request resolved: ${result}`);
+          }
+        } catch (err) {
+          console.warn('[notification] startup permission preflight failed:', err);
+        }
+      }
     };
 
     initialize().catch((err) => {

--- a/src/components/common/FallbackChainList.tsx
+++ b/src/components/common/FallbackChainList.tsx
@@ -11,12 +11,17 @@
  * The component is generic over `T extends string`, allowing it to work with
  * any string-literal union type (SongCodec, VideoResolution, VideoCodec, etc.).
  *
+ * When the optional `allItems` prop is supplied, the component additionally
+ * renders an "Available" panel listing items not currently in the chain so
+ * the user can remove and re-add codecs/resolutions on demand (#659).
+ *
  * @see {@link ../settings/tabs/FallbackTab.tsx} -- Audio/video fallback chains
  * @see {@link ../settings/tabs/QualityTab.tsx}  -- Video codec priority
  */
 
-// Lucide icons: GripVertical for the drag handle, ArrowUp/ArrowDown for reorder buttons.
-import { GripVertical, ArrowUp, ArrowDown } from 'lucide-react';
+// Lucide icons: GripVertical for the drag handle, ArrowUp/ArrowDown for reorder
+// buttons, X for remove, Plus for re-add.
+import { GripVertical, ArrowUp, ArrowDown, X, Plus } from 'lucide-react';
 
 /**
  * FallbackChainList -- Generic reorderable list for a priority/fallback chain.
@@ -28,20 +33,26 @@ import { GripVertical, ArrowUp, ArrowDown } from 'lucide-react';
  *
  * @typeParam T - The union type of the chain items (e.g., SongCodec).
  *
- * @param items    - The ordered array of chain items (highest priority first).
- * @param labels   - A Record mapping each item value to its display name.
- * @param onChange - Callback invoked with the new array whenever an item
- *                   is moved. The parent is responsible for persisting the
- *                   updated order to the settings store.
+ * @param items     - The ordered array of chain items (highest priority first).
+ * @param labels    - A Record mapping each item value to its display name.
+ * @param onChange  - Callback invoked with the new array whenever an item
+ *                    is moved, removed, or re-added. The parent persists the
+ *                    updated order to the settings store.
+ * @param allItems  - Optional full universe of available items. When supplied,
+ *                    the component renders remove buttons on each row and an
+ *                    "Available" panel listing items not currently in `items`.
+ *                    Omit to render a pure-reorder list (legacy callers).
  */
 export function FallbackChainList<T extends string>({
   items,
   labels,
   onChange,
+  allItems,
 }: {
   items: T[];
   labels: Record<T, string>;
   onChange: (items: T[]) => void;
+  allItems?: readonly T[];
 }) {
   /**
    * Moves the item at `index` one position up (towards higher priority).
@@ -66,45 +77,112 @@ export function FallbackChainList<T extends string>({
     onChange(newItems);
   };
 
+  // Refuse the last removal — an empty chain is meaningless and would block
+  // every download. The remove button on the only row stays disabled.
+  const removeAt = (index: number) => {
+    if (items.length <= 1) return;
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  // Append a previously-removed item to the bottom of the chain.
+  const addItem = (item: T) => {
+    if (items.includes(item)) return; // Defensive — should never trigger from the UI
+    onChange([...items, item]);
+  };
+
+  // Compute the disabled set only when `allItems` is supplied. Preserves the
+  // declared order from `allItems` so the "Available" list reads naturally.
+  const disabled: T[] = allItems
+    ? allItems.filter((entry) => !items.includes(entry))
+    : [];
+
   return (
-    <div className="space-y-1">
-      {items.map((item, index) => (
-        <div
-          key={item}
-          className="flex items-center gap-2 px-3 py-2 rounded-platform border border-border-light bg-surface-secondary"
-        >
-          {/* Drag handle indicator */}
-          <GripVertical size={14} className="text-content-tertiary flex-shrink-0" />
+    <div className="space-y-3">
+      <div className="space-y-1">
+        {items.map((item, index) => (
+          <div
+            key={item}
+            className="flex items-center gap-2 px-3 py-2 rounded-platform border border-border-light bg-surface-secondary"
+          >
+            {/* Drag handle indicator */}
+            <GripVertical size={14} className="text-content-tertiary flex-shrink-0" />
 
-          {/* Priority number */}
-          <span className="w-6 text-center text-xs font-mono text-content-tertiary">
-            {index + 1}
-          </span>
+            {/* Priority number */}
+            <span className="w-6 text-center text-xs font-mono text-content-tertiary">
+              {index + 1}
+            </span>
 
-          {/* Item label */}
-          <span className="flex-1 text-sm text-content-primary">{labels[item]}</span>
+            {/* Item label */}
+            <span className="flex-1 text-sm text-content-primary">{labels[item]}</span>
 
-          {/* Reorder buttons */}
-          <div className="flex gap-0.5">
-            <button
-              onClick={() => moveUp(index)}
-              disabled={index === 0}
-              className="p-1 rounded text-content-tertiary hover:text-content-primary disabled:opacity-30 transition-colors"
-              aria-label="Move up"
-            >
-              <ArrowUp size={14} />
-            </button>
-            <button
-              onClick={() => moveDown(index)}
-              disabled={index === items.length - 1}
-              className="p-1 rounded text-content-tertiary hover:text-content-primary disabled:opacity-30 transition-colors"
-              aria-label="Move down"
-            >
-              <ArrowDown size={14} />
-            </button>
+            {/* Reorder + remove buttons */}
+            <div className="flex gap-0.5">
+              <button
+                onClick={() => moveUp(index)}
+                disabled={index === 0}
+                className="p-1 rounded text-content-tertiary hover:text-content-primary disabled:opacity-30 transition-colors"
+                aria-label="Move up"
+              >
+                <ArrowUp size={14} />
+              </button>
+              <button
+                onClick={() => moveDown(index)}
+                disabled={index === items.length - 1}
+                className="p-1 rounded text-content-tertiary hover:text-content-primary disabled:opacity-30 transition-colors"
+                aria-label="Move down"
+              >
+                <ArrowDown size={14} />
+              </button>
+              {allItems && (
+                <button
+                  onClick={() => removeAt(index)}
+                  disabled={items.length <= 1}
+                  className="p-1 rounded text-content-tertiary hover:text-status-error disabled:opacity-30 transition-colors"
+                  aria-label={`Remove ${labels[item]} from fallback chain`}
+                  title={
+                    items.length <= 1
+                      ? 'At least one item must remain in the chain'
+                      : `Remove ${labels[item]} from chain`
+                  }
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Available items pool — only rendered when allItems is supplied
+          AND there are items currently outside the chain (#659). */}
+      {allItems && disabled.length > 0 && (
+        <div>
+          <h5 className="text-xs uppercase tracking-wide text-content-tertiary mb-1">
+            Available (not in chain)
+          </h5>
+          <div className="space-y-1">
+            {disabled.map((item) => (
+              <div
+                key={item}
+                className="flex items-center gap-2 px-3 py-2 rounded-platform border border-dashed border-border-light bg-surface-primary opacity-70"
+              >
+                <span className="w-6 text-center text-xs font-mono text-content-tertiary">
+                  &mdash;
+                </span>
+                <span className="flex-1 text-sm text-content-secondary">{labels[item]}</span>
+                <button
+                  onClick={() => addItem(item)}
+                  className="p-1 rounded text-content-tertiary hover:text-content-primary transition-colors"
+                  aria-label={`Add ${labels[item]} back to fallback chain`}
+                  title={`Add ${labels[item]} to the bottom of the chain`}
+                >
+                  <Plus size={14} />
+                </button>
+              </div>
+            ))}
           </div>
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/src/components/download/DownloadForm.tsx
+++ b/src/components/download/DownloadForm.tsx
@@ -448,13 +448,15 @@ export function DownloadForm() {
       try {
         const result = await submitBatchDownload(multiUrlInfo.validUrls, isOffline);
 
-        // Show duplicate warnings (batched into a single toast if multiple)
+        // Show duplicate warnings (batched into a single toast if multiple).
+        // Uses `'info'` (auto-dismisses) rather than `'warning'` (persistent) — the
+        // download is still queued and no user action is required (#657).
         if (result.duplicateWarnings.length > 0) {
           addToast(
             result.duplicateWarnings.length === 1
               ? result.duplicateWarnings[0]
               : `${result.duplicateWarnings.length} duplicate URLs detected in queue`,
-            'warning'
+            'info'
           );
         }
 
@@ -493,9 +495,10 @@ export function DownloadForm() {
         const result = await submitDownload(isOffline);
 
         // Show duplicate URL warning if the backend detected a match.
-        // This is non-blocking — the download is still queued.
+        // This is non-blocking — the download is still queued, so the toast
+        // uses `'info'` (auto-dismisses) rather than `'warning'` (persistent) (#657).
         if (result.duplicate_warning) {
-          addToast(result.duplicate_warning, 'warning');
+          addToast(result.duplicate_warning, 'info');
         }
 
         if (isOffline) {

--- a/src/components/settings/tabs/FallbackTab.tsx
+++ b/src/components/settings/tabs/FallbackTab.tsx
@@ -59,6 +59,18 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { SONG_CODEC_LABELS, VIDEO_RESOLUTION_LABELS } from '@/types';
 import type { SongCodec, VideoResolution } from '@/types';
 
+/**
+ * Full universe of audio codecs that may appear in the fallback chain (#659).
+ * Used to populate the "Available" panel below the active chain so users can
+ * remove and re-add codecs on demand. Order here is the order shown in the
+ * "Available" pool — it does NOT influence chain priority, which is driven
+ * by the user-managed `music_fallback_chain` array.
+ */
+const ALL_SONG_CODECS = Object.keys(SONG_CODEC_LABELS) as SongCodec[];
+
+/** Full universe of video resolutions for the fallback "Available" panel (#659). */
+const ALL_VIDEO_RESOLUTIONS = Object.keys(VIDEO_RESOLUTION_LABELS) as VideoResolution[];
+
 // Shared components: Button for toggle tabs, FallbackChainList for reorderable lists.
 import { Button, FallbackChainList, SettingsSection } from '@/components/common';
 
@@ -94,7 +106,7 @@ export function FallbackTab() {
     <div className="space-y-3">
       <SettingsSection
         title="Fallback Chain"
-        description="When the preferred codec or resolution is unavailable, GAMDL will automatically try the next option in the chain. Drag items to reorder priority (top = highest priority). Note: codecs marked (Experimental) may fail intermittently without the Wrapper service — only AAC Legacy and AAC-HE Legacy are reliably downloadable with cookies alone."
+        description="When the preferred codec or resolution is unavailable, GAMDL will automatically try the next option in the chain. Use the up/down arrows to reorder priority (top = highest), the × button to remove a codec from the chain, and the + button under Available to put a removed codec back. Note: codecs marked (Experimental) may fail intermittently without the Wrapper service — only AAC Legacy and AAC-HE Legacy are reliably downloadable with cookies alone."
       >
         {/* Chain selector tabs */}
         <div className="flex gap-2 border-b border-border-light pb-2">
@@ -130,6 +142,7 @@ export function FallbackTab() {
             <FallbackChainList<SongCodec>
               items={settings.music_fallback_chain}
               labels={SONG_CODEC_LABELS}
+              allItems={ALL_SONG_CODECS}
               onChange={(chain) => updateSettings({ music_fallback_chain: chain })}
             />
           </div>
@@ -144,6 +157,7 @@ export function FallbackTab() {
             <FallbackChainList<VideoResolution>
               items={settings.video_fallback_chain}
               labels={VIDEO_RESOLUTION_LABELS}
+              allItems={ALL_VIDEO_RESOLUTIONS}
               onChange={(chain) => updateSettings({ video_fallback_chain: chain })}
             />
           </div>

--- a/src/components/settings/tabs/GeneralTab.tsx
+++ b/src/components/settings/tabs/GeneralTab.tsx
@@ -69,7 +69,7 @@ import ChannelSwitchWarning from '@/components/settings/ChannelSwitchWarning';
 import { PRE_RELEASE_CHANNELS, type UpdateChannel } from '@/types';
 
 // Lucide icons for the refresh/check action button and export/import buttons.
-import { Download, RefreshCw, Upload } from 'lucide-react';
+import { Bell, Download, RefreshCw, Upload } from 'lucide-react';
 import type { AfterQueueAction } from '@/types';
 
 /**
@@ -560,6 +560,54 @@ export function GeneralTab() {
             }
           />
         )}
+
+        {/* Test Notification button (#658).
+            Fires a real native notification so the user can verify that the
+            OS-level permission has been granted and the plugin pipeline works.
+            On macOS this also forces the system permission prompt the first
+            time it is invoked if the user dismissed the startup prompt. */}
+        {settings.desktop_notifications &&
+          (settings.notification_style ?? 'native_and_in_app') !== 'in_app_only' && (
+            <div className="flex flex-col gap-1">
+              <Button
+                variant="secondary"
+                icon={<Bell size={14} />}
+                onClick={async () => {
+                  try {
+                    const { isPermissionGranted, requestPermission, sendNotification } =
+                      await import('@tauri-apps/plugin-notification');
+                    let granted = await isPermissionGranted();
+                    if (!granted) {
+                      const result = await requestPermission();
+                      granted = result === 'granted';
+                    }
+                    if (!granted) {
+                      addToast(
+                        'Notification permission was not granted. Open System Settings > Notifications > MeedyaDL to enable.',
+                        'warning',
+                      );
+                      return;
+                    }
+                    sendNotification({
+                      title: 'MeedyaDL — Test',
+                      body: 'If you can read this, native notifications are working.',
+                    });
+                    addToast('Test notification sent. If you do not see it, check OS notification settings.', 'info');
+                  } catch (err) {
+                    addToast(
+                      `Test notification failed: ${err instanceof Error ? err.message : String(err)}`,
+                      'error',
+                    );
+                  }
+                }}
+              >
+                Send Test Notification
+              </Button>
+              <p className="text-xs text-content-tertiary">
+                Sends a one-off native notification so you can verify the OS pipeline.
+              </p>
+            </div>
+          )}
 
         {/* Notification auto-dismiss duration — only visible when notifications are enabled */}
         {settings.desktop_notifications && (

--- a/src/components/settings/tabs/SettingsTabs.test.tsx
+++ b/src/components/settings/tabs/SettingsTabs.test.tsx
@@ -65,6 +65,10 @@ vi.mock('lucide-react', () => {
     ArrowDown: stub('ArrowDown'),
     /* Settings tabs */
     Trash2: stub('Trash2'),
+    /* GeneralTab: Send Test Notification button (#658) */
+    Bell: stub('Bell'),
+    /* FallbackChainList: remove / re-add buttons (#659) */
+    Plus: stub('Plus'),
     /* Download components (pulled via barrel transitive) */
     Pause: stub('Pause'),
     Play: stub('Play'),

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -280,6 +280,8 @@ export const useUiStore = create<UiState>((set) => ({
     }
 
     // Send native OS notification when notification_style includes native.
+    // Errors are surfaced to the WebView console so future regressions can
+    // be diagnosed instead of failing silently (#658).
     if (style === 'native_and_in_app' || style === 'native_only') {
       const typeLabel = type === 'error' ? 'Error' : type === 'warning' ? 'Warning' : type === 'success' ? 'Success' : 'Info';
       import('@tauri-apps/plugin-notification').then(({ isPermissionGranted, requestPermission, sendNotification }) => {
@@ -291,10 +293,19 @@ export const useUiStore = create<UiState>((set) => ({
           .then((result) => {
             if (result === 'granted') {
               sendNotification({ title: `MeedyaDL — ${typeLabel}`, body: message });
+            } else {
+              console.warn(
+                `[notification] permission not granted (status: ${result}). ` +
+                'Open System Settings > Notifications > MeedyaDL to enable.',
+              );
             }
           })
-          .catch(() => { /* Notification permission denied or unavailable */ });
-      }).catch(() => { /* Plugin not available (e.g., dev mode without Tauri) */ });
+          .catch((err: unknown) => {
+            console.warn('[notification] sendNotification failed:', err);
+          });
+      }).catch((err: unknown) => {
+        console.warn('[notification] plugin module failed to load:', err);
+      });
     }
 
     // Skip in-app toast when user prefers native-only notifications.


### PR DESCRIPTION
## Summary

Bundles six independently-committed fixes for issues reported in the same session, each scoped to its own GitHub issue and verified by tests. All trace back to behaviour the user observed on a v0.50.1 build.

| Issue | Type | Fix |
| --- | --- | --- |
| #657 | bug | Duplicate-URL toast switched from `'warning'` (persistent) to `'info'` (auto-dismiss). |
| #658 | bug | Native macOS notifications now actually fire: startup permission preflight, surfaced errors, backend respects `notification_style`, plus a "Send Test Notification" button in Settings. |
| #659 | feature | Audio + Video fallback chains now support remove (×) and re-add (+); `FallbackChainList` extended with optional `allItems`. No settings schema migration needed. |
| #660 | bug | Python tracebacks (header / `File "..."` frames / caret lines) classified into a new `TracebackFrame` variant and suppressed from the user-facing activity-log feed in non-verbose mode. Disk mirror still records everything. |
| #661 | bug | `set_complete()` and `set_error()` refuse to overwrite terminal states (`Error → Complete` revival blocked). Misleading "marking complete" timeout text replaced; new "Final tag pass…" log entry makes the long advisory pass visible. |
| #663 | bug | Companion task no longer keeps emitting `Companion: converted N TTML…` events for 5–15 minutes after `handle.abort()` — added an `Arc<AtomicBool>` cooperative-cancel flag checked at every loop boundary inside the *synchronous* lyrics-conversion function. |

## Why six fixes in one PR

The user reported five issues in one session, then provided fresh evidence for a sixth (the post-timeout activity-log spring-back-to-life, captured at 22:08 / 22:19) while this PR was already open. Adding it here keeps the user's "marking complete" complaint and its real underlying cause in the same merge.

## Testing

- `cargo test --lib` (Rust): **902 passed, 0 failed, 1 ignored**
- `npm run test` (frontend): **303 passed, 0 failed**
- `npm run type-check`: clean
- `cargo clippy -- -D warnings`: clean

## Test plan

- [ ] Toast: paste a duplicate URL; verify the "already in queue" toast disappears after 5s.
- [ ] Notifications: launch app, accept the macOS permission prompt that fires on startup; click Settings > General > Send Test Notification.
- [ ] Fallback: open Settings > Fallback, remove AAC Binaural, reload — confirm it stays out. Click + to re-add.
- [ ] Tracebacks: trigger a music-video download that hits the upstream cover-art bug; activity log should show one error line per failure (the exception summary), no traceback header / `File "..."` frames in non-verbose mode. Toggle verbose — frames reappear.
- [ ] Revival: trigger an item that fails; verify the row stays Error after the completion-task fires later.
- [ ] Cooperative cancel: queue an item with the companion mode set so a tier finishes quickly but enrichment runs long; force the 10-min timeout (e.g. by pointing output at a slow disk); confirm the activity log produces one short "Companion task aborted" line and goes quiet within seconds, not minutes.

## Closes

- Closes #657
- Closes #658
- Closes #659
- Closes #660
- Closes #661
- Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)