### PR TITLE
ci: serialise changelog/release-please workflows + install git-cliff binary (#703)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -67,6 +67,26 @@ on:
 permissions:
   contents: write
 
+# Concurrency control (#703).
+#
+# Without a concurrency group, two pushes to main spawn two parallel
+# changelog jobs that race on CHANGELOG.md — both check out the same SHA,
+# both regenerate against slightly different histories, and the second
+# push is rejected non-fast-forward. Earlier patches (#544, #700) bolted
+# bash-level retry loops onto the symptom; this group fixes the root
+# cause by serialising runs.
+#
+# `cancel-in-progress: false` so we don't drop changelog updates when a
+# fast-follow merge arrives — the second job waits for the first to
+# complete, then runs against the new origin/main, then short-circuits
+# (no diff) if the first job's regeneration already covered it.
+#
+# Group keyed by ref so workflow_dispatch from a feature branch doesn't
+# block the main-branch push handler (and vice versa).
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ============================================================
   # Generate and Commit CHANGELOG.md
@@ -101,33 +121,43 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
 
-      # Step 2: Generate CHANGELOG.md using git-cliff.
-      # The orhun/git-cliff-action@v4 installs git-cliff and runs it with the
-      # specified configuration file (cliff.toml).
+      # Step 2: Install the git-cliff binary on the runner's $PATH.
       #
-      # Inputs:
-      #   config: cliff.toml -- Path to the git-cliff configuration file that defines
-      #           the changelog template, commit parsers, and sorting rules
-      #   args: --verbose    -- Print debug information about commit parsing
+      # We previously used orhun/git-cliff-action@v4 here, but that runs
+      # git-cliff as a Docker action — the binary lives inside the
+      # container that the action uses, not on the host. The retry loop
+      # in the Commit step (#700) needs to invoke `git-cliff` directly
+      # to regenerate against a freshly-reset working tree, so the
+      # binary must be on $PATH (#703 — Run #530 failed with
+      # `git-cliff: command not found`).
       #
-      # Environment:
-      #   OUTPUT: CHANGELOG.md -- The output file path for the generated changelog.
-      #           git-cliff writes the complete changelog to this file (replacing
-      #           any existing content).
+      # Pinning the version explicitly here also gives us hermetic,
+      # reproducible regeneration: both the initial regeneration and
+      # any retry-loop regenerations use the same binary, so they can
+      # never produce different outputs against the same history.
       #
-      # The step ID 'git-cliff' makes the action's outputs available to later steps
-      # (e.g., steps.git-cliff.outputs.changelog for the generated content).
-      #
-      # @see https://github.com/orhun/git-cliff-action -- Action documentation
-      # @see https://git-cliff.org/docs/usage/cli -- CLI options reference
+      # Bump GIT_CLIFF_VERSION when a new git-cliff release introduces
+      # changelog formatting we want; otherwise leave pinned for stable
+      # CHANGELOG.md output across runs.
+      - name: Install git-cliff
+        run: |
+          set -euo pipefail
+          GIT_CLIFF_VERSION=2.10.1
+          GIT_CLIFF_DIR="git-cliff-${GIT_CLIFF_VERSION}"
+          GIT_CLIFF_TARBALL="${GIT_CLIFF_DIR}-x86_64-unknown-linux-gnu.tar.gz"
+          curl --fail --silent --show-error --location \
+            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GIT_CLIFF_TARBALL}" \
+            -o /tmp/git-cliff.tar.gz
+          tar -xzf /tmp/git-cliff.tar.gz -C /tmp
+          sudo install -m 755 "/tmp/${GIT_CLIFF_DIR}/git-cliff" /usr/local/bin/git-cliff
+          git-cliff --version
+
+      # Step 3: Generate CHANGELOG.md using the locally-installed binary.
+      # Same effective invocation as the orhun action, but uses the binary
+      # we just installed so the version is consistent with the retry
+      # loop's regenerations below (#703).
       - name: Generate changelog
-        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4
-        id: git-cliff
-        with:
-          config: cliff.toml
-          args: --verbose
-        env:
-          OUTPUT: CHANGELOG.md
+        run: git-cliff --config cliff.toml --verbose --output CHANGELOG.md
 
       # Step 3: Commit and push the updated CHANGELOG.md.
       # This step:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,6 +64,20 @@ permissions:
   contents: write
   pull-requests: write
 
