### PR TITLE
feat(queue,history): add per-item delete (#685)

### DIFF
--- a/src-tauri/src/commands/gamdl.rs
+++ b/src-tauri/src/commands/gamdl.rs
@@ -1078,6 +1078,58 @@ pub async fn retry_download_without_wrapper(
     }
 }
 
+/// Removes a single item from the queue by ID (#685).
+///
+/// **Frontend caller:** `deleteQueueItem(downloadId)` in `src/lib/tauri-commands.ts`
+///
+/// Sibling of `cancel_download` (which transitions an active item to
+/// `Cancelled` but keeps the row visible) and `clear_all_queue` (bulk).
+/// This is the per-item destructive removal — typically used to purge a
+/// stubbornly-failing entry from the queue without nuking the rest.
+///
+/// Active items (`Downloading` / `Processing`) are refused — the caller
+/// must `cancel_download` first. The frontend already hides the menu entry
+/// for active rows, so this is defense-in-depth against a context-menu
+/// race (state changed between menu open and click).
+///
+/// # Events Emitted
+/// * `"queue-item-deleted"` — payload: the deleted download ID. The
+///   frontend can listen for this to update lists without a full refetch
+///   (the existing 3 s polling fallback also catches it).
+#[tauri::command]
+pub async fn delete_queue_item(
+    app: AppHandle,
+    queue: State<'_, QueueHandle>,
+    download_id: String,
+) -> Result<(), String> {
+    log::info!("Delete requested for download: {download_id}");
+
+    let result = {
+        let mut q = queue.lock().await;
+        q.delete(&download_id)
+    };
+
+    match result {
+        Ok(true) => {
+            // Persist the updated queue (item removed). Mirrors the
+            // cancel/retry/clear paths so a crash or quit can't resurrect
+            // a deleted row from disk on next startup.
+            let queue_handle = queue.inner().clone();
+            download_queue::save_queue_to_disk(&app, &queue_handle).await;
+
+            let short = &download_id[..8.min(download_id.len())];
+            emit_app_log(&app, &format!("Removed queue item [{short}]"));
+
+            // Best-effort frontend notification; the deletion has already
+            // landed regardless of whether the event reaches the UI.
+            let _ = app.emit("queue-item-deleted", &download_id);
+            Ok(())
+        }
+        Ok(false) => Err(format!("Download {download_id} not found")),
+        Err(e) => Err(e),
+    }
+}
+
 /// Clears all completed, failed, and cancelled items from the queue.
 ///
 /// **Frontend caller:** `clearQueue()` in `src/lib/tauri-commands.ts`

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -42,3 +42,17 @@ pub fn clear_history(app: AppHandle) -> Result<(), String> {
 pub fn search_history(app: AppHandle, query: String) -> Vec<HistoryEntry> {
     history_service::search_history(&app, &query)
 }
+
+/// Removes a single history entry by ID (#685).
+///
+/// Sibling of `clear_history` (bulk). Returns `Err` only when the ID
+/// doesn't match any row, so the frontend can surface "already gone"
+/// distinctly from a no-op.
+#[tauri::command]
+pub fn delete_history_entry(app: AppHandle, id: String) -> Result<(), String> {
+    if history_service::delete_entry(&app, &id) {
+        Ok(())
+    } else {
+        Err(format!("History entry {id} not found"))
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1140,6 +1140,7 @@ pub fn run() {
             commands::gamdl::retry_download_without_wrapper,
             commands::gamdl::clear_queue,
             commands::gamdl::clear_all_queue,
+            commands::gamdl::delete_queue_item,
             commands::gamdl::abort_all_downloads,
             commands::gamdl::get_queue_status,
             commands::gamdl::check_gamdl_update,
@@ -1199,6 +1200,7 @@ pub fn run() {
             commands::history::list_history,
             commands::history::clear_history,
             commands::history::search_history,
+            commands::history::delete_history_entry,
             // API field audit command (diagnostic tool)
             commands::api_audit::audit_api_fields,
             // Clipboard monitoring command

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -1539,6 +1539,37 @@ impl DownloadQueue {
         }
     }
 
+    /// Removes a single item from the queue by ID.
+    ///
+    /// Refuses to remove `Downloading` / `Processing` items — the user must
+    /// `cancel()` them first. Without this guard, deleting a live row would
+    /// orphan the GAMDL subprocess (which writes to disk and would emit
+    /// progress events with no queue entry to update), and the cancellation
+    /// poll loop would have nothing to find on its next tick.
+    ///
+    /// # Returns
+    /// - `Ok(true)` if the item was found and removed.
+    /// - `Ok(false)` if the item was not found (already removed by a prior
+    ///   call, or the ID was wrong).
+    /// - `Err(message)` if the item exists but is in an active state.
+    pub fn delete(&mut self, download_id: &str) -> Result<bool, String> {
+        let Some(idx) = self.items.iter().position(|i| i.status.id == download_id) else {
+            return Ok(false);
+        };
+
+        match self.items[idx].status.state {
+            DownloadState::Downloading | DownloadState::Processing => Err(format!(
+                "Cannot delete download {download_id} — currently active. \
+                 Cancel it first."
+            )),
+            _ => {
+                self.items.remove(idx);
+                log::info!("Deleted download {download_id} from queue");
+                Ok(true)
+            }
+        }
+    }
+
     /// Removes completed and cancelled items from the queue.
     /// Errored items are kept so the user can review and retry them.
     ///
@@ -10542,6 +10573,120 @@ mod tests {
             DownloadState::Complete,
             "set_error must not transition Complete -> Error (#661)"
         );
+    }
+
+    // ==========================================================
+    // 11b. delete() tests (#685)
+    // ==========================================================
+
+    /// Verifies that delete() removes a queued item and reports success.
+    #[test]
+    fn delete_removes_queued_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        assert_eq!(queue.get_status().len(), 1);
+
+        let result = queue.delete(&id);
+        assert_eq!(result, Ok(true));
+        assert!(queue.get_status().is_empty());
+    }
+
+    /// Verifies that delete() removes a Complete item.
+    #[test]
+    fn delete_removes_complete_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        queue.set_complete(&id);
+
+        assert_eq!(queue.delete(&id), Ok(true));
+        assert!(queue.get_status().is_empty());
+    }
+
+    /// Verifies that delete() removes an Error item (the primary use case
+    /// — purging a stubbornly-failing entry without nuking the whole list).
+    #[test]
+    fn delete_removes_errored_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        queue.set_error(&id, "permanent failure");
+
+        assert_eq!(queue.delete(&id), Ok(true));
+        assert!(queue.get_status().is_empty());
+    }
+
+    /// Verifies that delete() removes a Cancelled item.
+    #[test]
+    fn delete_removes_cancelled_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        queue.cancel(&id);
+
+        assert_eq!(queue.delete(&id), Ok(true));
+        assert!(queue.get_status().is_empty());
+    }
+
+    /// Verifies that delete() refuses to remove an actively Downloading
+    /// item — orphaning the subprocess would leak file handles and emit
+    /// progress events with no queue row to update.
+    #[test]
+    fn delete_refuses_active_downloading_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        // Force-set state to Downloading. (In production this happens via
+        // process_queue; the test only needs the state for the guard check.)
+        if let Some(item) = queue.items.iter_mut().find(|i| i.status.id == id) {
+            item.status.state = DownloadState::Downloading;
+        }
+
+        let result = queue.delete(&id);
+        assert!(result.is_err(), "active items must not be deletable");
+        assert_eq!(queue.get_status().len(), 1, "item must still be present");
+    }
+
+    /// Verifies that delete() refuses to remove a Processing item — the
+    /// enrichment pipeline is still writing tags / running companions
+    /// after GAMDL exits, and pulling the queue row out from under it
+    /// would invalidate the QueueItemHandle the pipeline holds.
+    #[test]
+    fn delete_refuses_active_processing_item() {
+        let mut queue = DownloadQueue::new();
+        let id = enqueue_one(&mut queue);
+        if let Some(item) = queue.items.iter_mut().find(|i| i.status.id == id) {
+            item.status.state = DownloadState::Processing;
+        }
+
+        let result = queue.delete(&id);
+        assert!(result.is_err(), "processing items must not be deletable");
+        assert_eq!(queue.get_status().len(), 1);
+    }
+
+    /// Verifies that delete() returns Ok(false) for an unknown ID rather
+    /// than treating it as an error — the IPC layer can distinguish "no-op"
+    /// (already removed by a parallel click) from "guard violation".
+    #[test]
+    fn delete_unknown_id_is_noop() {
+        let mut queue = DownloadQueue::new();
+        let _ = enqueue_one(&mut queue);
+
+        assert_eq!(queue.delete("nonexistent-id"), Ok(false));
+        assert_eq!(queue.get_status().len(), 1, "real items untouched");
+    }
+
+    /// Verifies that delete() removes only the targeted item when several
+    /// items are present.
+    #[test]
+    fn delete_targets_only_the_named_item() {
+        let mut queue = DownloadQueue::new();
+        let ids = enqueue_n(&mut queue, 3);
+        assert_eq!(queue.get_status().len(), 3);
+
+        assert_eq!(queue.delete(&ids[1]), Ok(true));
+
+        let remaining: Vec<String> = queue.get_status().into_iter().map(|s| s.id).collect();
+        assert_eq!(remaining.len(), 2);
+        assert!(remaining.contains(&ids[0]));
+        assert!(remaining.contains(&ids[2]));
+        assert!(!remaining.contains(&ids[1]));
     }
 
     // ==========================================================

