### PR TITLE
fix(release): require conventional PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 MeedyaDL
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# PR Title Lint
+# =============
+#
+# Release Please reads the squash-merge commit title from merged pull
+# requests. If that title is not a Conventional Commit, Release Please
+# treats the change as non-user-facing and will not create a release PR.
+# This workflow catches bad PR titles before merge.
+
+name: PR Title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s\n' "$PR_TITLE" | npx commitlint


### PR DESCRIPTION
## Summary
- add a PR Title workflow that validates pull request titles with the existing commitlint Conventional Commit config
- prevent squash-merge titles like 'Fix retry dedupe...' or 'Make companion timeout...' from being merged and then ignored by Release Please
- make this fix itself a conventional commit so Release Please has a releasable commit after this PR lands

## Root Cause
Release Please is not failing. The latest Release Please logs show it skipped release creation because it could not parse recent merged commit titles and then reported: 'No user facing commits found since v0.52.3'. The recent PRs were merged with non-conventional squash titles, so Release Please ignored them.

## Expected Flow After Merge
1. This PR merges with a conventional squash title.
2. Release Please sees fix(release): require conventional PR titles.
3. Release Please creates or updates the release PR for the next patch version.
4. Merging that release PR creates the tag/GitHub Release and triggers the Release workflow.

## Verification
- printf '%s\n' 'fix(release): require conventional PR titles' | npx commitlint
- printf '%s\n' 'Make companion timeout advisory before hard abort' | npx commitlint (fails as expected)
- git diff --check