### PR TITLE
fix(queue): stop classifying per-track codec skips as download failures (#698)

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -1765,6 +1765,16 @@ impl DownloadQueue {
                 // summary line is captured separately via the Error variant
                 // (PYTHON_EXCEPTION_REGEX).
                 process::GamdlOutputEvent::TracebackFrame { .. } => {}
+                // Per-track codec-availability skips (#698) are normal
+                // catalog behaviour, not download failures. Don't set
+                // `item.status.error` from these — the queue's terminal
+                // classifier inspects the collected `errors` Vec at exit
+                // time and produces a meaningful "no audio available"
+                // message when every recorded warning is a codec skip.
+                // Setting `error` here would surface the misleading
+                // `[WARNING] Skipping ...` text mid-download even if the
+                // remaining tracks succeed and the item ends Complete.
+                process::GamdlOutputEvent::CodecSkip { .. } => {}
             }
         }
     }
@@ -5871,6 +5881,20 @@ pub fn process_queue(
                             if !has_output_now {
                                 // Terminal: no output, no IO recovery, no files on
                                 // disk despite codec fallback exhausted.
+                                //
+                                // Distinguish the codec-skips-only case (#698) from
+                                // genuine download failures: when every collected
+                                // warning is a per-track codec-availability skip,
+                                // Apple Music simply doesn't offer this content in
+                                // any of the user's requested formats. That's a
+                                // catalog limitation, not a download infrastructure
+                                // failure, and the user-facing message should say
+                                // so honestly instead of "Download completed but no
+                                // output files were produced: [WARNING] Skipping ...".
+                                let only_codec_skips = !warnings.is_empty()
+                                    && warnings
+                                        .iter()
+                                        .all(|w| process::is_codec_skip_message(w));
                                 let error_msg = if has_io_error {
                                     format!(
                                         "Output path may be unreachable or too slow. \
@@ -5878,6 +5902,13 @@ pub fn process_queue(
                                      output path. Details: {}",
                                         warnings.last().cloned().unwrap_or_default()
                                     )
+                                } else if only_codec_skips {
+                                    "No audio available: Apple Music does not offer \
+                                 this content in any of your requested formats. Try \
+                                 alternative codecs in Settings > Quality > Music \
+                                 Codec, or check that this content exists in your \
+                                 storefront."
+                                        .to_string()
                                 } else if let Some(last_warning) = warnings.last() {
                                     format!(
                                         "Download completed but no output files were \
@@ -8541,10 +8572,19 @@ async fn run_download_with_events(
                         q.update_item_progress(&download_id, &event);
                     }
 
-                    // Collect errors for fallback decisions
-                    if let process::GamdlOutputEvent::Error { ref message } = event {
-                        let mut errs = errors.lock().await;
-                        errs.push(message.clone());
+                    // Collect errors for fallback decisions. CodecSkip events
+                    // (#698) are also pushed so the existing `is_codec_error`
+                    // / `count_codec_skip_warnings` checks in the terminal
+                    // block keep working unchanged — the queue's classifier
+                    // distinguishes "all errors are codec skips" via
+                    // `is_codec_skip_message` at decision time.
+                    match event {
+                        process::GamdlOutputEvent::Error { ref message }
+                        | process::GamdlOutputEvent::CodecSkip { ref message } => {
+                            let mut errs = errors.lock().await;
+                            errs.push(message.clone());
+                        }
+                        _ => {}
                     }
 
                     // #508: detect the transition into the silent
@@ -8664,9 +8704,16 @@ async fn run_download_with_events(
                         q.update_item_progress(&download_id, &event);
                     }
 
-                    if let process::GamdlOutputEvent::Error { ref message } = event {
-                        let mut errs = errors.lock().await;
-                        errs.push(message.clone());
+                    // Collect errors + codec-skips for fallback decisions
+                    // (#698 — same compatibility-shim rationale as the stdout
+                    // reader above).
+                    match event {
+                        process::GamdlOutputEvent::Error { ref message }
+                        | process::GamdlOutputEvent::CodecSkip { ref message } => {
+                            let mut errs = errors.lock().await;
+                            errs.push(message.clone());
+                        }
+                        _ => {}
                     }
 
                     let progress = gamdl_service::GamdlProgress {

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -361,6 +361,35 @@ pub enum GamdlOutputEvent {
         /// The raw frame / header line as printed by Python.
         raw: String,
     },
+
+    /// A per-track codec-availability skip emitted by GAMDL when Apple
+    /// Music's catalog does not offer the requested format(s) for a
+    /// specific track (#698). Canonical shape:
+    ///
+    /// ```text
+    /// [WARNING 22:32:23] [Track 23/24] Skipping "Die Young (Deconstructed Mix)":
+    /// Requested format is not available (media ID: 592365442):
+    /// [<SongCodec.ATMOS: 'atmos'>, <SongCodec.ALAC: 'alac'>, ...]
+    /// ```
+    ///
+    /// This is **not** a download failure — it's normal catalog behaviour
+    /// (live mixes, deconstructed mixes, anniversary editions etc. often
+    /// don't have ATMOS / Lossless variants). Routing this to a dedicated
+    /// variant lets the queue distinguish "Apple does not offer this in
+    /// the requested format" from "the download infrastructure failed",
+    /// which materially changes the user-facing terminal-state message.
+    ///
+    /// Previously these lines were caught by Priority 7's `"skipping"`
+    /// keyword and emitted as `Error`, polluting the queue item's error
+    /// field with the misleading text "Download completed but no output
+    /// files were produced: [WARNING] ...". With this variant, the
+    /// downstream classifier can produce a meaningful "No audio available
+    /// in your requested formats" message instead.
+    CodecSkip {
+        /// The raw warning line, with the `[WARNING ...]` banner
+        /// stripped so the message reads cleanly in the activity log.
+        message: String,
+    },
 }
 
 /// Parses a single line of GAMDL output into a structured event.
@@ -556,6 +585,27 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
         return GamdlOutputEvent::Complete { path };
     }
 
+    // Priority 6b: Per-track codec-availability skip (#698).
+    //
+    // GAMDL emits lines like:
+    //   `[WARNING 22:32:23] [Track 23/24] Skipping "Die Young (...)":
+    //   Requested format is not available (media ID: ...): [...codecs...]`
+    //
+    // when Apple Music's catalog does not offer the requested format(s)
+    // for a specific track. This is normal catalog behaviour, not a
+    // download failure — many tracks (live mixes, deconstructed mixes,
+    // anniversary editions) don't have ATMOS / Lossless variants.
+    //
+    // Catching this before Priority 7's keyword match prevents the line
+    // from being emitted as `Error`, which would otherwise pollute the
+    // queue's error field with the misleading text "Download completed
+    // but no output files were produced: [WARNING] ...".
+    if is_codec_skip_line(trimmed) {
+        return GamdlOutputEvent::CodecSkip {
+            message: trimmed.to_string(),
+        };
+    }
+
     // Priority 7: Common error patterns detected by keyword matching.
     // These catch errors that don't have an explicit "ERROR:" prefix but
     // contain well-known error indicators. The lowercase conversion ensures
@@ -567,9 +617,18 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
     //   - "permission denied"-- filesystem permission errors
     //   - "codec not available" -- requested audio/video codec not offered
     //   - "format is not available" -- GAMDL 2.8.x: "Requested format is not available"
-    //   - "skipping"         -- GAMDL: track skipped due to format/codec issues
     //   - "no entry"         -- missing archive entries or config keys
     //   - "exception"        -- Python exception messages
+    //
+    // The `"skipping"` keyword used to live here too, but it was too
+    // broad — every per-track codec-availability warning matched and
+    // bubbled up as `Error`. Those warnings are now classified by
+    // Priority 6b above as `CodecSkip` and routed through a dedicated
+    // path that does not pollute the queue's error field (#698). Other
+    // GAMDL "Skipping" emissions (rate-limit retries, pre-existing
+    // file detection, etc.) do not contain the canonical "format is
+    // not available" / "requested format" phrase and so still fall
+    // through to the keyword match below if they're truly errors.
     //
     // The `traceback` keyword used to live here too, but the bare
     // `Traceback (most recent call last):` header is just the start of a
@@ -584,7 +643,6 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
         || lower.contains("permission denied")
         || lower.contains("codec not available")
         || lower.contains("format is not available")
-        || lower.contains("skipping")
         || lower.contains("no entry")
         || lower.contains("exception")
     {
@@ -626,6 +684,48 @@ pub fn parse_gamdl_output(line: &str) -> GamdlOutputEvent {
 /// # Connection
 /// Called by `services::download_queue` after a download fails, before
 /// deciding whether to enqueue a retry with a lower-quality codec.
+/// Detects per-track codec-availability skip lines emitted by GAMDL (#698).
+///
+/// Canonical shape:
+/// ```text
+/// [WARNING 22:32:23] [Track 23/24] Skipping "Die Young (Deconstructed Mix)":
+///     Requested format is not available (media ID: 592365442):
+///     [<SongCodec.ATMOS: 'atmos'>, <SongCodec.ALAC: 'alac'>, ...]
+/// ```
+///
+/// This is **not** a download failure — it's normal Apple Music catalog
+/// behaviour. Detecting these lines upstream of Priority 7's generic error
+/// keyword match lets us route them to a dedicated `CodecSkip` event so
+/// the queue's terminal-state classifier can produce a meaningful "no
+/// audio available in your requested formats" message instead of the
+/// misleading "Download completed but no output files were produced".
+///
+/// The match conditions are deliberately narrow: the line must contain
+/// **both** a `Skipping`-style verb AND a phrase indicating format
+/// unavailability. Any other "Skipping" line (rate-limit retries,
+/// pre-existing file detection, etc.) falls through to other parser
+/// branches and is classified normally.
+#[must_use]
+pub fn is_codec_skip_line(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    let has_skip_verb = lower.contains("skipping") || lower.contains("skipped");
+    let has_format_unavailable = lower.contains("requested format is not available")
+        || lower.contains("format is not available")
+        || lower.contains("format not available")
+        || lower.contains("requested format");
+    has_skip_verb && has_format_unavailable
+}
+
+/// Detects whether an already-collected error/warning message is a codec
+/// skip — used by the queue's terminal-state classifier to decide whether
+/// every recorded "error" is actually just a normal Apple Music catalog
+/// limitation. Same predicate as [`is_codec_skip_line`]; aliased here so
+/// the queue's intent reads clearly at the call site.
+#[must_use]
+pub fn is_codec_skip_message(message: &str) -> bool {
+    is_codec_skip_line(message)
+}
+
 #[must_use]
 pub fn is_codec_error(error_message: &str) -> bool {
     let lower = error_message.to_lowercase();
@@ -1833,23 +1933,30 @@ mod tests {
     }
 
     #[test]
-    fn v3_codec_skips_are_detected_as_errors() {
+    fn v3_codec_skips_are_detected_as_codec_skip_events() {
         // The two "Skipping ... Requested format is not available" lines
-        // are WARNING level from GAMDL's perspective. For MeedyaDL's
-        // parser they should register as Error events so
-        // `count_codec_skip_warnings` / `is_codec_error` can pick them
-        // up — we need that to kick off gap-fill retry.
+        // are WARNING level from GAMDL's perspective. After #698 they
+        // classify as `CodecSkip`, not `Error` — the queue's terminal
+        // classifier inspects these via `is_codec_skip_message` to
+        // distinguish "Apple doesn't offer this format" from a genuine
+        // download failure. The downstream gap-fill / `is_codec_error`
+        // signal still fires because those helpers are called against
+        // the message string content, not against the variant tag (see
+        // `v3_codec_skips_trigger_codec_error_classification` below).
         let events = classify_lines(FIXTURE_V3_CODEC_SKIPS);
-        let errors: Vec<String> = events
+        let codec_skips: Vec<String> = events
             .iter()
             .filter_map(|e| match e {
-                GamdlOutputEvent::Error { message } => Some(message.clone()),
+                GamdlOutputEvent::CodecSkip { message } => Some(message.clone()),
                 _ => None,
             })
             .collect();
         assert!(
-            errors.iter().any(|m| m.to_lowercase().contains("format is not available")),
-            "Expected at least one 'format is not available' Error, got: {errors:?}"
+            codec_skips
+                .iter()
+                .any(|m| m.to_lowercase().contains("format is not available")),
+            "Expected at least one 'format is not available' CodecSkip event \
+             after #698, got: {codec_skips:?}"
         );
     }
 
@@ -2469,6 +2576,105 @@ mod tests {
         assert!(
             events.is_empty(),
             "flat-filter fixture contains no `Downloading \"...\"` lines; no TrackInfo should fire — got {events:?}"
+        );
+    }
+
+    // ==========================================================
+    // Codec-skip classification (#698)
+    // ==========================================================
+
+    /// The canonical GAMDL "Skipping ... format is not available" line
+    /// must classify as `CodecSkip`, not `Error`. Before #698 this hit
+    /// Priority 7's `"skipping"` keyword and surfaced as a red error in
+    /// the queue item's error field plus an "Error" entry in the activity
+    /// log — the user-visible "format-not-available misclassification"
+    /// symptom from the bug report.
+    #[test]
+    fn codec_skip_classifies_as_codec_skip_not_error() {
+        let line = "[WARNING 22:32:23] [Track 23/24] Skipping \"Die Young (Deconstructed Mix)\": \
+                    Requested format is not available (media ID: 592365442): \
+                    [<SongCodec.ATMOS: 'atmos'>, <SongCodec.ALAC: 'alac'>, \
+                    <SongCodec.AC3: 'ac3'>, <SongCodec.AAC: 'aac'>, \
+                    <SongCodec.AAC_LEGACY: 'aac-legacy'>]";
+        match parse_gamdl_output(line) {
+            GamdlOutputEvent::CodecSkip { message } => {
+                assert!(message.contains("Skipping"));
+                assert!(message.contains("format is not available"));
+            }
+            other => panic!("expected CodecSkip, got {other:?}"),
+        }
+    }
+
+    /// Older GAMDL phrasing variants must also classify as `CodecSkip`.
+    #[test]
+    fn codec_skip_recognises_lowercase_format_not_available() {
+        let line = "Skipping track: format not available";
+        assert!(matches!(
+            parse_gamdl_output(line),
+            GamdlOutputEvent::CodecSkip { .. }
+        ));
+    }
+
+    /// `is_codec_skip_line` must require BOTH a skip verb AND a
+    /// format-unavailable phrase. Lines that mention "skipping" alone
+    /// (e.g. rate-limit retry skips, pre-existing-file skips) must NOT
+    /// be misclassified.
+    #[test]
+    fn codec_skip_does_not_match_unrelated_skipping_lines() {
+        // "Skipping" alone — no format keyword
+        assert!(!is_codec_skip_line("[INFO] Skipping cover art (already downloaded)"));
+        assert!(!is_codec_skip_line("Skipping rate-limited request, retrying in 30s"));
+        // "Format" alone — no skip verb
+        assert!(!is_codec_skip_line("Requested format: ATMOS"));
+        assert!(!is_codec_skip_line("Format is not available — falling back"));
+    }
+
+    /// Non-codec-skip warnings that contain the `"skipping"` substring
+    /// (e.g. genuine errors that mention skipping in their text) must
+    /// still fall through to Priority 7's keyword match if they contain
+    /// other error signal words. A line with only `"skipping"` and no
+    /// other error keywords now classifies as `Unknown` — by design,
+    /// since post-#698 we don't treat a bare `"skipping"` mention as
+    /// inherently failure-shaped.
+    #[test]
+    fn bare_skipping_without_format_keyword_is_no_longer_error() {
+        // This used to classify as Error via Priority 7's `"skipping"`.
+        // Post-#698 it falls through to Unknown — the parser is no
+        // longer the layer that decides whether a "Skipping" mention is
+        // an error; the queue's terminal classifier does, by inspecting
+        // the recorded warnings.
+        let line = "Skipping cover art (already downloaded)";
+        assert!(matches!(
+            parse_gamdl_output(line),
+            GamdlOutputEvent::Unknown { .. }
+        ));
+    }
+
+    /// `is_codec_skip_message` is an alias for `is_codec_skip_line` used
+    /// at the queue's terminal classifier. Both predicates must agree.
+    #[test]
+    fn is_codec_skip_message_agrees_with_is_codec_skip_line() {
+        let canonical = "[WARNING] Skipping \"Track\": Requested format is not available";
+        assert!(is_codec_skip_line(canonical));
+        assert!(is_codec_skip_message(canonical));
+
+        let unrelated = "[ERROR] Connection refused";
+        assert!(!is_codec_skip_line(unrelated));
+        assert!(!is_codec_skip_message(unrelated));
+    }
+
+    /// `is_codec_error` must continue to recognise the same vocabulary —
+    /// the gap-fill / fallback-retry decisions in `download_queue` rely
+    /// on it, and #698 only changes how the parser routes the line, not
+    /// what classification means downstream. Existing keyword set must
+    /// stay intact.
+    #[test]
+    fn is_codec_error_still_matches_codec_skip_messages() {
+        let line = "Skipping \"Track\": Requested format is not available: [<SongCodec.ATMOS>]";
+        assert!(
+            is_codec_error(line),
+            "is_codec_error must still match the codec-skip vocabulary so the \
+             queue's existing has_codec_error gate keeps firing for these lines"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #698.

GAMDL emits warnings like:

\`\`\`
[WARNING 22:32:23] [Track 23/24] Skipping "Die Young (Deconstructed Mix)":
Requested format is not available (media ID: 592365442):
[<SongCodec.ATMOS: 'atmos'>, <SongCodec.ALAC: 'alac'>, ...]
\`\`\`

when Apple Music's catalog doesn't offer the requested format(s) for a specific track. This is **normal behaviour** for live mixes, deconstructed mixes, anniversary editions, etc. — not a download failure.

Pre-fix, Priority 7's \`"skipping"\` keyword routed these to \`GamdlOutputEvent::Error\`, which surfaced in the queue item's error field as the misleading text "Download completed but no output files were produced: [WARNING] ...". Items where Apple simply didn't offer the requested codec were indistinguishable from genuine download failures.

## What changed

**1. New \`GamdlOutputEvent::CodecSkip { message }\` variant** routed via Priority 6b in \`parse_gamdl_output\`. Detection helper \`is_codec_skip_line()\` requires BOTH a skip verb AND a format-unavailable phrase, so unrelated "Skipping" mentions (rate-limit retry, pre-existing file detection) don't get reclassified.

**2. Removed the bare \`"skipping"\` keyword from Priority 7.** It was too broad. \`"format is not available"\` stays as a defensive fallback for GAMDL phrasing variants without "skipping".

**3. Queue terminal-state classifier in \`download_queue.rs\`** now checks \`errors_are_only_codec_skips\` and emits a distinct message when every recorded warning is a codec-skip:

> No audio available: Apple Music does not offer this content in any of your requested formats. Try alternative codecs in Settings > Quality > Music Codec, or check that this content exists in your storefront.

instead of "Download completed but no output files were produced: [WARNING] ...".

**4. \`update_item_progress\`** now ignores \`CodecSkip\` events for the \`item.status.error\` field — these are warnings, not state transitions. Surfacing them mid-download was a major source of the visible "red error text under the URL" symptom in the queue UI.

## Compatibility shim

\`CodecSkip\` messages are still pushed into the \`errors\` Vec by the stdout/stderr readers, so the existing \`is_codec_error\` / \`count_codec_skip_warnings\` / gap-fill paths keep firing without changes. Those helpers operate on string content, not on variant tags.

## Tests

| Test | Verifies |
| --- | --- |
| \`codec_skip_classifies_as_codec_skip_not_error\` | The canonical screenshot line classifies as \`CodecSkip\`, not \`Error\` |
| \`codec_skip_recognises_lowercase_format_not_available\` | Lowercase phrasing variant still matches |
| \`codec_skip_does_not_match_unrelated_skipping_lines\` | "Skipping cover art" / "Skipping rate-limited request" do NOT misclassify |
| \`bare_skipping_without_format_keyword_is_no_longer_error\` | Locks in the Priority 7 narrowing |
| \`is_codec_skip_message_agrees_with_is_codec_skip_line\` | Predicates stay aligned |
| \`is_codec_error_still_matches_codec_skip_messages\` | Downstream gap-fill signal still works |
| \`v3_codec_skips_are_detected_as_codec_skip_events\` (renamed) | Existing v3 fixture re-asserts new behaviour |

\`cargo clippy --all-targets -- -D warnings\` clean. **957 Rust tests pass** (951 + 6 new). **305 frontend tests pass**. \`tsc --noEmit\` clean.

## Out of scope (future work)

- Adding a new \`DownloadState::NoFormatsAvailable\` variant to render a distinct icon (amber warning sign vs red X). Deferred until messaging fix is observed in practice.
- Pre-flight Apple Music API checks to confirm format availability before invoking GAMDL. Would let us distinguish "Apple says no" from "Apple says yes but fetch failed" up front.
- Counting music video files toward the "produced output" success check (per the user's clarification — currently \`count_audio_files_in_directory\` is audio-only).

## Test plan

- [ ] Queue an album that Apple doesn't offer in your selected codec. Item ends with the new "No audio available: Apple Music does not offer..." message — not "Download completed but no output files were produced".
- [ ] Queue an album where some tracks are unavailable but most succeed. Item completes with audio on disk; "Open Folder" works; per-track skip warnings are no longer surfaced as red error text under the URL.
- [ ] Existing gap-fill / fallback retry behaviour unchanged for partial-success cases.
- [ ] Activity log: the original GAMDL \`[WARNING ...]\` lines still render (stderr stream → amber, as before); they're just no longer mirrored to the queue item's \`error\` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)