--- a/src-tauri/src/services/history_service.rs
+++ b/src-tauri/src/services/history_service.rs
@@ -191,6 +191,24 @@ pub fn cleanup_duplicate_entries(app: &AppHandle) {
     let _ = load_history_from_disk(app);
 }
 
+/// Removes a single history entry by its ID.
+///
+/// Returns `true` if an entry matched and was removed, `false` if no entry
+/// with the given ID was found (the file is left untouched in the latter
+/// case to avoid an unnecessary disk write).
+pub fn delete_entry(app: &AppHandle, id: &str) -> bool {
+    let mut entries = load_history_from_disk(app);
+    let original_len = entries.len();
+    entries.retain(|entry| entry.id != id);
+
+    if entries.len() != original_len {
+        save_history_to_disk(app, &entries);
+        true
+    } else {
+        false
+    }
+}
+
 /// Deletes all history entries.
 pub fn clear_history(app: &AppHandle) {
     let path = history_path(app);

--- a/src/components/download/DownloadQueue.tsx
+++ b/src/components/download/DownloadQueue.tsx
@@ -74,6 +74,9 @@ import { PageHeader } from '@/components/layout';
  */
 import { QueueItem } from './QueueItem';
 
+/** Per-item snapshot type used by the Delete confirmation modal (#685). */
+import type { QueueItemStatus } from '@/types';
+
 /**
  * Renders the download queue page showing all download items with their
  * current status, real-time progress, and available actions.
@@ -139,6 +142,9 @@ export function DownloadQueue() {
   /** Clear ALL non-active items from the queue. */
   const clearAll = useDownloadStore((s) => s.clearAll);
 
+  /** Delete a single non-active item from the queue (#685). */
+  const deleteItem = useDownloadStore((s) => s.deleteItem);
+
   /**
    * Exports the current queue to a `.meedyadl` file via a native save dialog.
    * Only non-terminal items (queued/active) are included in the export.
@@ -162,6 +168,14 @@ export function DownloadQueue() {
 
   /** Confirmation modal state for "Clear All". */
   const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
+
+  /**
+   * Confirmation modal target for per-item Delete (#685). Holds the
+   * full queue item snapshot so the modal can render a meaningful label
+   * (URL, current track) without re-querying the store. `null` means the
+   * modal is closed.
+   */
+  const [deleteTarget, setDeleteTarget] = useState<QueueItemStatus | null>(null);
 
   /**
    * Confirmation modal state for "Retry All Failed" (#665). Bulk retry
@@ -359,6 +373,37 @@ export function DownloadQueue() {
       addToast(`Cleared all ${removed} item${removed !== 1 ? 's' : ''}`, 'info');
     } catch {
       addToast('Failed to clear queue', 'error');
+    }
+  };
+
+  /**
+   * Per-item Delete (#685). Opens the confirmation modal with the
+   * targeted item — actual deletion happens in
+   * `handleDeleteItemConfirmed` only after the user confirms.
+   */
+  const handleDeleteItem = (id: string) => {
+    const target = queueItems.find((i) => i.id === id);
+    if (!target) return;
+    setDeleteTarget(target);
+  };
+
+  /**
+   * Confirms the Delete action for the currently-targeted item. Errors
+   * surface as a toast (e.g. backend race where the item became active
+   * after the menu opened — Rust guard would reject).
+   */
+  const handleDeleteItemConfirmed = async () => {
+    const target = deleteTarget;
+    if (!target) return;
+    setDeleteTarget(null);
+    try {
+      await deleteItem(target.id);
+      addToast('Item removed from queue', 'info');
+    } catch (e) {
+      addToast(
+        e instanceof Error ? e.message : 'Failed to delete item',
+        'error',
+      );
     }
   };
 
@@ -685,6 +730,7 @@ export function DownloadQueue() {
                 onRetry={handleRetry}
                 onRetryWithoutWrapper={handleRetryWithoutWrapper}
                 onCopyUrl={() => addToast('Link copied to clipboard', 'success')}
+                onDelete={handleDeleteItem}
               />
             ))}
           </div>
