### PR TITLE
Fix retry dedupe and unavailable format log context

### DIFF
--- a/src-tauri/src/commands/gamdl.rs
+++ b/src-tauri/src/commands/gamdl.rs
@@ -506,7 +506,24 @@ pub async fn start_download(
                     }
                 }
 
+                if q.has_duplicate_urls(&split_request.urls) {
+                    crate::services::history_service::remove_entries_for_urls(
+                        &app,
+                        &split_request.urls,
+                    );
+                    emit_app_log(
+                        &app,
+                        &format!(
+                            "Skipped duplicate queued URL(s): {}",
+                            split_request.urls.join(", ")
+                        ),
+                    );
+                    continue;
+                }
+
+                let queued_urls = split_request.urls.clone();
                 let download_id = q.enqueue(split_request, &settings);
+                crate::services::history_service::remove_entries_for_urls(&app, &queued_urls);
                 log::info!(
                     "Download {download_id} queued (artist mode: {})",
                     mode.to_cli_string()
@@ -765,10 +782,36 @@ pub async fn start_download(
     // Acquire the queue lock and enqueue the download. The lock is scoped
     // to this block to release it before the async process_queue() call,
     // avoiding potential deadlocks.
+    let submitted_urls = request.urls.clone();
+    let filtered_urls = {
+        let q = queue.lock().await;
+        q.filter_out_active_duplicate_urls(&request.urls)
+    };
+    if filtered_urls.is_empty() {
+        crate::services::history_service::remove_entries_for_urls(&app, &submitted_urls);
+        emit_app_log(
+            &app,
+            &format!("Nothing queued for {urls_display} — already in Queue"),
+        );
+        return Ok(StartDownloadResult {
+            download_id: String::new(),
+            duplicate_warning: Some("This URL is already in the queue".to_string()),
+        });
+    }
+    if filtered_urls.len() != request.urls.len() {
+        let skipped = request.urls.len() - filtered_urls.len();
+        emit_app_log(
+            &app,
+            &format!("Skipped {skipped} duplicate queued URL(s) from request"),
+        );
+        request.urls = filtered_urls;
+    }
+
     let download_id = {
         let mut q = queue.lock().await;
         q.enqueue(request, &settings)
     };
+    crate::services::history_service::remove_entries_for_urls(&app, &submitted_urls);
 
     log::info!("Download {download_id} queued");
     emit_app_log(&app, &format!("Queued: {urls_display}"));
@@ -926,12 +969,23 @@ pub async fn retry_download(
     // Attempt to reset the download item to Queued state.
     // q.retry() returns true only if the item exists and is in a retryable state
     // (Failed or Cancelled).
+    let retry_urls = {
+        let q = queue.lock().await;
+        q.get_status()
+            .into_iter()
+            .find(|item| item.id == download_id)
+            .map(|item| item.urls)
+            .unwrap_or_default()
+    };
+
     let retried = {
         let mut q = queue.lock().await;
         q.retry(&download_id, &settings)
     };
 
     if retried {
+        crate::services::history_service::remove_entries_for_urls(&app, &retry_urls);
+
         // Persist the updated queue (retried item now Queued again)
         let queue_handle = queue.inner().clone();
         download_queue::save_queue_to_disk(&app, &queue_handle).await;
@@ -987,12 +1041,23 @@ pub async fn retry_download_without_wrapper(
 
     // Attempt to reset the download with wrapper disabled.
     // Returns true only if the item exists, is retryable, and was using wrapper.
+    let retry_urls = {
+        let q = queue.lock().await;
+        q.get_status()
+            .into_iter()
+            .find(|item| item.id == download_id)
+            .map(|item| item.urls)
+            .unwrap_or_default()
+    };
+
     let retried = {
         let mut q = queue.lock().await;
         q.retry_without_wrapper(&download_id, &settings)
     };
 
     if retried {
+        crate::services::history_service::remove_entries_for_urls(&app, &retry_urls);
+
         // Persist the updated queue (retried item now Queued again)
         let queue_handle = queue.inner().clone();
         download_queue::save_queue_to_disk(&app, &queue_handle).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1375,6 +1375,9 @@ pub fn run() {
                 services::activity_log_writer::ACTIVITY_LOG_RETENTION_DAYS
             );
 
+            // Compact any duplicate history rows left by older retry behaviour.
+            services::history_service::cleanup_duplicate_entries(app.handle());
+
             // Restore any persisted queue items and schedule delayed processing
             setup_queue_recovery(app);
 

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -454,7 +454,7 @@ fn extract_album_info_from_url(url: &str) -> (Option<String>, Option<String>) {
     (None, None)
 }
 
-fn normalize_url_for_dedup(url: &str) -> String {
+pub(crate) fn normalize_url_for_dedup(url: &str) -> String {
     // Split scheme + authority from path+query.
     // URL structure: scheme://authority/path?query#fragment
     let url = url.trim();
@@ -1227,7 +1227,14 @@ impl DownloadQueue {
     ///
     /// # Returns
     /// The unique download ID for tracking this job.
-    pub fn enqueue(&mut self, request: DownloadRequest, settings: &AppSettings) -> String {
+    pub fn enqueue(&mut self, mut request: DownloadRequest, settings: &AppSettings) -> String {
+        self.remove_terminal_duplicates_for_urls(&request.urls);
+
+        let mut seen_urls = HashSet::new();
+        request
+            .urls
+            .retain(|url| seen_urls.insert(normalize_url_for_dedup(url)));
+
         // Generate a unique download ID using UUID v4.
         // This ID is used to track the download across the queue, events, and frontend.
         let download_id = uuid::Uuid::new_v4().to_string();
@@ -1307,6 +1314,34 @@ impl DownloadQueue {
         download_id
     }
 
+    /// Removes terminal queue rows that match the incoming URL set.
+    ///
+    /// Retried history entries are requeued as fresh items, so any older
+    /// failed/cancelled/completed row for the same link should disappear
+    /// from Queue instead of accumulating as a duplicate.
+    fn remove_terminal_duplicates_for_urls(&mut self, urls: &[String]) -> usize {
+        if urls.is_empty() {
+            return 0;
+        }
+
+        let incoming: HashSet<String> = urls.iter().map(|u| normalize_url_for_dedup(u)).collect();
+        let original_len = self.items.len();
+        self.items.retain(|item| {
+            let is_terminal = matches!(
+                item.status.state,
+                DownloadState::Complete | DownloadState::Error | DownloadState::Cancelled
+            );
+            let matches_incoming = item
+                .status
+                .urls
+                .iter()
+                .any(|u| incoming.contains(&normalize_url_for_dedup(u)));
+            !(is_terminal && matches_incoming)
+        });
+
+        original_len - self.items.len()
+    }
+
     /// Checks whether any of the given URLs already exist in the queue in an
     /// active or pending state (Queued, Downloading, or Processing).
     ///
@@ -1332,6 +1367,32 @@ impl DownloadQueue {
                 .iter()
                 .any(|u| incoming.contains(&normalize_url_for_dedup(u)))
         })
+    }
+
+    /// Returns only URLs that are not already in a queued/active item.
+    #[must_use]
+    pub fn filter_out_active_duplicate_urls(&self, urls: &[String]) -> Vec<String> {
+        let active_urls: HashSet<String> = self
+            .items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.status.state,
+                    DownloadState::Queued | DownloadState::Downloading | DownloadState::Processing
+                )
+            })
+            .flat_map(|item| item.status.urls.iter())
+            .map(|url| normalize_url_for_dedup(url))
+            .collect();
+
+        let mut seen_in_request = HashSet::new();
+        urls.iter()
+            .filter(|url| {
+                let normalized = normalize_url_for_dedup(url);
+                seen_in_request.insert(normalized.clone()) && !active_urls.contains(&normalized)
+            })
+            .cloned()
+            .collect()
     }
 
     /// Returns the public status of all queue items for display in the frontend.
@@ -8034,7 +8095,6 @@ async fn run_download_with_events(
 
     // Build the command with all arguments
     let mut cmd = gamdl_service::build_gamdl_command_public(app, urls, options)?;
-
     // Verbose: log CLI args for debugging
     emit_verbose_download_log(
         app,
@@ -8814,6 +8874,22 @@ pub fn load_queue_from_disk(app: &AppHandle) -> Vec<PersistedQueueItem> {
         |_| vec![], // File doesn't exist (first run) — not an error
         |json| match serde_json::from_str::<Vec<PersistedQueueItem>>(&json) {
             Ok(items) => {
+                let original_len = items.len();
+                let items = dedupe_persisted_queue_items(items);
+                if items.len() != original_len {
+                    log::info!(
+                        "Cleaned up {} duplicate persisted queue item(s)",
+                        original_len - items.len()
+                    );
+                    match serde_json::to_string_pretty(&items) {
+                        Ok(json) => {
+                            if let Err(e) = std::fs::write(&queue_path, json) {
+                                log::warn!("Failed to write cleaned queue.json: {e}");
+                            }
+                        }
+                        Err(e) => log::warn!("Failed to serialize cleaned queue: {e}"),
+                    }
+                }
                 if !items.is_empty() {
                     log::info!("Loaded {} persisted queue item(s) from disk", items.len());
                 }
@@ -8825,6 +8901,28 @@ pub fn load_queue_from_disk(app: &AppHandle) -> Vec<PersistedQueueItem> {
             }
         },
     )
+}
+
+fn dedupe_persisted_queue_items(items: Vec<PersistedQueueItem>) -> Vec<PersistedQueueItem> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::with_capacity(items.len());
+
+    for item in items.into_iter().rev() {
+        let urls: Vec<String> = item
+            .request
+            .urls
+            .iter()
+            .map(|url| normalize_url_for_dedup(url))
+            .collect();
+        if urls.iter().any(|url| seen.contains(url)) {
+            continue;
+        }
+        seen.extend(urls);
+        deduped.push(item);
+    }
+
+    deduped.reverse();
+    deduped
 }
 
 /// Deletes the `queue.json` persistence file.
@@ -9216,6 +9314,29 @@ mod tests {
         assert!(status.error.is_none());
         assert!(status.output_path.is_none());
         assert!(!status.fallback_occurred);
+    }
+
+    #[test]
+    fn enqueue_removes_terminal_duplicate_attempt() {
+        let mut queue = DownloadQueue::new();
+        let settings = test_settings();
+        let old_request = DownloadRequest {
+            urls: vec!["https://music.apple.com/us/album/test/123?ls=1".to_string()],
+            options: None,
+        };
+        let old_id = queue.enqueue(old_request, &settings);
+        queue.set_error(&old_id, "failed once");
+
+        let new_request = DownloadRequest {
+            urls: vec!["https://Music.Apple.Com/us/album/test/123/".to_string()],
+            options: None,
+        };
+        let new_id = queue.enqueue(new_request, &settings);
+        let statuses = queue.get_status();
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].id, new_id);
+        assert_eq!(statuses[0].state, DownloadState::Queued);
     }
 
     /// Verifies that enqueue() merges global settings into the item's options.
@@ -11341,6 +11462,53 @@ mod tests {
 
         let urls = vec!["https://music.apple.com/us/album/other/456".to_string()];
         assert!(!queue.has_duplicate_urls(&urls));
+    }
+
+    #[test]
+    fn filter_out_active_duplicate_urls_keeps_only_new_urls() {
+        let mut queue = DownloadQueue::new();
+        let settings = test_settings();
+        queue.enqueue(
+            DownloadRequest {
+                urls: vec!["https://music.apple.com/us/album/test/123?ls=1".to_string()],
+                options: None,
+            },
+            &settings,
+        );
+
+        let urls = vec![
+            "https://Music.Apple.Com/us/album/test/123/".to_string(),
+            "https://music.apple.com/us/album/other/456".to_string(),
+        ];
+
+        assert_eq!(
+            queue.filter_out_active_duplicate_urls(&urls),
+            vec!["https://music.apple.com/us/album/other/456".to_string()]
+        );
+    }
+
+    #[test]
+    fn dedupe_persisted_queue_items_keeps_newest_matching_url() {
+        fn persisted(id: &str, url: &str) -> PersistedQueueItem {
+            PersistedQueueItem {
+                id: id.to_string(),
+                request: DownloadRequest {
+                    urls: vec![url.to_string()],
+                    options: None,
+                },
+                created_at: "2026-05-04T10:00:00Z".to_string(),
+                error: Some("failed".to_string()),
+                service: None,
+            }
+        }
+
+        let items = dedupe_persisted_queue_items(vec![
+            persisted("old", "https://music.apple.com/us/album/test/123?ls=1"),
+            persisted("new", "https://Music.Apple.Com/us/album/test/123/"),
+        ]);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "new");
     }
 
     // ============================================================

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -677,6 +677,77 @@ fn count_codec_skip_warnings(warnings: &[String]) -> usize {
         .count()
 }
 
+fn requested_format_cli_values(options: &GamdlOptions) -> Vec<String> {
+    if let Some(priority) = options.song_codec_priority.as_deref() {
+        return priority
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect();
+    }
+
+    options
+        .song_codec
+        .as_ref()
+        .map(|codec| vec![codec.to_cli_string().to_string()])
+        .unwrap_or_default()
+}
+
+fn extract_song_codec_values_from_line(line: &str) -> Vec<String> {
+    line.split("SongCodec.")
+        .skip(1)
+        .filter_map(|part| {
+            let value_start = part.find(": '")? + 3;
+            let value_rest = &part[value_start..];
+            let value_end = value_rest.find('\'')?;
+            Some(value_rest[..value_end].to_string())
+        })
+        .collect()
+}
+
+fn describe_song_codec_cli_value(value: &str) -> String {
+    SongCodec::from_cli_string(value).map_or_else(
+        || value.to_string(),
+        |codec| format!("{} [{}]", codec.display_name(), codec.to_cli_string()),
+    )
+}
+
+fn annotate_unavailable_format_line(line: &str, requested_formats: &[String]) -> String {
+    let lower = line.to_lowercase();
+    let is_unavailable_format = lower.contains("format is not available")
+        || lower.contains("format not available")
+        || lower.contains("requested format");
+    if !is_unavailable_format || line.contains("Unavailable requested format") {
+        return line.to_string();
+    }
+
+    let parsed_formats = extract_song_codec_values_from_line(line);
+    let formats = if parsed_formats.is_empty() {
+        requested_formats.to_vec()
+    } else {
+        parsed_formats
+    };
+    if formats.is_empty() {
+        return line.to_string();
+    }
+
+    let labels: Vec<String> = formats
+        .iter()
+        .map(|value| describe_song_codec_cli_value(value))
+        .collect();
+    let detail = if labels.len() == 1 {
+        format!("Unavailable requested format: {}", labels[0])
+    } else {
+        format!(
+            "Unavailable requested format candidates: {}",
+            labels.join(" -> ")
+        )
+    };
+
+    format!("{line} ({detail})")
+}
+
 /// Build a gap-fill priority chain by removing wrapper-dependent codecs
 /// (Atmos, AC3) from the original chain. These codecs don't reliably
 /// work without wrapper authentication for per-track availability.
@@ -8095,6 +8166,7 @@ async fn run_download_with_events(
 
     // Build the command with all arguments
     let mut cmd = gamdl_service::build_gamdl_command_public(app, urls, options)?;
+    let requested_format_context = requested_format_cli_values(options);
     // Verbose: log CLI args for debugging
     emit_verbose_download_log(
         app,
@@ -8194,6 +8266,7 @@ async fn run_download_with_events(
         // raw output buffer used by the soft-error friendly-message
         // generator and the storefront-mismatch detector (#666).
         let raw_output = raw_output_lines.clone();
+        let requested_formats = requested_format_context.clone();
         tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
             let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
@@ -8240,6 +8313,8 @@ async fn run_download_with_events(
                     // outputs for terminal colouring but render as garbage
                     // in the Activity Log's HTML view.
                     let clean_line = process::strip_ansi_codes(segment);
+                    let display_line =
+                        annotate_unavailable_format_line(&clean_line, &requested_formats);
                     log::debug!("[gamdl stdout] {clean_line}");
 
                     // Emit to activity-log: last \r segment only (normal),
@@ -8258,7 +8333,7 @@ async fn run_download_with_events(
                             let log_event = ActivityLogEvent {
                                 download_id: download_id.clone(),
                                 stream: "stdout",
-                                line: clean_line.clone(),
+                                line: display_line.clone(),
                                 timestamp: chrono::Utc::now().to_rfc3339(),
                             };
                             // Suppress Python traceback noise from the user-
@@ -8399,6 +8474,7 @@ async fn run_download_with_events(
         let raw_output = raw_output_lines.clone();
         let seen = seen_lines.clone();
         let last_activity = last_activity_ms.clone();
+        let requested_formats = requested_format_context.clone();
         tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stderr);
             let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
@@ -8423,6 +8499,8 @@ async fn run_download_with_events(
 
                     // Strip ANSI escape codes before display and parsing
                     let clean_line = process::strip_ansi_codes(segment);
+                    let display_line =
+                        annotate_unavailable_format_line(&clean_line, &requested_formats);
                     log::debug!("[gamdl stderr] {clean_line}");
 
                     // Emit to activity-log: last \r segment only (normal),
@@ -8438,7 +8516,7 @@ async fn run_download_with_events(
                             let log_event = ActivityLogEvent {
                                 download_id: download_id.clone(),
                                 stream: "stderr",
-                                line: clean_line.clone(),
+                                line: display_line.clone(),
                                 timestamp: chrono::Utc::now().to_rfc3339(),
                             };
                             // Suppress Python traceback noise from the
@@ -11216,6 +11294,29 @@ mod tests {
             "Requested format is not available for song 03".to_string(),
         ];
         assert_eq!(count_codec_skip_warnings(&warnings), 3);
+    }
+
+    #[test]
+    fn annotate_unavailable_format_line_adds_single_requested_codec() {
+        let line = r#"[WARNING] Skipping "Track": Requested format is not available"#;
+        let annotated = annotate_unavailable_format_line(line, &["atmos".to_string()]);
+
+        assert!(annotated.contains("Unavailable requested format"));
+        assert!(annotated.contains("Dolby Atmos"));
+        assert!(annotated.contains("[atmos]"));
+    }
+
+    #[test]
+    fn annotate_unavailable_format_line_decodes_gamdl_song_codec_list() {
+        let line = "Requested format is not available: [<SongCodec.ATMOS: 'atmos'>, <SongCodec.ALAC: 'alac'>]";
+        let annotated = annotate_unavailable_format_line(line, &["aac".to_string()]);
+
+        assert!(annotated.contains("Unavailable requested format candidates"));
+        assert!(annotated.contains("Dolby Atmos"));
+        assert!(annotated.contains("[atmos]"));
+        assert!(annotated.contains("Lossless"));
+        assert!(annotated.contains("[alac]"));
+        assert!(!annotated.contains("[aac]"));
     }
 
     #[test]

--- a/src-tauri/src/services/history_service.rs
+++ b/src-tauri/src/services/history_service.rs
@@ -24,6 +24,10 @@ use tauri::AppHandle;
 /// When this limit is exceeded, the oldest entries are trimmed.
 const MAX_HISTORY_ENTRIES: usize = 1000;
 
+fn normalize_url_for_history_dedup(url: &str) -> String {
+    crate::services::download_queue::normalize_url_for_dedup(url)
+}
+
 // ============================================================
 // Data model
 // ============================================================
@@ -83,7 +87,23 @@ fn load_history_from_disk(app: &AppHandle) -> Vec<HistoryEntry> {
     std::fs::read_to_string(&path).map_or_else(
         |_| vec![],
         |json| match serde_json::from_str::<Vec<HistoryEntry>>(&json) {
-            Ok(entries) => entries,
+            Ok(entries) => {
+                let original_len = entries.len();
+                let entries = dedupe_history_entries(entries);
+                if entries.len() != original_len {
+                    log::info!(
+                        "Cleaned up {} duplicate history {}",
+                        original_len - entries.len(),
+                        if original_len - entries.len() == 1 {
+                            "entry"
+                        } else {
+                            "entries"
+                        }
+                    );
+                    save_history_to_disk(app, &entries);
+                }
+                entries
+            }
             Err(e) => {
                 log::debug!("Failed to parse history.json: {e}");
                 vec![]
@@ -107,6 +127,14 @@ fn save_history_to_disk(app: &AppHandle, entries: &[HistoryEntry]) {
     }
 }
 
+fn dedupe_history_entries(mut entries: Vec<HistoryEntry>) -> Vec<HistoryEntry> {
+    entries.sort_by(|a, b| b.completed_at.cmp(&a.completed_at));
+
+    let mut seen = std::collections::HashSet::new();
+    entries.retain(|entry| seen.insert(normalize_url_for_history_dedup(&entry.url)));
+    entries
+}
+
 // ============================================================
 // Public API
 // ============================================================
@@ -125,6 +153,8 @@ pub fn list_history(app: &AppHandle) -> Vec<HistoryEntry> {
 /// oldest entries are trimmed to stay within the limit.
 pub fn save_history_entry(app: &AppHandle, entry: HistoryEntry) {
     let mut entries = load_history_from_disk(app);
+    let incoming_url = normalize_url_for_history_dedup(&entry.url);
+    entries.retain(|existing| normalize_url_for_history_dedup(&existing.url) != incoming_url);
     entries.push(entry);
 
     // Sort newest first, then trim to the limit
@@ -132,6 +162,33 @@ pub fn save_history_entry(app: &AppHandle, entry: HistoryEntry) {
     entries.truncate(MAX_HISTORY_ENTRIES);
 
     save_history_to_disk(app, &entries);
+}
+
+/// Removes any history rows whose URL matches one of the supplied URLs.
+///
+/// Used when a history row is retried/requeued: the fresh queue attempt
+/// becomes the live source of truth, and the new terminal result will write
+/// back a single replacement history row when it finishes.
+pub fn remove_entries_for_urls(app: &AppHandle, urls: &[String]) {
+    if urls.is_empty() {
+        return;
+    }
+
+    let incoming: std::collections::HashSet<String> =
+        urls.iter().map(|url| normalize_url_for_history_dedup(url)).collect();
+    let mut entries = load_history_from_disk(app);
+    let original_len = entries.len();
+    entries.retain(|entry| !incoming.contains(&normalize_url_for_history_dedup(&entry.url)));
+
+    if entries.len() != original_len {
+        save_history_to_disk(app, &entries);
+    }
+}
+
+/// Compacts history on startup after upgrades that may have produced
+/// duplicate rows in earlier versions.
+pub fn cleanup_duplicate_entries(app: &AppHandle) {
+    let _ = load_history_from_disk(app);
 }
 
 /// Deletes all history entries.
@@ -229,5 +286,21 @@ mod tests {
         assert!(entry.codec.is_none());
         assert!(entry.file_path.is_none());
         assert!(entry.error_message.is_none());
+    }
+
+    #[test]
+    fn dedupe_history_entries_keeps_newest_matching_url() {
+        let mut older = make_entry("Older", "failed");
+        older.url = "https://music.apple.com/us/album/test/123?ls=1".to_string();
+        older.completed_at = "2026-05-04T10:00:00Z".to_string();
+
+        let mut newer = make_entry("Newer", "success");
+        newer.url = "https://Music.Apple.Com/us/album/test/123/".to_string();
+        newer.completed_at = "2026-05-04T11:00:00Z".to_string();
+
+        let entries = dedupe_history_entries(vec![older, newer.clone()]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, newer.id);
     }
 }

--- a/src/components/download/HistoryPage.tsx
+++ b/src/components/download/HistoryPage.tsx
@@ -139,15 +139,15 @@ export function HistoryPage() {
   }, []);
 
   /**
-   * Re-enqueue a failed history entry via `start_download`. The history
-   * entry is left untouched — the new download writes its own history
-   * entry on completion. Per-item retry path; the bulk variant batches
-   * many calls.
+   * Re-enqueue a failed history entry via `start_download`. The backend
+   * removes the old history row for the same URL, and the new attempt writes
+   * one replacement row on completion.
    */
   const handleRetryOne = useCallback(
     async (entry: HistoryEntry) => {
       try {
         await startDownload({ urls: [entry.url] });
+        setEntries((current) => current.filter((item) => item.id !== entry.id));
         addToast(`Re-queued: ${getDisplayLabel(entry)}`, 'success');
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -193,6 +193,7 @@ export function HistoryPage() {
     }
     try {
       await startDownload({ urls: uniqueUrls });
+      setEntries((current) => current.filter((entry) => !uniqueUrls.includes(entry.url)));
       addToast(
         `Re-queued ${uniqueUrls.length} download${uniqueUrls.length !== 1 ? 's' : ''}` +
           (uniqueUrls.length < failedCount


### PR DESCRIPTION
## Summary
- Prevent retry and requeue flows from accumulating duplicate Queue and History rows for the same normalized URL.
- Compact pre-existing duplicate History rows on startup/list/save and duplicate persisted Queue rows on queue restore.
- Skip exact URLs already queued or active instead of adding another duplicate live attempt.
- Annotate Activity Log lines for unavailable requested formats with readable codec names and CLI values.

## Issues
- Fixes #679
- Fixes #680

## Implementation Details
### Retry, Queue, and History dedupe
- DownloadQueue enqueue now removes terminal duplicate attempts for incoming URLs and dedupes repeated URLs in the request.
- start_download filters out URLs already queued/downloading/processing, while still removing stale History entries if the same URL is already live.
- history save replaces same-URL rows instead of appending duplicates.
- history cleanup runs during app setup, and history load paths compact older duplicate rows automatically.
- persisted queue loading compacts duplicate queue entries and writes the cleaned queue back to disk.
- the History page removes retried rows from local state after successful requeue so the UI updates immediately.

### Unavailable format log context
- GAMDL stdout/stderr lines still feed parsing and fallback detection unchanged.
- the Activity Log event line is annotated only for requested-format unavailable warnings.
- GAMDL SongCodec repr lists are decoded into readable labels such as Dolby Atmos (Experimental) [atmos].
- when GAMDL does not include codec details in the warning, MeedyaDL falls back to the active song codec or song codec priority request context.

## Verification
- cargo test dedupe_history_entries_keeps_newest_matching_url
- cargo test duplicate
- cargo test dedupe_persisted_queue_items_keeps_newest_matching_url
- cargo test unavailable_format

## Notes
- cargo fmt --check reports broad pre-existing Rust formatting drift across unrelated files, so this PR deliberately avoids a whole-repo format pass.