+# Concurrency control (#703 — hardening).
+#
+# release-please-action coalesces internally on its own release-PR
+# branch, so this group is belt-and-braces — but every other long-
+# running workflow that mutates `main` in this repo (alpha/beta/rc/
+# nightly/weekly/monthly/realign-alpha/update-security-policy) has a
+# concurrency group, and missing it here was a foot-gun for the
+# future. `cancel-in-progress: false` matches the pattern used by
+# those workflows so a late-arriving push doesn't drop a release-PR
+# update mid-flight.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please


### PR DESCRIPTION
## Summary

Closes #703. Properly closes #700 (the regenerate-on-clean-state logic from #701 was correct in spirit but couldn't run because the git-cliff binary isn't on \`\$PATH\`).

This is the **third** PR addressing the recurring \`changelog.yml\` race. Time to fix the architectural root cause instead of patching the symptom again. After this PR, the previous patches (#544's retry loop, #700's regenerate-on-clean-state) become defense-in-depth — the primary defense is now structural.

## Pattern

| Failure | Root cause | Fix that landed |
| --- | --- | --- |
| #544 | Non-fast-forward push race | Retry loop with \`git pull --rebase\` |
| #700 | Rebase conflict on CHANGELOG.md | Regenerate from clean state on each retry (#701) |
| Run #530 (today) | \`git-cliff\` not on \`\$PATH\` outside the orhun action's Docker container | (this PR) |

All three are **downstream symptoms of two changelog jobs running in parallel.** Audit of every push-to-main workflow in the repo confirmed: alpha/beta/rc/nightly/weekly/monthly/realign-alpha/update-security-policy ALL have a \`concurrency\` group. \`changelog.yml\` and \`release-please.yml\` were the only outliers.

## What changed

### 1. Architectural — \`concurrency\` group on \`changelog.yml\`

\`\`\`yaml
concurrency:
  group: changelog-\${{ github.ref }}
  cancel-in-progress: false
\`\`\`

\`cancel-in-progress: false\` so we don't drop changelog updates when a fast-follow merge arrives — the second job waits, then runs against the new \`origin/main\`, then short-circuits if the first job's regeneration already covered it. **The race is impossible.**

### 2. Tactical — install \`git-cliff\` binary explicitly

Replaced \`orhun/git-cliff-action@v4\` (Docker action — binary not on host \`\$PATH\`) with an inline curl-based install pinned to v2.10.1. Benefits:

- Binary is on \`\$PATH\` for the retry loop to use → fixes today's "command not found" failure.
- Hermetic version: both the initial regeneration and any retry-loop regenerations use the same \`git-cliff\` version, so they cannot produce divergent \`CHANGELOG.md\` output.
- One fewer pinned third-party action to babysit for security advisories.

### 3. Hardening — \`concurrency\` group on \`release-please.yml\`

release-please-action coalesces internally on its own release-PR branch, so this is belt-and-braces, but missing it was a foot-gun for the future. Every other long-running push-to-main workflow has the same pattern; making it uniform.

## Defense-in-depth

The retry loop from #701 stays in place. With concurrency it should almost never fire, but if \`release-please.yml\` (or some other unrelated workflow with its own concurrency group) lands a push between our checkout and our push, the loop handles it cleanly — and now the binary is actually available, so the regeneration step works.

## Validation

- \`python3 -c 'import yaml; yaml.safe_load(...)'\` — both YAML files valid.
- Manual review confirms \`concurrency\` semantics match the pattern used by 8 other workflows in the repo.
- \`git-cliff v2.10.1\` is current upstream stable; release notes show no breaking changes vs. what \`orhun/git-cliff-action@v4\` was bundling.

## Test plan

- [ ] Merge to main → workflow runs cleanly, no race.
- [ ] Verify in run logs that \`git-cliff --version\` printed as expected (the install step).
- [ ] If a fast-follow merge to main happens after this PR lands, verify the second changelog run *waits* (not parallel) and then no-ops.
- [ ] Manual \`workflow_dispatch\` from \`main\` produces a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)