@@ -742,6 +788,31 @@ export function DownloadQueue() {
             onClick={handleClearAllConfirmed}
           >
             Clear All
+          </Button>
+        </div>
+      </Modal>
+
+      {/* Confirmation modal for per-item Delete (#685) */}
+      <Modal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title="Remove queue item"
+      >
+        <p className="text-sm text-content-secondary mb-4">
+          Remove this item from the download queue? Already-downloaded
+          files on disk are not deleted — only the queue entry.
+        </p>
+        {deleteTarget && (
+          <p className="text-xs text-content-tertiary mb-6 break-all">
+            {deleteTarget.current_track || deleteTarget.urls?.[0] || deleteTarget.id}
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setDeleteTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleDeleteItemConfirmed}>
+            Remove
           </Button>
         </div>
       </Modal>

--- a/src/components/download/HistoryPage.tsx
+++ b/src/components/download/HistoryPage.tsx
@@ -25,7 +25,15 @@ import {
   RotateCcw,
   Copy,
 } from 'lucide-react';
-import { listHistory, clearHistory, searchHistory, startDownload } from '@/lib/tauri-commands';
+// Trash2 used for both "Clear History" header button and the per-row Delete
+// context menu entry (#685) — single icon import covers both call sites.
+import {
+  listHistory,
+  clearHistory,
+  searchHistory,
+  startDownload,
+  deleteHistoryEntry,
+} from '@/lib/tauri-commands';
 import { useUiStore } from '@/stores/uiStore';
 
 import type { HistoryEntry } from '@/types';
@@ -88,6 +96,12 @@ export function HistoryPage() {
     y: number;
   } | null>(null);
   const [showRetryAllConfirm, setShowRetryAllConfirm] = useState(false);
+  /**
+   * Per-item Delete confirmation modal target (#685). Holds the entry
+   * being deleted so the modal can show a meaningful label. `null` =
+   * modal closed.
+   */
+  const [deleteTarget, setDeleteTarget] = useState<HistoryEntry | null>(null);
   const addToast = useUiStore((s) => s.addToast);
 
   /** Loads history entries from the backend. */
@@ -209,6 +223,25 @@ export function HistoryPage() {
     }
   }, [failedEntries, failedCount, addToast]);
 
