### PR TITLE
ci(changelog): regenerate from clean state on each retry attempt (#700)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -146,31 +146,77 @@ jobs:
       # any workflows for this push, providing a second layer of infinite loop prevention.
       #
       # @see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-      # Push is wrapped in a pull-rebase + bounded retry loop to survive the
-      # race where another workflow (e.g. release-please, or a concurrent
-      # changelog run from a fast-follow merge) lands on main between our
-      # checkout and our push. Without the loop, the push is rejected as
-      # non-fast-forward and the job fails cosmetically even though the next
-      # successful run regenerates CHANGELOG.md from scratch anyway.
-      # See https://github.com/MWBMPartners/MeedyaDL/issues/544 for the trigger run.
+      # Push is wrapped in a regenerate-from-scratch + bounded retry loop to
+      # survive the race where another workflow (e.g. release-please, or a
+      # concurrent changelog run from a fast-follow merge) lands on main
+      # between our checkout and our push.
+      #
+      # The earlier retry strategy (#544) used `git pull --rebase` to resolve
+      # the non-fast-forward case, but did not handle a CHANGELOG.md conflict
+      # produced *during* that rebase. When two changelog runs both
+      # regenerated the file from slightly different histories, the rebase
+      # left an unmerged tree, and the next iteration of the loop tripped
+      # on `Pulling is not possible because you have unmerged files` until
+      # the budget was exhausted (#700).
+      #
+      # The fix: every retry iteration starts from a hermetically-clean
+      # state — abort any pending rebase, hard-reset to the latest
+      # origin/main, regenerate CHANGELOG.md from the new history, then
+      # commit and push. Because `git-cliff` is a deterministic function
+      # of `git log`, regenerating against the merged base produces the
+      # correct file content; there is no semantic conflict to resolve.
+      #
+      # `git-cliff` is on $PATH because orhun/git-cliff-action@v4 (the
+      # previous step) installs it and exports the directory via
+      # $GITHUB_PATH. Cargo install fallback isn't needed for this
+      # workflow's invocation pattern.
       - name: Commit changelog
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Probe once: if the action's first regeneration produced no
+          # diff against the checkout, we can short-circuit before the
+          # loop spends an iteration.
           git add CHANGELOG.md
           if git diff --staged --quiet; then
             echo "No changelog changes to commit."
             exit 0
           fi
-          git commit -m "docs: update CHANGELOG.md [skip ci]"
-          for attempt in 1 2 3; do
-            if git pull --rebase --autostash origin main && git push; then
-              echo "Changelog pushed on attempt $attempt."
+          git reset HEAD -- CHANGELOG.md > /dev/null
+
+          for attempt in 1 2 3 4; do
+            # Clean slate: abort any rebase the previous iteration left
+            # behind, then fast-forward the working tree to the current
+            # tip of origin/main. Discards our local CHANGELOG.md edits;
+            # we'll regenerate them in a moment.
+            git rebase --abort 2>/dev/null || true
+            git fetch origin main
+            git reset --hard origin/main
+
+            # Regenerate against the new history. `git-cliff` is
+            # deterministic, so the output is the canonical CHANGELOG.md
+            # for whatever HEAD now points at — no conflict to resolve.
+            git-cliff --config cliff.toml --output CHANGELOG.md
+
+            git add CHANGELOG.md
+            if git diff --staged --quiet; then
+              echo "No changelog changes to commit (attempt ${attempt}) — \
+            another run already pushed an equivalent regeneration."
               exit 0
             fi
+
+            git commit -m "docs: update CHANGELOG.md [skip ci]"
+
+            if git push; then
+              echo "Changelog pushed on attempt ${attempt}."
+              exit 0
+            fi
+
             sleep_seconds=$((attempt * 2))
-            echo "Push attempt $attempt failed; retrying in ${sleep_seconds}s..."
-            sleep "$sleep_seconds"
+            echo "Push attempt ${attempt} failed (likely non-fast-forward — \
+          another push landed); retrying in ${sleep_seconds}s..."
+            sleep "${sleep_seconds}"
           done
-          echo "Push failed after 3 attempts." >&2
+          echo "Push failed after 4 attempts." >&2
           exit 1


### PR DESCRIPTION
## Summary

Closes #700.

The \`changelog.yml\` workflow's **Commit changelog** step was failing intermittently when two changelog runs raced on \`CHANGELOG.md\`. Today's failure ([run 25406767271](https://github.com/MWBMPartners/MeedyaDL/actions/runs/25406767271)) exposed a gap in the existing retry loop (#544): \`git pull --rebase\` produced a conflict, the rebase was left half-applied, and every subsequent iteration tripped on \`Pulling is not possible because you have unmerged files\` until the budget was exhausted.

## What changed

Every retry iteration now starts from a hermetically-clean state:

1. \`git rebase --abort\` (idempotent) — clears any rebase the previous iteration left behind.
2. \`git fetch origin main\` + \`git reset --hard origin/main\` — discards our local commit and the half-merged \`CHANGELOG.md\`.
3. \`git-cliff --config cliff.toml --output CHANGELOG.md\` — regenerates against the new history.
4. Commit and push. If push fails (non-fast-forward), retry from the top.

Since \`git-cliff\` is a deterministic function of \`git log\`, regenerating against the merged base produces the canonical \`CHANGELOG.md\` for whatever \`HEAD\` now points at — no semantic conflict to resolve.

Also:
- Attempt budget bumped 3 → 4 (each iteration is now cheap non-FF retries instead of stuck-in-rebase ones).
- Early short-circuit added: if the action's first regeneration produced no diff against the checkout, exit before entering the loop at all.

## Validation

- YAML syntax valid (\`python3 -c 'import yaml; yaml.safe_load(...)'\`).
- \`git-cliff\` is on \`\$PATH\` because the prior \`orhun/git-cliff-action@v4\` step exports it via \`\$GITHUB_PATH\`.
- The original race (#544 — non-fast-forward push) is still handled: the push step retries up to 4 times with the new \`origin/main\` as base each time.

## Test plan

- [ ] Manual \`workflow_dispatch\` on a clean main produces "No changelog changes to commit" cleanly.
- [ ] Workflow recovers from a rebase-conflict scenario (cannot reproduce on demand without arranging a second push, but the trace will be visible in any future run that lands on the same race window).
- [ ] No infinite-loop risk: \`paths-ignore\` + \`[skip ci]\` continue to prevent self-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)