### PR TITLE
fix(ci): stop release-channel workflow self-trigger loop ([skip ci])

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -123,7 +123,11 @@ jobs:
       - name: Commit version bump
         run: |
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
-          git commit -m "chore(alpha): ${{ steps.version.outputs.version }}"
+          # `[skip ci]` prevents the bot's push from re-triggering this same
+          # workflow (RELEASE_PAT attributes the push to the PAT owner, not
+          # github-actions[bot], which defeats the actor check). See the
+          # release-candidate-release.yml comment for the full incident write-up.
+          git commit -m "chore(alpha): ${{ steps.version.outputs.version }} [skip ci]"
 
       - name: Push alpha branch and tag
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -100,7 +100,11 @@ jobs:
       - name: Commit version bump
         run: |
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
-          git commit -m "chore(beta): ${{ steps.version.outputs.version }}"
+          # `[skip ci]` prevents the bot's push from re-triggering this same
+          # workflow (RELEASE_PAT attributes the push to the PAT owner, not
+          # github-actions[bot], which defeats the actor check). See the
+          # release-candidate-release.yml comment for the full incident write-up.
+          git commit -m "chore(beta): ${{ steps.version.outputs.version }} [skip ci]"
 
       - name: Push beta branch and tag
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release-candidate-release.yml
+++ b/.github/workflows/release-candidate-release.yml
@@ -104,7 +104,17 @@ jobs:
       - name: Commit version bump
         run: |
           git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock
-          git commit -m "chore(rc): ${{ steps.version.outputs.version }}"
+          # `[skip ci]` is critical: this push lands on the same `release-candidate`
+          # branch that triggers this workflow, and our `RELEASE_PAT` causes
+          # GitHub to attribute the bot's push to the PAT owner (a human
+          # account), which defeats the `if: github.actor != 'github-actions[bot]'`
+          # guard at the job level. Without `[skip ci]` the workflow loops:
+          # a single human push produces N consecutive RC tags before someone
+          # notices (rc.1 → rc.2 → … → rc.21 occurred on 2026-05-08).
+          # The marker is parsed at GitHub's trigger layer so the workflow
+          # is never even queued for the bot's own push. Belt-and-braces with
+          # the existing actor check.
+          git commit -m "chore(rc): ${{ steps.version.outputs.version }} [skip ci]"
 
       - name: Push release-candidate branch and tag
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Incident

Single human push to \`release-candidate\` on 2026-05-08 09:38 UTC spawned **21 sequential RC tags** (\`v1.0.0-rc.1\` through \`v1.0.0-rc.21\`) and 6 published + 5 draft GitHub Releases before the loop was caught and killed by hand. Spurious tags + releases have been deleted; only the intended \`v1.0.0-rc.1\` remains.

## Root cause

The push-driven release workflows for \`alpha\` / \`beta\` / \`release-candidate\` each commit a version bump and push it back to the same branch that triggered them. The job-level guard

\`\`\`yaml
if: github.actor != 'github-actions[bot]' || github.event_name == 'workflow_dispatch'
\`\`\`

was meant to skip the bot's own push, **but does not work in this repo** because:

- The bot uses \`secrets.RELEASE_PAT\` (not the default \`GITHUB_TOKEN\`) for the push.
- GitHub attributes PAT-authenticated pushes to the **PAT owner's user account**, not to \`github-actions[bot]\`.
- So \`github.actor\` is the human user; the check is always true; the workflow re-runs every push.

Each iteration: \`BASE = \"1.0.0\"\`, \`MAX\` increments because the previous run created \`v1.0.0-rc.N\`, \`NEXT = MAX + 1\`, version manifests patched + committed + tagged, push to \`release-candidate\` triggers the workflow again. Loop only stops when the PAT runs out of API quota or someone cancels in-progress runs.

## Fix

Append \`[skip ci]\` to the bot's commit message in all three push-driven release-channel workflows:

- \`.github/workflows/alpha-release.yml\`
- \`.github/workflows/beta-release.yml\`
- \`.github/workflows/release-candidate-release.yml\`

GitHub parses \`[skip ci]\` at the **trigger layer** — the workflow is not even queued for the bot's own push. The pre-existing actor guard is kept as belt-and-braces.

## Why this fix is safe

- Only the bot's own commit message changes; no behavioural difference for any human contributor.
- \`[skip ci]\` is parsed by GitHub natively, no custom logic required.
- Cron-driven workflows (\`nightly\` / \`weekly\` / \`monthly\`) have \`on: schedule\` but no \`on: push\` — they were never affected. Verified via \`grep -A 5 \"^on:\" .github/workflows/{nightly,weekly,monthly}-release.yml\`.

## Verification

- [x] Three workflow files updated — diff is one-line per file, commit message string only
- [x] \`grep \"\\[skip ci\\]\" .github/workflows/{alpha,beta,release-candidate}-release.yml\` confirms presence in all three
- [ ] After merge: smoke-test by triggering one push to \`alpha\` (separate, low-risk channel) and confirming exactly **one** \`alpha\` tag is produced
- [ ] After successful smoke-test, can resume \`v1.0.1-prep\` work without fear of re-runaway

## Cleanup already done out-of-band

- \`v1.0.0-rc.2\` through \`v1.0.0-rc.21\` tags deleted (\`gh release delete --cleanup-tag\` for rc.2-rc.11, \`git push origin --delete\` for rc.12-rc.21 which only had tags).
- All in-progress / queued \`release.yml\` runs for the spurious tags cancelled (saves GHA minutes).
- \`release-candidate\` branch HEAD is currently at the bot's \`chore(rc): 1.0.0-rc.21\` commit. Not reset (force-push protected) — the next legitimate RC bump will compute \`MAX=1\` from remaining tags and produce \`v1.0.0-rc.2\` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)