+  /**
+   * Per-item Delete (#685). Confirms via modal, then removes the entry
+   * from disk via the IPC. Updates local state on success so the UI
+   * doesn't flicker during the round-trip.
+   */
+  const handleDeleteConfirmed = useCallback(async () => {
+    const target = deleteTarget;
+    if (!target) return;
+    setDeleteTarget(null);
+    try {
+      await deleteHistoryEntry(target.id);
+      setEntries((current) => current.filter((entry) => entry.id !== target.id));
+      addToast('History entry removed', 'info');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      addToast(`Failed to remove: ${message}`, 'error');
+    }
+  }, [deleteTarget, addToast]);
+
   /** Right-click handler — opens the per-row context menu at the cursor. */
   const handleContextMenu = useCallback(
     (event: React.MouseEvent, entry: HistoryEntry) => {
@@ -247,6 +280,14 @@ export function HistoryPage() {
           onClick: () => handleOpenFolder(entry.file_path!),
         });
       }
+      // Delete entry (#685). Always available — history rows are
+      // metadata-only, so deletion never affects on-disk audio.
+      items.push({
+        label: 'Delete',
+        icon: <Trash2 size={14} />,
+        onClick: () => setDeleteTarget(entry),
+        separator: true,
+      });
       return items;
     },
     [handleCopyUrl, handleRetryOne, handleOpenFolder],
