### PR TITLE
fix: unblock #666 storefront fallback on GAMDL v3.4+ + detect MV cover bug

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -8080,12 +8080,20 @@ async fn run_download_with_events(
     // which is more informative than just the exit code.
     let collected_errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
-    // Collect ALL stderr lines (raw) for Python traceback extraction.
-    // When GAMDL crashes with a Python traceback, the parsed error list may
-    // only contain "Traceback (most recent call last):" because intermediate
-    // lines and the final exception line may not match any error keyword.
-    // The raw stderr buffer lets us extract the actual exception post-mortem.
-    let raw_stderr_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    // Collect ALL output lines (raw) from BOTH stdout and stderr for
+    // post-mortem analysis: Python traceback extraction, soft-error
+    // friendly-message generation, and storefront-mismatch detection
+    // for the #666 fallback path.
+    //
+    // Originally stderr-only; expanded to cover stdout in a fix to the
+    // #666 blind spot exposed by GAMDL v3.4 (2026-04-27), which moved
+    // its logging output stream from stderr → stdout via
+    // `structlog.PrintLoggerFactory(file=CustomOutputWriter([sys.stdout]))`.
+    // Tracebacks and the AMP `Resource Not Found` shape that
+    // `is_storefront_mismatch_error` keys on now arrive on stdout, so a
+    // stderr-only buffer leaves the detector seeing empty input and the
+    // storefront fallback never fires.
+    let raw_output_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
     // Deduplication set for Activity Log emissions.
     // GAMDL and its Python dependencies (yt-dlp, tqdm) may write the same
@@ -8106,6 +8114,10 @@ async fn run_download_with_events(
         let last_activity = last_activity_ms.clone();
         let post_proc = post_processing_flag.clone();
         let soft_errors = soft_error_count.clone();
+        // GAMDL v3.4+ logs to stdout, so stdout must also feed the
+        // raw output buffer used by the soft-error friendly-message
+        // generator and the storefront-mismatch detector (#666).
+        let raw_output = raw_output_lines.clone();
         tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
             let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
@@ -8185,6 +8197,15 @@ async fn run_download_with_events(
                             // Mirror to on-disk log (#541) for post-hoc diagnosis.
                             crate::utils::activity_log::write_to_disk(&log_event);
                         }
+                    }
+
+                    // Mirror clean_line into the shared raw-output buffer so
+                    // GAMDL v3.4+'s stdout-emitted tracebacks and AMP 404s
+                    // are visible to `is_storefront_mismatch_error` (#666)
+                    // and `classify_gamdl_traceback` (#660 friendly path).
+                    {
+                        let mut raw = raw_output.lock().await;
+                        raw.push(clean_line.clone());
                     }
 
                     let event = process::parse_gamdl_output(&clean_line);
@@ -8299,7 +8320,7 @@ async fn run_download_with_events(
         let app = app.clone();
         let queue = queue.clone();
         let errors = collected_errors.clone();
-        let raw_stderr = raw_stderr_lines.clone();
+        let raw_output = raw_output_lines.clone();
         let seen = seen_lines.clone();
         let last_activity = last_activity_ms.clone();
         tokio::spawn(async move {
@@ -8359,10 +8380,13 @@ async fn run_download_with_events(
 
                     let event = process::parse_gamdl_output(&clean_line);
 
-                    // Collect raw stderr lines for Python traceback extraction
-                    // (always, regardless of dedup — needed for exception analysis)
+                    // Mirror to the shared raw output buffer (#666 detector
+                    // and #660 friendly-traceback path read this on the
+                    // soft-error gate). The stdout reader writes to the
+                    // same Arc<Mutex>, so the buffer ends up containing
+                    // both streams, which is what the consumers need.
                     {
-                        let mut raw = raw_stderr.lock().await;
+                        let mut raw = raw_output.lock().await;
                         raw.push(clean_line.clone());
                     }
 
@@ -8477,13 +8501,34 @@ async fn run_download_with_events(
     // an error instead of swallowing them.
     let soft_errors = soft_error_count.load(std::sync::atomic::Ordering::Relaxed);
     if status.success() && soft_errors > 0 {
-        let raw_lines = raw_stderr_lines.lock().await;
+        let raw_lines = raw_output_lines.lock().await;
         let combined = raw_lines.join("\n");
+
+        // GAMDL music-video cover-template bug detection. Checked
+        // BEFORE the storefront detector because the bug's symptom
+        // (400 Bad Request on a literal `{w}x{h}` URL) is highly
+        // specific and gives the user a clear, actionable message
+        // instead of the generic per-track-error count. Storefront
+        // fallback wouldn't help here — the URL works fine, GAMDL's
+        // template engine is at fault.
+        if process::is_gamdl_mv_cover_template_bug(&combined) {
+            return Err(format!(
+                "GAMDL bug — music-video cover URL not templated. \
+                 Apple returned 400 Bad Request for {soft_errors} track(s) \
+                 because GAMDL sent the literal `{{w}}x{{h}}` placeholders \
+                 instead of real dimensions. This is upstream — please \
+                 report at https://github.com/glomatico/gamdl/issues. \
+                 Audio for affected tracks did not download."
+            ));
+        }
+
         // Storefront-mismatch detection (#666). The friendly soft-error
         // message would otherwise hide the AMP "Resource Not Found" signal
         // that the storefront-fallback retry path keys on. When the raw
-        // stderr looks like a wrong-storefront failure, prepend the
+        // output looks like a wrong-storefront failure, prepend the
         // marker so `is_storefront_mismatch_error` matches downstream.
+        // Reads from `raw_output_lines` (both stdout and stderr) since
+        // GAMDL v3.4+ emits its log lines to stdout, not stderr.
         let storefront_signal = if process::is_storefront_mismatch_error(&combined) {
             " — AMP API returned 404 Resource Not Found (likely wrong storefront)"
         } else {
@@ -8511,7 +8556,7 @@ async fn run_download_with_events(
         // The error message is also used by classify_error() to determine the
         // retry/fallback strategy (codec error vs network error vs unknown).
         let errors = collected_errors.lock().await;
-        let raw_lines = raw_stderr_lines.lock().await;
+        let raw_lines = raw_output_lines.lock().await;
 
         errors.last().map_or_else(
             || {

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -832,6 +832,43 @@ pub fn is_playlist_title_keyerror(error_message: &str) -> bool {
             || lower.contains("playlist_file_path"))
 }
 
+/// Detect GAMDL's music-video cover-art URL templating bug.
+///
+/// GAMDL fetches per-track cover art for music videos from
+/// `https://a1.mzstatic.com/Video.../<id>.jpg/{w}x{h}mv.jpg`, where
+/// `{w}` and `{h}` are placeholder tokens GAMDL is supposed to
+/// substitute with concrete pixel dimensions before issuing the HTTP
+/// request. On music-video albums (or any album whose tracks include
+/// a (Visualizer) entry) GAMDL skips that substitution and sends the
+/// literal `{w}x{h}` to Apple's CDN, which responds with
+/// `400 Bad Request`. Every track that hits this code path fails
+/// without ever attempting the audio download, so the user's run
+/// produces 0 output files and a `GAMDL reported N per-track error(s)`
+/// soft-error count where N == the music-video track count.
+///
+/// Captured shape (from a real user run, 2026-05-02):
+/// ```text
+/// httpx.HTTPStatusError: Client error '400 Bad Request' for url
+/// 'https://a1.mzstatic.com/Video221/v4/.../1968719474350101.jpg/%7Bw%7Dx%7Bh%7Dmv.jpg'
+/// ```
+/// Note `%7B` / `%7D` are the URL-encoded `{` / `}`. We match BOTH
+/// the encoded and the raw forms since either could appear depending
+/// on whether httpx percent-encoded before raising.
+///
+/// Returns `true` when the buffer contains the bug's signature so the
+/// caller can surface a focused message ("known GAMDL bug — music-
+/// video cover URL not templated; report to glomatico/gamdl") instead
+/// of the generic per-track-error count.
+#[must_use]
+pub fn is_gamdl_mv_cover_template_bug(error_message: &str) -> bool {
+    let lower = error_message.to_lowercase();
+    let has_400 = lower.contains("400 bad request") || lower.contains("status code: 400");
+    let has_mv_url = lower.contains("mzstatic.com/video");
+    let has_unsubstituted_template = lower.contains("%7bw%7dx%7bh%7d")
+        || lower.contains("{w}x{h}");
+    has_400 && has_mv_url && has_unsubstituted_template
+}
+
 // ============================================================
 // GAMDL output classification helpers (companion download safety)
 // ============================================================
@@ -1135,6 +1172,46 @@ mod tests {
         assert!(!is_storefront_mismatch_error(
             "GAMDL reported 1 per-track error(s) even though the process exited 0"
         ));
+    }
+
+    // ----------------------------------------------------------
+    // GAMDL music-video cover-template bug detector tests
+    // ----------------------------------------------------------
+
+    #[test]
+    fn is_gamdl_mv_cover_template_bug_recognises_url_encoded_placeholders() {
+        // Captured user evidence (2026-05-02) — httpx percent-encoded the URL:
+        let msg = "httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://a1.mzstatic.com/Video221/v4/78/43/07/78430707-4e2a-0d51-0fb0-c49607dfe652/1968719474350101.jpg/%7Bw%7Dx%7Bh%7Dmv.jpg'";
+        assert!(is_gamdl_mv_cover_template_bug(msg));
+    }
+
+    #[test]
+    fn is_gamdl_mv_cover_template_bug_recognises_raw_placeholders() {
+        // Defensive: same shape with raw `{w}x{h}` (e.g. if a future
+        // GAMDL version skips the percent-encoding pass).
+        let msg = "Client error '400 Bad Request' for url 'https://a1.mzstatic.com/Video112/v4/abc/{w}x{h}mv.jpg'";
+        assert!(is_gamdl_mv_cover_template_bug(msg));
+    }
+
+    #[test]
+    fn is_gamdl_mv_cover_template_bug_requires_all_three_signals() {
+        // 400 alone is not enough — many things can 400.
+        assert!(!is_gamdl_mv_cover_template_bug("400 Bad Request"));
+        // Video URL alone with no 400 isn't the bug shape.
+        assert!(!is_gamdl_mv_cover_template_bug(
+            "200 OK from mzstatic.com/Video221"
+        ));
+        // 400 + Video URL but with substituted dimensions = a different bug.
+        assert!(!is_gamdl_mv_cover_template_bug(
+            "400 Bad Request for url https://a1.mzstatic.com/Video221/v4/abc/1920x1080mv.jpg"
+        ));
+    }
+
+    #[test]
+    fn is_gamdl_mv_cover_template_bug_rejects_storefront_404_shape() {
+        // Storefront mismatch is a different bug — must not double-classify.
+        let msg = r#"gamdl.api.exceptions.GamdlApiResponseError: Error fetching from AMP API (Status code: 404): {"errors":[{"id":"X","title":"Resource Not Found"}]}"#;
+        assert!(!is_gamdl_mv_cover_template_bug(msg));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two fixes that came out of investigating today's user-reported failures (queue with 8 failed items, all `GAMDL reported N per-track error(s) even though the process exited 0`).

| Issue | What | One-line fix |
| --- | --- | --- |
| **#672** | #666 storefront fallback was a no-op on GAMDL v3.4+ | The detector buffer (`raw_stderr_lines`) was only fed by stderr. GAMDL v3.4 moved logging to stdout, so the buffer stayed empty. Renamed to `raw_output_lines` and have both readers append to it. |
| **#673** | Music-video albums fail every track with a confusing generic error | Added `is_gamdl_mv_cover_template_bug` detector and a focused user-facing message replacing the generic per-track-error count. |

## Captured user evidence

Today's session log (1-day window) shows:
- **77 distinct AMP "Resource Not Found" 404s** — these should have triggered the auto-retry-with-account-region path from #666 but didn't.
- **78 `httpx.HTTPStatusError: 400 Bad Request`** for `mzstatic.com/Video.../{w}x{h}mv.jpg` URLs — every track of a 78-track music-video album failed because GAMDL didn't substitute the cover-URL placeholders.
- **Zero** activity-log lines mentioning `Storefront fallback` or `account region` for the same window.

Both root causes confirmed at the source:
- #672: `raw_stderr_lines` declared at `download_queue.rs:8088` was only written from the stderr task. GAMDL v3.4+'s `structlog` migration to stdout (documented in `CLAUDE.md` and `.github/audits/gamdl-v3.4-v3.5-audit.md`) means the buffer is empty when `is_storefront_mismatch_error` runs at line 8508.
- #673: Real captured error: ``httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://a1.mzstatic.com/Video221/v4/.../%7Bw%7Dx%7Bh%7Dmv.jpg'`` — `%7Bw%7Dx%7Bh%7D` is URL-encoded `{w}x{h}`, the literal placeholder GAMDL was supposed to substitute.

## What changed

- `src-tauri/src/services/download_queue.rs`
  - Renamed `raw_stderr_lines` → `raw_output_lines` and added a clone + push from the stdout reader so both streams feed the consumer buffer.
  - Soft-error path now checks `is_gamdl_mv_cover_template_bug` BEFORE the storefront detector, returning a focused upstream-bug message that names the cause + links to the GAMDL issue tracker + warns that no audio downloaded.
- `src-tauri/src/utils/process.rs`
  - New `is_gamdl_mv_cover_template_bug(error_message)` requiring all three signals (`400 Bad Request` + `mzstatic.com/Video` + raw or URL-encoded `{w}x{h}` template). Won't match generic 400s, won't match the storefront 404 shape.
- 4 new unit tests for the cover-template detector.

## Tests

- 8 targeted tests pass (4 storefront-mismatch, 4 cover-template).
- `cargo clippy -- -D warnings` clean.
- Frontend: 303 tests pass, type-check clean.

**Note on the parallel-test flake.** Adding any new tests to the suite reshuffles the scheduler and exposes a pre-existing race against `gamdl_capabilities`'s global version cache (`ini_includes_wrapper_m3u8_ip_on_v31` flakes when run in parallel with sibling `ini_omits_wrapper_m3u8_ip_on_v30`). Both pass in isolation; tracked separately for a `serial_test`-style fix.

## Test plan

- [ ] **#672 verify:** Queue a `/us/album/X` URL that you know is region-locked away from the US, on a `gb` account. Activity log should now show `Storefront 'us' returned no catalog entry — retrying with your account region 'gb'…` and the retry should land.
- [ ] **#673 verify:** Queue a music-video-heavy album (e.g. an Anniversary Edition with visualizers). When it fails, the queue item's error text should now read the focused `GAMDL bug — music-video cover URL not templated…` message instead of `GAMDL reported N per-track error(s) even though the process exited 0`.

## Closes

- Closes #672
- Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)