### PR TITLE
chore(deps): override basic-ftp to ^5.3.1 (GHSA-rpmf-866q-6p89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "basic-ftp": "^5.3.1"
   }
 }


### PR DESCRIPTION
## Summary

A high-severity advisory ([GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89)) was published against \`basic-ftp <=5.3.0\` — unbounded multiline control response buffering that lets a malicious FTP server cause client-side DoS. The package is a transitive **dev** dependency through:

\`\`\`
puppeteer → @puppeteer/browsers → proxy-agent → pac-proxy-agent → get-uri → basic-ftp
\`\`\`

Recent main CI runs were green (last on 2026-05-06 10:55 UTC) — the advisory was published after that, so it surfaced as a fresh audit failure on PR #707 and would surface on every subsequent PR until fixed.

## Why an override

\`npm audit fix\` does NOT bump \`basic-ftp\` on its own — the parent's caret range (\`^5.0.2\`) still matches the vulnerable 5.3.0 already pinned in the lock file. The narrowest fix is an \`overrides\` entry forcing the patched 5.3.1.

## Diff

- \`package.json\`: +3 lines (one \`"overrides"\` block).
- \`package-lock.json\`: 2 lines updated (basic-ftp \`5.3.0 → 5.3.1\` version + integrity hashes only). No other transitive deps affected.

## Test plan

- [x] \`npm install\` runs cleanly
- [x] \`npm audit --audit-level=high\` reports **0 vulnerabilities** (was 1 high)
- [x] \`npm ls basic-ftp\` resolves to 5.3.1 under the same chain
- [x] \`npm run type-check\` clean (verifying basic-ftp's API surface unchanged within the patch bump — caller is internal to puppeteer's proxy plumbing, not user code)
- [ ] CI green (will run on push)

## Follow-up

Once this merges, PR #707 will be rebased onto the new \`main\` so it picks up the override and its Security audit step turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)