### PR TITLE
perf: cache version-detection regexes on hot paths (#688)

### DIFF
--- a/src-tauri/src/services/dependency_manager.rs
+++ b/src-tauri/src/services/dependency_manager.rs
@@ -50,6 +50,7 @@
 // - Tokio async filesystem operations: https://docs.rs/tokio/latest/tokio/fs/
 
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use tauri::AppHandle;
 
 // `archive` provides download_and_extract() for streaming HTTP download + archive extraction,
@@ -106,6 +107,32 @@ fn load_mirror_config() -> Option<MirrorConfig> {
     toml::from_str(&toml::to_string(mirror_table).ok()?).ok()
 }
 
+// Regex caches.
+//
+// Compiling a regex involves parsing the pattern + building an NFA, costing
+// hundreds of microseconds. Tool-version probing runs at every startup and
+// on every "Check for updates" click, so per-call compilation is wasted
+// work that adds up across a session. Each pattern is compiled once via
+// `LazyLock` and reused for the rest of the process lifetime — same shape
+// as `apple_music_api::parse_apple_music_url` and `process::ERROR_PREFIX_REGEX`.
+//
+// All patterns are static literals with no user input, so `.expect()` on
+// `Regex::new` only fires on developer typos at boot — never at runtime.
+static VERSION_TUPLE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(\d+)\.(\d+)(?:\.(\d+))?").expect("static regex"));
+static SEMVER_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(\d+\.\d+(?:\.\d+)?)").expect("static regex"));
+static MP4BOX_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?:GPAC|version)\s+(\d+\.\d+(?:\.\d+)?)").expect("static regex")
+});
+static MP4DECRYPT_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"Bento4 Version (\d+\.\d+\.\d+)").expect("static regex")
+});
+static NM3U8DL_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"v?(\d+\.\d+\.\d+)").expect("static regex"));
+static MEDIAINFO_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"v(\d+\.\d+)").expect("static regex"));
+
 /// Parses a version string into (major, minor, patch) components.
 ///
 /// Handles various formats:
@@ -114,9 +141,7 @@ fn load_mirror_config() -> Option<MirrorConfig> {
 ///   - "2.4-DEV" → (2, 4, 0)
 ///   - "N-112479-..." → None (`FFmpeg` nightly builds without numeric version)
 fn parse_version_tuple(version_str: &str) -> Option<(u32, u32, u32)> {
-    // Use regex to extract the first version-like pattern (digits.digits[.digits])
-    let re = regex::Regex::new(r"(\d+)\.(\d+)(?:\.(\d+))?").ok()?;
-    let caps = re.captures(version_str)?;
+    let caps = VERSION_TUPLE_RE.captures(version_str)?;
 
     let major: u32 = caps.get(1)?.as_str().parse().ok()?;
     let minor: u32 = caps.get(2)?.as_str().parse().ok()?;
@@ -151,13 +176,11 @@ fn extract_version_from_output(output: &str, tool_id: &str) -> Option<String> {
                 // Nightly build — can't reliably compare, accept as compatible
                 return Some("nightly".to_string());
             }
-            let re = regex::Regex::new(r"(\d+\.\d+(?:\.\d+)?)").ok()?;
-            Some(re.find(after_version)?.as_str().to_string())
+            Some(SEMVER_RE.find(after_version)?.as_str().to_string())
         }
         "mp4box" => {
             // MP4Box: "MP4Box - GPAC version 2.4-DEV..." or "GPAC version 2.4..."
-            let re = regex::Regex::new(r"(?:GPAC|version)\s+(\d+\.\d+(?:\.\d+)?)").ok()?;
-            let caps = re.captures(first_line)?;
+            let caps = MP4BOX_RE.captures(first_line)?;
             Some(caps.get(1)?.as_str().to_string())
         }
         "mp4decrypt" => {
@@ -165,29 +188,24 @@ fn extract_version_from_output(output: &str, tool_id: &str) -> Option<String> {
             //   MP4 Decrypter - Version 1.4
             //   (Bento4 Version 1.6.0.0)
             // Extract the Bento4 version from the full output.
-            let re = regex::Regex::new(r"Bento4 Version (\d+\.\d+\.\d+)").ok()?;
-            let caps = re.captures(output)?;
+            let caps = MP4DECRYPT_RE.captures(output)?;
             Some(caps.get(1)?.as_str().to_string())
         }
         "nm3u8dlre" => {
             // N_m3u8DL-RE: "N_m3u8DL-RE version 0.5.1-beta" or just "v0.5.1-beta"
-            let re = regex::Regex::new(r"v?(\d+\.\d+\.\d+)").ok()?;
-            let caps = re.captures(first_line)?;
+            let caps = NM3U8DL_RE.captures(first_line)?;
             Some(caps.get(1)?.as_str().to_string())
         }
         "mediainfo" => {
             // MediaInfo: "MediaInfo Command line,\nMediaInfoLib - v26.01"
             // The version is on the second line, but first_line may be the first.
             // Try to find "v{major}.{minor}" anywhere in the output.
-            let full_output = output;
-            let re = regex::Regex::new(r"v(\d+\.\d+)").ok()?;
-            let caps = re.captures(full_output)?;
+            let caps = MEDIAINFO_RE.captures(output)?;
             Some(caps.get(1)?.as_str().to_string())
         }
         _ => {
             // Generic: try to find any version-like pattern
-            let re = regex::Regex::new(r"(\d+\.\d+(?:\.\d+)?)").ok()?;
-            Some(re.find(first_line)?.as_str().to_string())
+            Some(SEMVER_RE.find(first_line)?.as_str().to_string())
         }
     }
 }