@@ -438,6 +479,31 @@ export function HistoryPage() {
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      {/* Per-item Delete confirmation modal (#685) */}
+      <Modal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title="Remove history entry"
+      >
+        <p className="text-sm text-content-secondary mb-4">
+          Remove this entry from your download history? Already-downloaded
+          files on disk are not deleted — only the history record.
+        </p>
+        {deleteTarget && (
+          <p className="text-xs text-content-tertiary mb-6 break-all">
+            {getDisplayLabel(deleteTarget)}
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setDeleteTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleDeleteConfirmed}>
+            Remove
+          </Button>
+        </div>
+      </Modal>
 
       {/* Bulk retry confirmation modal (#665) */}
       <Modal

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -69,6 +69,7 @@ import {
   FolderOpen,
   FileOutput,
   AlertTriangle,
+  Trash2,
 } from 'lucide-react';
 
 /**
@@ -131,6 +132,16 @@ interface QueueItemProps {
    * notification confirming the copy.
    */
   onCopyUrl: (url: string) => void;
+
+  /**
+   * Callback invoked when the user picks "Delete" from the right-click
+   * menu (#685). The parent is responsible for showing a confirmation
+   * modal before invoking the IPC. Receives the unique download ID.
+   *
+   * The Delete entry is hidden for active rows (`downloading` /
+   * `processing`) — the user must Cancel first.
+   */
+  onDelete: (id: string) => void;
 }
 
 /**
@@ -211,6 +222,7 @@ export function QueueItem({
   onRetry,
   onRetryWithoutWrapper,
   onCopyUrl,
+  onDelete,
 }: QueueItemProps) {
   /**
    * Look up the visual configuration (icon, colour, label) for the
@@ -357,6 +369,18 @@ export function QueueItem({
                 },
               ]
             : []),
+        ]
+      : []),
+    // "Delete" — non-active rows only (#685). Active items must be
+    // cancelled first; the Rust guard rejects deletion of active rows
+    // for defense-in-depth, but hiding the entry keeps the UI honest.
+    ...(item.state !== 'downloading' && item.state !== 'processing'
+      ? [
+          {
+            label: 'Delete',
+            icon: <Trash2 size={14} />,
+            onClick: () => onDelete(item.id),
+          },
         ]
       : []),
   ];

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -633,6 +633,22 @@ export function clearAllQueue(): Promise<number> {
 }
 
 /**
+ * Removes a single queue item by ID (#685).
+ *
+ * Rust handler: `delete_queue_item()` in `src-tauri/src/commands/gamdl.rs`
+ *
+ * Backend refuses active items (`Downloading` / `Processing`) — the caller
+ * must `cancelDownload()` first. The frontend already hides the menu
+ * entry for active rows, so the rejection is defense-in-depth.
+ *
+ * @param downloadId - UUID of the queue item to remove.
+ * @returns Promise resolving when the item has been removed and persisted.
+ */
+export function deleteQueueItem(downloadId: string): Promise<void> {
+  return invoke<void>('delete_queue_item', { downloadId });
+}
+
+/**
  * Returns the current status of the entire download queue.
  *
  * Rust handler: `get_queue_status()` in `src-tauri/src/commands/download.rs`
@@ -1430,6 +1446,20 @@ export function clearHistory(): Promise<void> {
  */
 export function searchHistory(query: string): Promise<import('@/types').HistoryEntry[]> {
   return invoke<import('@/types').HistoryEntry[]>('search_history', { query });
+}
+
+/**
+ * Removes a single history entry by ID (#685).
+ *
+ * Rust handler: `delete_history_entry()` in `src-tauri/src/commands/history.rs`
+ *
+ * The Rust side rejects unknown IDs with an error so the caller can
+ * distinguish "already gone" from a successful delete.
+ *
+ * @param id - UUID of the history entry to remove.
+ */
+export function deleteHistoryEntry(id: string): Promise<void> {
+  return invoke<void>('delete_history_entry', { id });
 }
 
 // ============================================================

--- a/src/stores/downloadStore.test.ts
+++ b/src/stores/downloadStore.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/lib/tauri-commands', () => ({
   cancelDownload: vi.fn(),
   retryDownload: vi.fn(),
   clearQueue: vi.fn(),
+  deleteQueueItem: vi.fn(),
   getQueueStatus: vi.fn(),
 }));
 
