### PR TITLE
refactor(testing): centralised fixture builders — audit v2 #4

### DIFF
--- a/src/components/download/ActivityLog.test.tsx
+++ b/src/components/download/ActivityLog.test.tsx
@@ -36,7 +36,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useActivityStore } from '@/stores/activityStore';
 import { ActivityLog } from '@/components/download/ActivityLog';
-import type { ActivityLogEntry } from '@/types';
+import { makeActivityEntry as makeEntry } from '@/testing/fixtures';
 
 // Mock the virtualizer to render every entry synchronously. The real
 // useVirtualizer measures DOM elements via getBoundingClientRect()
@@ -74,20 +74,6 @@ vi.mock('@/lib/tauri-commands', () => ({
   exportDiskActivityLog: vi.fn().mockResolvedValue(1024),
   getLogsFolderPath: vi.fn().mockResolvedValue('/var/log/meedyadl'),
 }));
-
-/**
- * Build an ActivityLogEntry fixture. Tests override only what they
- * care about; defaults produce a typical download stdout line.
- */
-function makeEntry(overrides: Partial<ActivityLogEntry> = {}): ActivityLogEntry {
-  return {
-    download_id: overrides.download_id ?? 'abc12345-de00-4000-9000-000000000000',
-    stream: overrides.stream ?? 'stdout',
-    line: overrides.line ?? 'Downloading track 1/12',
-    timestamp: overrides.timestamp ?? '2026-05-08T12:00:00.000Z',
-    _id: overrides._id,
-  };
-}
 
 beforeEach(() => {
   // Reset the activityStore between tests so entries don't bleed.

--- a/src/components/download/DownloadQueue.test.tsx
+++ b/src/components/download/DownloadQueue.test.tsx
@@ -33,6 +33,7 @@ import { useDownloadStore } from '@/stores/downloadStore';
 import { useUiStore } from '@/stores/uiStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { DownloadQueue } from '@/components/download/DownloadQueue';
+import { makeQueueItem as makeItem } from '@/testing/fixtures';
 import type { QueueItemStatus, DownloadState } from '@/types';
 
 /**
@@ -49,34 +50,6 @@ vi.mock('@/components/download/QueueItem', () => ({
     </div>
   ),
 }));
-
-/**
- * Build a QueueItemStatus fixture with sensible defaults — tests
- * override only the fields they care about (typically `id` + `state`).
- */
-function makeItem(overrides: Partial<QueueItemStatus> = {}): QueueItemStatus {
-  return {
-    id: overrides.id ?? 'item-1',
-    urls: overrides.urls ?? ['https://music.apple.com/us/album/foo/123'],
-    state: overrides.state ?? 'queued',
-    progress: 0,
-    current_track: null,
-    album_name: null,
-    artist_name: null,
-    total_tracks: null,
-    completed_tracks: null,
-    speed: null,
-    eta: null,
-    processing_label: null,
-    processing_progress: null,
-    error: null,
-    output_path: null,
-    codec_used: null,
-    fallback_occurred: false,
-    used_wrapper: false,
-    ...overrides,
-  } as QueueItemStatus;
-}
 
 beforeEach(() => {
   // Reset all three stores between tests so no item state bleeds.

--- a/src/components/library/MvGapFillModal.test.tsx
+++ b/src/components/library/MvGapFillModal.test.tsx
@@ -20,7 +20,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MvGapFillModal } from '@/components/library/MvGapFillModal';
-import type { ScannedManifest } from '@/lib/tauri-commands';
+import { makeScannedManifest } from '@/testing/fixtures';
 
 vi.mock('lucide-react', () => ({
   X: (props: Record<string, unknown>) => <span data-testid="x-icon" {...props} />,
@@ -35,19 +35,7 @@ vi.mock('lucide-react', () => ({
   ),
 }));
 
-const baseManifest: ScannedManifest = {
-  manifest_path: '/music/Artist/Album/manifest.meedyadl',
-  album_dir: '/music/Artist/Album',
-  urls: ['https://music.apple.com/us/album/foo/123'],
-  platform: 'apple-music',
-  artist: 'Test Artist',
-  album: 'Test Album',
-  downloaded_at: null,
-  track_count: 10,
-  current_codec: 'alac',
-  audio_file_count: 9,
-  last_modified_date: null,
-};
+const baseManifest = makeScannedManifest();
 
 describe('MvGapFillModal', () => {
   // ===========================================================================

--- a/src/testing/fixtures.test.ts
+++ b/src/testing/fixtures.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for the fixture builder helpers (audit v2 #4).
+ *
+ * Pins the contract for `makeFixture` + the three named builders so
+ * a future change to a domain type (QueueItemStatus, ActivityLogEntry,
+ * ScannedManifest) that breaks the default shape is caught here
+ * before it cascades into the consumer test files.
+ */
+
+import {
+  makeActivityEntry,
+  makeFixture,
+  makeQueueItem,
+  makeScannedManifest,
+} from '@/testing/fixtures';
+
+describe('makeFixture', () => {
+  it('returns the defaults when no overrides are supplied', () => {
+    const make = makeFixture({ a: 1, b: 'two' });
+    expect(make()).toEqual({ a: 1, b: 'two' });
+  });
+
+  it('shallow-merges Partial overrides on top of defaults', () => {
+    const make = makeFixture({ a: 1, b: 'two', c: false });
+    expect(make({ b: 'three' })).toEqual({ a: 1, b: 'three', c: false });
+  });
+
+  it('does not share state between calls (each call returns a fresh object)', () => {
+    const make = makeFixture({ count: 0, items: [] as number[] });
+    const first = make();
+    const second = make();
+    expect(first).not.toBe(second);
+    // Defaults reused by reference for nested values — that's by
+    // design (shallow spread); tests that mutate nested state should
+    // override the field with a fresh reference.
+  });
+});
+
+describe('makeQueueItem', () => {
+  it('produces a queued item with default URL when called bare', () => {
+    const item = makeQueueItem();
+    expect(item.id).toBe('item-1');
+    expect(item.state).toBe('queued');
+    expect(item.urls).toEqual(['https://music.apple.com/us/album/foo/123']);
+    expect(item.progress).toBe(0);
+    expect(item.fallback_occurred).toBe(false);
+    expect(item.used_wrapper).toBe(false);
+  });
+
+  it('overrides only the fields supplied', () => {
+    const item = makeQueueItem({ id: 'x', state: 'downloading', progress: 47 });
+    expect(item.id).toBe('x');
+    expect(item.state).toBe('downloading');
+    expect(item.progress).toBe(47);
+    // Untouched defaults preserved
+    expect(item.urls).toEqual(['https://music.apple.com/us/album/foo/123']);
+    expect(item.error).toBeNull();
+  });
+});
+
+describe('makeActivityEntry', () => {
+  it('produces a stdout download entry with UUID-shaped download_id', () => {
+    const entry = makeActivityEntry();
+    expect(entry.stream).toBe('stdout');
+    expect(entry.download_id).toMatch(/^[a-f0-9]{8}-/); // realistic UUID prefix
+    expect(entry.line).toBe('Downloading track 1/12');
+  });
+
+  it('overrides only the fields supplied', () => {
+    const entry = makeActivityEntry({
+      _id: 42,
+      download_id: 'system',
+      line: 'App started',
+    });
+    expect(entry._id).toBe(42);
+    expect(entry.download_id).toBe('system');
+    expect(entry.line).toBe('App started');
+    expect(entry.stream).toBe('stdout'); // default preserved
+  });
+});
+
+describe('makeScannedManifest', () => {
+  it('produces a single-album manifest with one missing track', () => {
+    const m = makeScannedManifest();
+    expect(m.album).toBe('Test Album');
+    expect(m.artist).toBe('Test Artist');
+    expect(m.track_count).toBe(10);
+    expect(m.audio_file_count).toBe(9);
+    expect(m.current_codec).toBe('alac');
+    expect(m.last_modified_date).toBeNull();
+  });
+
+  it('overrides only the fields supplied', () => {
+    const m = makeScannedManifest({ album: 'Other', last_modified_date: '2026-01-01' });
+    expect(m.album).toBe('Other');
+    expect(m.last_modified_date).toBe('2026-01-01');
+    expect(m.artist).toBe('Test Artist'); // default preserved
+  });
+});

--- a/src/testing/fixtures.ts
+++ b/src/testing/fixtures.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Centralised test fixture builders (audit v2 finding #4).
+ *
+ * Each domain type with non-trivial defaults gets a builder function
+ * that returns a fully-populated instance with sensible test defaults.
+ * Tests pass `Partial<T>` overrides for the fields they actually care
+ * about; everything else falls back to the defaults defined here.
+ *
+ * **Why this exists:**
+ *
+ * Pre-v2, every test file with a fixture re-defined its own builder
+ * inline (`makeItem` in DownloadQueue.test.tsx, `makeEntry` in
+ * ActivityLog.test.tsx, `baseManifest` in MvGapFillModal.test.tsx).
+ * Each builder duplicated the type's defaults across files, so a
+ * change to the type definition meant walking every test file and
+ * updating the same hardcoded shape. This module collects them in
+ * one place.
+ *
+ * **`makeFixture` generic helper:**
+ *
+ * For one-off types that don't warrant a named builder yet, use
+ * `makeFixture(defaults)` to produce a builder with the same
+ * shape. This keeps new tests from re-implementing the
+ * spread-overrides pattern by hand.
+ *
+ * @example
+ *   import { makeQueueItem } from '@/testing/fixtures';
+ *   const item = makeQueueItem({ state: 'downloading', progress: 50 });
+ *
+ * @example
+ *   import { makeFixture } from '@/testing/fixtures';
+ *   const makeUser = makeFixture<User>({ id: '1', name: 'Test' });
+ *   const u = makeUser({ name: 'Alice' });  // → { id: '1', name: 'Alice' }
+ */
+
+import type {
+  ActivityLogEntry,
+  QueueItemStatus,
+} from '@/types';
+import type { ScannedManifest } from '@/lib/tauri-commands';
+
+/**
+ * Generic fixture builder factory. Captures `defaults` once; returns
+ * a function that merges `Partial<T>` overrides on each call.
+ *
+ * Use this for ad-hoc fixtures that don't yet warrant a named
+ * builder export. Promotes the inline-builder pattern previously
+ * scattered across test files into a one-line declaration.
+ */
+export function makeFixture<T extends object>(
+  defaults: T
+): (overrides?: Partial<T>) => T {
+  return (overrides = {}) => ({ ...defaults, ...overrides });
+}
+
+/**
+ * Build a `QueueItemStatus` fixture with sensible defaults.
+ *
+ * Default state is `queued` with a single Apple Music album URL,
+ * zero progress, and no error/output/codec data. Tests typically
+ * override `id` (when multiple items in one test) and `state`
+ * (to exercise specific lifecycle branches).
+ *
+ * Fields not part of the stable `QueueItemStatus` interface that may
+ * be added later (e.g. service-specific extras for M8/M9/M10) should
+ * be added to this builder's defaults at the same time so existing
+ * tests don't break.
+ */
+export const makeQueueItem = makeFixture<QueueItemStatus>({
+  id: 'item-1',
+  urls: ['https://music.apple.com/us/album/foo/123'],
+  state: 'queued',
+  progress: 0,
+  current_track: null,
+  album_name: null,
+  artist_name: null,
+  total_tracks: null,
+  completed_tracks: null,
+  speed: null,
+  eta: null,
+  processing_label: null,
+  processing_progress: null,
+  error: null,
+  output_path: null,
+  codec_used: null,
+  fallback_occurred: false,
+  used_wrapper: false,
+} as QueueItemStatus);
+
+/**
+ * Build an `ActivityLogEntry` fixture with sensible defaults.
+ *
+ * Default produces a typical download stdout line tagged with a
+ * UUID-shaped `download_id` (so tests of the `[shortId]` truncation
+ * logic see a realistic 8-char prefix). Tests usually override
+ * `_id` (for stable React keys), `download_id` (to switch between
+ * `system` / per-download routing), `stream` (for the
+ * `[MeedyaDL]` internal-stream badge), or `line` (to exercise the
+ * search filter).
+ */
+export const makeActivityEntry = makeFixture<ActivityLogEntry>({
+  download_id: 'abc12345-de00-4000-9000-000000000000',
+  stream: 'stdout',
+  line: 'Downloading track 1/12',
+  timestamp: '2026-05-08T12:00:00.000Z',
+});
+
+/**
+ * Build a `ScannedManifest` fixture with sensible defaults.
+ *
+ * Default produces a single-album manifest at a fictitious music
+ * library path with the codec set to `alac` and one missing track
+ * (10 tracks expected, 9 on disk). Tests typically override `album`,
+ * `urls`, or `last_modified_date` to exercise the diff/freshness
+ * branches in Library Scan.
+ */
+export const makeScannedManifest = makeFixture<ScannedManifest>({
+  manifest_path: '/music/Artist/Album/manifest.meedyadl',
+  album_dir: '/music/Artist/Album',
+  urls: ['https://music.apple.com/us/album/foo/123'],
+  platform: 'apple-music',
+  artist: 'Test Artist',
+  album: 'Test Album',
+  downloaded_at: null,
+  track_count: 10,
+  current_codec: 'alac',
+  audio_file_count: 9,
+  last_modified_date: null,
+});


### PR DESCRIPTION
## Summary

First implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #4 (test fixture builders).

**New module** [\`src/testing/fixtures.ts\`](../blob/refactor/audit-v2-test-fixtures/src/testing/fixtures.ts):
- \`makeFixture<T>(defaults)\` generic factory
- \`makeQueueItem\` — \`QueueItemStatus\` builder
- \`makeActivityEntry\` — \`ActivityLogEntry\` builder
- \`makeScannedManifest\` — \`ScannedManifest\` builder

**9 tests** pin the helper contract + per-builder default shape so a future change to a domain type that breaks the defaults is caught here before cascading.

**Three call sites migrated:**
- \`DownloadQueue.test.tsx\` — inline \`makeItem\` builder removed (~25 LOC)
- \`ActivityLog.test.tsx\` — inline \`makeEntry\` builder removed (~10 LOC)
- \`MvGapFillModal.test.tsx\` — 13-line \`baseManifest\` literal → \`makeScannedManifest()\`

All 22 + 18 + 10 tests in the migrated files still pass without modification.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (this PR)
2. #1 useAsyncWithToast helper (next)
3. #3 confirmation modal factory hook
4. #6 settings field hook
5. #5 subprocess reader abstraction
6. #8 state injection docs
7. #2 useAsyncTask hook
8. #7 context_err! macro

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 409 pass (9 new, 0 regressions in 3 migrated files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)