--- a/src-tauri/src/services/update_checker.rs
+++ b/src-tauri/src/services/update_checker.rs
@@ -52,7 +52,19 @@
 // - Chrono for timestamps: https://docs.rs/chrono/latest/chrono/
 
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use tauri::AppHandle;
+
+// Cached semver-extraction regex.
+//
+// `check_component_update` runs on every app startup, every periodic update
+// poll, and every manual "Check for updates" click. Compiling this trivial
+// pattern per call wastes microseconds on a hot path; caching once via
+// `LazyLock` matches the pattern used in `apple_music_api.rs` and
+// `process.rs`. Pattern is a static literal so `.expect()` only fires on
+// developer typos at boot — never at runtime.
+static SEMVER_EXTRACT_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(\d+\.\d+(?:\.\d+)?)").expect("static regex"));
 
 // gamdl_service: provides get_gamdl_version() and check_latest_gamdl_version() for GAMDL update checks.
 // python_manager: provides get_installed_python_version() and get_target_python_version() for Python update checks.
@@ -1062,10 +1074,8 @@ async fn check_github_tool_update(
     // or "autobuild-2024-12-19", which can't be compared numerically.
     // Others (e.g., nilaoda/N_m3u8DL-RE) use "v0.5.1-beta" — we strip
     // the pre-release suffix to match how extract_version_from_output() works.
-    let semver_re = regex::Regex::new(r"(\d+\.\d+(?:\.\d+)?)").ok();
-    let latest_semver = semver_re
-        .as_ref()
-        .and_then(|re| re.find(&latest_tag))
+    let latest_semver = SEMVER_EXTRACT_RE
+        .find(&latest_tag)
         .map(|m| m.as_str().to_string());
 
     let latest_version = if latest_tag.is_empty() {
@@ -1312,13 +1322,13 @@ mod tests {
         assert!(UpdateChannel::from_tag("v1.0.0") >= user);
         assert!(UpdateChannel::from_tag("v1.0.0-rc.1") >= user);
         assert!(UpdateChannel::from_tag("v1.0.0-beta.1") >= user);
-        assert!(!(UpdateChannel::from_tag("v1.0.0-alpha.1") >= user));
-        assert!(!(UpdateChannel::from_tag("v1.0.0-nightly.20260101") >= user));
+        assert!(UpdateChannel::from_tag("v1.0.0-alpha.1") < user);
+        assert!(UpdateChannel::from_tag("v1.0.0-nightly.20260101") < user);
 
         let user = UpdateChannel::Stable;
         assert!(UpdateChannel::from_tag("v1.0.0") >= user);
-        assert!(!(UpdateChannel::from_tag("v1.0.0-rc.1") >= user));
-        assert!(!(UpdateChannel::from_tag("v1.0.0-beta.1") >= user));
+        assert!(UpdateChannel::from_tag("v1.0.0-rc.1") < user);
+        assert!(UpdateChannel::from_tag("v1.0.0-beta.1") < user);
     }
 
     /// requires_dev_access() should return true only for the four channels

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -2156,13 +2156,10 @@ mod tests {
         // `track_total`); it should surface as `Unknown` so the
         // activity log still displays the raw line.
         let line = "[INFO     12:00:02] [Track   1/-  ] Downloading \"Flowers\"";
-        match parse_gamdl_output(line) {
-            GamdlOutputEvent::TrackInfo { .. } => {
-                panic!("Track N/- must not parse as TrackInfo with numeric total");
-            }
-            // Any other event variant is acceptable — the contract is
-            // "don't silently record a wrong track_total".
-            _ => {}
+        // Any non-TrackInfo variant is acceptable — the contract is
+        // "don't silently record a wrong track_total".
+        if let GamdlOutputEvent::TrackInfo { .. } = parse_gamdl_output(line) {
+            panic!("Track N/- must not parse as TrackInfo with numeric total");
         }
     }
 
@@ -2339,11 +2336,8 @@ mod tests {
         // something similar ever does land in stdout it doesn't silently
         // populate a bogus track counter.
         let line = "[INFO     12:00:01] Processing album \"Midnights (3am Edition)\"";
-        match parse_gamdl_output(line) {
-            GamdlOutputEvent::TrackInfo { .. } => {
-                panic!("Album-wrapper line must not parse as TrackInfo");
-            }
-            _ => {}
+        if let GamdlOutputEvent::TrackInfo { .. } = parse_gamdl_output(line) {
+            panic!("Album-wrapper line must not parse as TrackInfo");
         }
     }
 
@@ -2352,11 +2346,8 @@ mod tests {
         // Same guard as the album case, for playlists. The `[URL N/M]`
         // prefix is for URL-level progress, not per-track.
         let line = "[INFO     12:00:01] [URL   1/1  ] Processing \"https://music.apple.com/.../pl.abc\"";
-        match parse_gamdl_output(line) {
-            GamdlOutputEvent::TrackInfo { .. } => {
-                panic!("URL-wrapper line must not parse as TrackInfo");
-            }
-            _ => {}
+        if let GamdlOutputEvent::TrackInfo { .. } = parse_gamdl_output(line) {
+            panic!("URL-wrapper line must not parse as TrackInfo");
         }
     }
 
@@ -2496,11 +2487,8 @@ mod tests {
             let content = load_v32_fixture(name);
             for line in content.lines() {
                 if line.contains("[URL") && line.contains("Processing") {
-                    match parse_gamdl_output(line) {
-                        GamdlOutputEvent::TrackInfo { .. } => {
-                            panic!("URL-context line from {name} must not parse as TrackInfo: {line}");
-                        }
-                        _ => {}
+                    if let GamdlOutputEvent::TrackInfo { .. } = parse_gamdl_output(line) {
+                        panic!("URL-context line from {name} must not parse as TrackInfo: {line}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Post-#685 code-quality + performance sweep. Two perf fixes on hot Rust paths plus a clippy cleanup so the test tree builds clean under \`-D warnings\`. Three larger findings deferred to dedicated follow-up issues with full root-cause analysis.

Closes #688.

## Audit methodology

Launched two parallel read-only investigations (one per layer) to gather findings:

| Audit | Findings | Severity breakdown |
| --- | --- | --- |
| React memory + perf | 5 | 1 bug, 4 smells |
| Rust async + perf | 4 | 2 bugs, 2 smells |
| Clippy \`-D warnings\` baseline | 8 | All test-only |

Each finding was independently verified against the code before either being fixed in this PR or filed as a follow-up. Two were dismissed as false positives during verification (see \"Dismissed\" below).

## Fixes landed in this PR

### Perf — Rust regex caching (hot paths)

\`dependency_manager.rs::parse_version_tuple\` and \`extract_version_from_output\` compiled six distinct \`regex::Regex::new(...)\` calls fresh on every invocation. Both run on every app startup and every \"Check for updates\" click. Hoisted to \`LazyLock\` statics — same pattern as \`apple_music_api::parse_apple_music_url\` and \`process::ERROR_PREFIX_REGEX\`.

\`update_checker.rs::check_component_update\` had the same shape — a per-call semver-extract regex. Hoisted to a single \`SEMVER_EXTRACT_RE\`.

Net: 7 per-call regex compiles → 0. Each hot path spends only the cached lookup cost going forward.

### Clippy — test-tree warnings (8 total)

\`cargo clippy --all-targets\` previously emitted 8 warnings, all in test code:

- \`update_checker.rs\`: 4 nested-not asserts (\`assert!(!(x >= y))\`) rewritten as \`assert!(x < y)\` — what they actually mean.
- \`process.rs\`: 4 single-arm \`match\` blocks rewritten as \`if let\`.

After this PR: \`cargo clippy --all-targets -- -D warnings\` is clean.

## Deferred to follow-up issues

Three findings with enough design surface to deserve their own PR + review focus, all filed with full RCA:

- **#689** — QueueItem render memoization with field-aware comparator. Naive \`React.memo\` won't help: IPC polling deserializes JSON on every 3 s tick, producing fresh \`item\` references for every row regardless of content. Needs a custom comparator over rendering-affecting fields, plus \`useCallback\` on all 8 parent handlers in DownloadQueue.tsx.
- **#690** — Cache settings in AppState to avoid disk reads on the completion hot path. Two paths in \`download_queue.rs\` reload \`settings.json\` per terminal item; on a 50-item batch that's 50 sequential reads.
- **#691** — ActivityLog incremental filter algorithm. Filter is currently O(n) per RAF-batched ingestion tick; under verbose batch downloads this dominates the React render budget.

## Dismissed as false positives during verification

- **HistoryPage \"double-fetch\" on every keystroke.** The audit flagged a \`useEffect\` re-run from \`loadEntries\` being recreated when \`searchQuery\` changed. Verified: the effect's \`return () => clearTimeout(timer)\` cleanup correctly cancels the prior debounce timer before the new one is scheduled. Behaviour is correct as-is.
- **Inline arrow callback \`() => addToast(...)\` in DownloadQueue.tsx \`.map()\`.** Without \`React.memo\` on \`QueueItem\` (deferred to #689), an unstable callback identity has no measurable effect — the child re-renders on every parent render anyway. Bundling this fix without #689 would be cargo-cult.

## Verification

| Check | Result |
| --- | --- |
| \`cargo clippy --all-targets -- -D warnings\` | ✅ clean |
| \`cargo test --lib\` | ✅ 951 / 0 |
| \`tsc --noEmit\` | ✅ clean |
| Frontend tests (\`npm run test\`) | ✅ 305 / 0 |
| ESLint on touched files | ✅ clean |

## Test plan

- [ ] App starts cleanly; setup wizard's tool-version probe works.
- [ ] \"Check for updates\" returns expected GAMDL / FFmpeg / mp4decrypt / N_m3u8DL-RE / MP4Box / MediaInfo versions.
- [ ] Channel-filter promotion still works (Beta user sees Beta+RC+Stable; Stable user sees only Stable).
- [ ] No CI regressions in the GAMDL output classifier (the 4 \`if let\` rewrites preserve semantics 1:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)