@@ -492,6 +493,40 @@ describe('downloadStore', () => {
       const removed = await useDownloadStore.getState().clearFinished();
 
       expect(removed).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // Per-item delete (#685)
+  // ============================================================
+
+  describe('deleteItem', () => {
+    it('calls deleteQueueItem and refreshes the queue', async () => {
+      vi.mocked(commands.deleteQueueItem).mockResolvedValueOnce(undefined);
+      const remaining = [createMockQueueItem({ id: 'dl-2', state: 'queued' })];
+      vi.mocked(commands.getQueueStatus).mockResolvedValueOnce({
+        total: 1,
+        active: 0,
+        queued: 1,
+        completed: 0,
+        failed: 0,
+        items: remaining,
+      });
+
+      await useDownloadStore.getState().deleteItem('dl-1');
+
+      expect(commands.deleteQueueItem).toHaveBeenCalledWith('dl-1');
+      expect(useDownloadStore.getState().queueItems).toEqual(remaining);
+    });
+
+    it('re-throws backend errors so callers can show a toast', async () => {
+      vi.mocked(commands.deleteQueueItem).mockRejectedValueOnce(
+        new Error('Cannot delete download xyz — currently active. Cancel it first.'),
+      );
+
+      await expect(useDownloadStore.getState().deleteItem('xyz')).rejects.toThrow(
+        /currently active/,
+      );
     });
   });
 

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -201,6 +201,19 @@ interface DownloadState {
   retryWithoutWrapper: (downloadId: string) => Promise<void>;
 
   /**
+   * Remove a single queue item by ID (#685). Refuses active items
+   * (`downloading` / `processing`) — the caller must cancel first; the
+   * Rust backend enforces the same guard for defense-in-depth.
+   *
+   * IPC call: `commands.deleteQueueItem(downloadId)` -> Rust `delete_queue_item`
+   * Refreshes the queue afterwards.
+   *
+   * @param downloadId - UUID of the queue item to remove.
+   * @throws Re-throws the IPC error so callers can show a toast.
+   */
+  deleteItem: (downloadId: string) => Promise<void>;
+
+  /**
    * Remove all completed, failed, and cancelled items from the queue.
    * IPC call: `commands.clearQueue()` -> Rust `clear_queue`
    * Returns the number of items removed. Refreshes the queue afterward.
@@ -484,6 +497,18 @@ export const useDownloadStore = create<DownloadState>((set, get) => ({
     } catch (e) {
       set({ error: String(e) });
     }
+  },
+
+  /**
+   * Remove a single queue item by ID (#685). The backend persists the
+   * change before returning, so the subsequent refresh sees the canonical
+   * post-delete state. Errors are re-thrown so the caller can surface
+   * them as a toast (e.g. "active downloads can't be deleted").
+   */
+  deleteItem: async (downloadId) => {
+    await commands.deleteQueueItem(downloadId);
+    const status = await commands.getQueueStatus();
+    set({ queueItems: status.items });
   },
 
   /**


### PR DESCRIPTION
## Summary

Adds per-item delete to the Download Queue and Download History pages, filling the gap where the only removal options were bulk Clear Finished / Clear All / Clear History. Common use case: purge a stubbornly-failing entry without nuking the rest.

Closes #685.

## Behaviour

**Queue**
- Right-click on a non-active row → `Delete` removes that single item; persisted across restart.
- The Rust backend refuses to delete `Downloading` / `Processing` items (the user must `Cancel` first) — the active-state guard prevents orphaning a live GAMDL subprocess.
- Frontend hides the menu entry for active rows for UX honesty; the Rust guard is defense-in-depth against a context-menu race (state changed between menu open and click).
- Confirmation modal before destructive action.
- Activity log entry: `[System] Removed queue item [<id-prefix>]`.

**History**
- Right-click on any row → `Delete` removes that single entry; persisted across restart.
- Confirmation modal before destructive action.
- Files on disk are never touched — only the history record metadata.

## Tests

- **Rust:** 8 new unit tests in `download_queue::tests::delete_*`. All 4 terminal states (Queued / Complete / Cancelled / Error) round-trip; both active states (Downloading / Processing) are refused; unknown ID is a no-op; multi-item targeting hits only the named ID.
- **Frontend:** 2 new tests in `downloadStore.test.ts::deleteItem` covering happy path + error propagation.
- Full Rust suite: 951 passed / 0 failed.
- Frontend suite: 305 passed / 0 failed.
- `cargo clippy --lib -- -D warnings`: clean.
- `tsc --noEmit`: clean.
- `eslint` on touched files: clean.
- `npm run build`: passes.

## Out of scope

- Multi-select / range delete (separate enhancement).
- Undo for per-item delete (existing `Clear All` undo buffer doesn't extend here for v1).
- Deleting downloaded files from disk — the rows are metadata-only; the audio is untouched.

## Test plan

- [ ] Right-click a queued item → Delete → confirmation modal appears
- [ ] Right-click an errored item → Delete → row disappears, persists across restart
- [ ] Right-click a downloading item → Delete entry is hidden (Cancel must be used first)
- [ ] Right-click a history row → Delete → row disappears, on-disk audio is preserved
- [ ] Confirmation modal can be cancelled (Esc + Cancel button)
- [ ] Activity log shows `[System] Removed queue item [<id>]`
- [ ] Existing Clear Finished / Clear All / Clear History still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)