### PR TITLE
refactor(lib): withErrorToast helper — audit v2 #1

### DIFF
--- a/src/components/download/DownloadQueue.tsx
+++ b/src/components/download/DownloadQueue.tsx
@@ -61,6 +61,7 @@ import { Download, Play, RefreshCw, RotateCcw, Square, Trash2, Upload } from 'lu
 import { useDownloadStore } from '@/stores/downloadStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useUiStore } from '@/stores/uiStore';
+import { withErrorToast } from '@/lib/withErrorToast';
 
 /** Reusable UI components from the common library. */
 import { Button, Modal } from '@/components/common';
@@ -314,13 +315,11 @@ export function DownloadQueue() {
    * Wraps `exportQueue()` with toast feedback showing the count exported.
    */
   const handleExport = async () => {
-    try {
-      const count = await exportQueue();
-      if (count > 0) {
-        addToast(`Exported ${count} item${count !== 1 ? 's' : ''}`, 'success');
-      }
-    } catch {
-      addToast('Failed to export queue', 'error');
+    const count = await withErrorToast(() => exportQueue(), {
+      errorMsg: 'Failed to export queue',
+    });
+    if (count !== undefined && count > 0) {
+      addToast(`Exported ${count} item${count !== 1 ? 's' : ''}`, 'success');
     }
   };
 
@@ -329,13 +328,11 @@ export function DownloadQueue() {
    * Wraps `importQueue()` with toast feedback showing the count imported.
    */
   const handleImport = async () => {
-    try {
-      const count = await importQueue();
-      if (count > 0) {
-        addToast(`Imported ${count} item${count !== 1 ? 's' : ''}`, 'success');
-      }
-    } catch {
-      addToast('Failed to import queue', 'error');
+    const count = await withErrorToast(() => importQueue(), {
+      errorMsg: 'Failed to import queue',
+    });
+    if (count !== undefined && count > 0) {
+      addToast(`Imported ${count} item${count !== 1 ? 's' : ''}`, 'success');
     }
   };
 
@@ -344,12 +341,11 @@ export function DownloadQueue() {
    * Wraps `processQueue()` with toast feedback.
    */
   const handleStartQueue = async () => {
-    try {
-      await processQueue();
-      addToast('Queue processing started', 'info');
-    } catch {
-      addToast('Failed to start queue processing', 'error');
-    }
+    await withErrorToast(() => processQueue(), {
+      successMsg: 'Queue processing started',
+      successVariant: 'info',
+      errorMsg: 'Failed to start queue processing',
+    });
   };
 
   /**
@@ -357,22 +353,22 @@ export function DownloadQueue() {
    * Wraps `clearFinished()` with toast feedback showing the count removed.
    */
   const handleClearFinished = async () => {
-    try {
-      const removed = await clearFinished();
+    const removed = await withErrorToast(() => clearFinished(), {
+      errorMsg: 'Failed to clear queue',
+    });
+    if (removed !== undefined) {
       addToast(`Cleared ${removed} item${removed !== 1 ? 's' : ''}`, 'info');
-    } catch {
-      addToast('Failed to clear queue', 'error');
     }
   };
 
   /** Clear ALL non-active items after user confirms. */
   const handleClearAllConfirmed = async () => {
     setShowClearAllConfirm(false);
-    try {
-      const removed = await clearAll();
+    const removed = await withErrorToast(() => clearAll(), {
+      errorMsg: 'Failed to clear queue',
+    });
+    if (removed !== undefined) {
       addToast(`Cleared all ${removed} item${removed !== 1 ? 's' : ''}`, 'info');
-    } catch {
-      addToast('Failed to clear queue', 'error');
     }
   };
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -92,6 +92,7 @@ import {
 // @see https://zustand.docs.pmnd.rs/getting-started/introduction
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useUiStore } from '@/stores/uiStore';
+import { withErrorToast } from '@/lib/withErrorToast';
 
 // Shared UI components used in the header action bar.
 import { Button } from '@/components/common';
@@ -230,12 +231,10 @@ export function SettingsPage() {
    * Displays a success or error toast notification based on the outcome.
    */
   const handleSave = async () => {
-    try {
-      await saveSettings();
-      addToast('Settings saved successfully', 'success');
-    } catch {
-      addToast('Failed to save settings', 'error');
-    }
+    await withErrorToast(() => saveSettings(), {
+      successMsg: 'Settings saved successfully',
+      errorMsg: 'Failed to save settings',
+    });
   };
 
   /**

--- a/src/components/settings/tabs/CrashReportSection.tsx
+++ b/src/components/settings/tabs/CrashReportSection.tsx
@@ -29,6 +29,7 @@ import { Trash2, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/common';
 import { listCrashReports, deleteCrashReport, deleteAllCrashReports } from '@/lib/tauri-commands';
 import { useUiStore } from '@/stores/uiStore';
+import { withErrorToast } from '@/lib/withErrorToast';
 import type { CrashReport } from '@/types';
 
 import { CrashReportDialog } from './CrashReportDialog';
@@ -115,23 +116,24 @@ export function CrashReportSection() {
 
   /** Deletes a crash report and removes it from the displayed list. */
   const handleDelete = async (id: string) => {
-    try {
-      await deleteCrashReport(id);
+    const ok = await withErrorToast(() => deleteCrashReport(id), {
+      successMsg: 'Crash report deleted',
+      successVariant: 'info',
+      errorMsg: (err) => `Failed to delete crash report: ${err}`,
+    });
+    if (ok !== undefined) {
       setReports((prev) => prev.filter((r) => r.id !== id));
-      addToast('Crash report deleted', 'info');
-    } catch (err) {
-      addToast(`Failed to delete crash report: ${err}`, 'error');
     }
   };
 
   /** Deletes all crash reports and clears the displayed list. */
   const handleDeleteAll = async () => {
-    try {
-      const count = await deleteAllCrashReports();
+    const count = await withErrorToast(() => deleteAllCrashReports(), {
+      errorMsg: (err) => `Failed to clear error reports: ${err}`,
+    });
+    if (count !== undefined) {
       setReports([]);
       addToast(`Deleted ${count} error report(s)`, 'info');
-    } catch (err) {
-      addToast(`Failed to clear error reports: ${err}`, 'error');
     }
   };
 

--- a/src/lib/withErrorToast.test.ts
+++ b/src/lib/withErrorToast.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for withErrorToast (audit v2 #1).
+ *
+ * Pins the helper's contract:
+ *   - Success path: returns value + optional success toast
+ *   - Error path: returns undefined + error toast (suppressible)
+ *   - errorMsg overload: string | (err) => string | omitted
+ *   - successVariant: 'success' (default) | 'info'
+ *   - suppressOn: case-insensitive substring match on the displayed msg
+ *
+ * Tests use real uiStore (no IPC dependencies) and inspect its
+ * `toasts` array to verify what was emitted.
+ */
+
+import { withErrorToast } from '@/lib/withErrorToast';
+import { useUiStore } from '@/stores/uiStore';
+
+beforeEach(() => {
+  useUiStore.setState({ toasts: [] });
+});
+
+/** Convenience: the toasts currently in the store, oldest first. */
+function getToasts() {
+  return useUiStore.getState().toasts;
+}
+
+describe('withErrorToast', () => {
+  // ===========================================================================
+  // Success path
+  // ===========================================================================
+
+  it('returns the resolved value when fn succeeds', async () => {
+    const result = await withErrorToast(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('emits no toast when no successMsg supplied', async () => {
+    await withErrorToast(async () => 'ok');
+    expect(getToasts()).toHaveLength(0);
+  });
+
+  it('emits a success toast when successMsg supplied', async () => {
+    await withErrorToast(async () => 'ok', { successMsg: 'Saved!' });
+    const toasts = getToasts();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toBe('Saved!');
+    expect(toasts[0].type).toBe('success');
+  });
+
+  it('honours successVariant: "info"', async () => {
+    await withErrorToast(async () => 'ok', {
+      successMsg: 'Reset',
+      successVariant: 'info',
+    });
+    expect(getToasts()[0].type).toBe('info');
+  });
+
+  // ===========================================================================
+  // Error path
+  // ===========================================================================
+
+  it('returns undefined when fn rejects', async () => {
+    const result = await withErrorToast(async () => {
+      throw new Error('boom');
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('emits the raw error message when no errorMsg supplied', async () => {
+    await withErrorToast(async () => {
+      throw new Error('IPC timeout');
+    });
+    const toasts = getToasts();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toBe('IPC timeout');
+    expect(toasts[0].type).toBe('error');
+  });
+
+  it('stringifies non-Error rejections', async () => {
+    await withErrorToast(async () => {
+      throw 'plain string failure';
+    });
+    expect(getToasts()[0].message).toBe('plain string failure');
+  });
+
+  it('uses static string errorMsg verbatim, ignoring the actual error', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('underlying noise');
+      },
+      { errorMsg: 'Failed to save settings' },
+    );
+    expect(getToasts()[0].message).toBe('Failed to save settings');
+  });
+
+  it('uses errorMsg fn to format the displayed text', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('disk full');
+      },
+      { errorMsg: (err) => `Failed to delete crash report: ${err instanceof Error ? err.message : err}` },
+    );
+    expect(getToasts()[0].message).toBe('Failed to delete crash report: disk full');
+  });
+
+  // ===========================================================================
+  // suppressOn
+  // ===========================================================================
+
+  it('suppresses error toast when displayed message matches a suppressOn pattern (case-insensitive)', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('User Cancelled');
+      },
+      { suppressOn: ['cancel'] },
+    );
+    expect(getToasts()).toHaveLength(0);
+  });
+
+  it('still suppresses when errorMsg fn rewrites to include the pattern', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('aborted');
+      },
+      {
+        errorMsg: (err) => `dismissed: ${err}`,
+        suppressOn: ['dismissed'],
+      },
+    );
+    expect(getToasts()).toHaveLength(0);
+  });
+
+  it('does NOT suppress when no suppressOn pattern matches', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('Real failure');
+      },
+      { suppressOn: ['cancel'] },
+    );
+    expect(getToasts()).toHaveLength(1);
+  });
+
+  it('empty suppressOn array does nothing (no special behaviour)', async () => {
+    await withErrorToast(
+      async () => {
+        throw new Error('boom');
+      },
+      { suppressOn: [] },
+    );
+    expect(getToasts()).toHaveLength(1);
+  });
+});

--- a/src/lib/withErrorToast.ts
+++ b/src/lib/withErrorToast.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file withErrorToast — async wrapper that emits success/error toasts.
+ *
+ * Audit v2 finding #1: ~30+ component handlers across the codebase
+ * follow the shape:
+ *
+ *   try {
+ *     await ipc();
+ *     addToast('Success!', 'success');
+ *   } catch (err) {
+ *     addToast(`Failed to do X: ${err}`, 'error');
+ *   }
+ *
+ * Each repetition is 4-6 lines that say nothing the call site cares
+ * about. This helper collapses the shape to a single call:
+ *
+ *   await withErrorToast(() => ipc(), {
+ *     successMsg: 'Success!',
+ *     errorMsg: (err) => `Failed to do X: ${err}`,
+ *   });
+ *
+ * The function reads `addToast` from `useUiStore.getState()` so it
+ * works from any context (component handlers, store actions, async
+ * effects) without needing to be a React hook.
+ *
+ * @see uiStore.addToast — the underlying toast emitter
+ * @see audit doc finding #1 in
+ *      [.github/audits/codebase-unification-audit-v2.md]
+ */
+
+import { useUiStore } from '@/stores/uiStore';
+
+/**
+ * Options controlling toast emission for a single async operation.
+ *
+ * Omit any field for the corresponding default behaviour:
+ * - No `successMsg` → no toast on success
+ * - No `errorMsg` → use the raw error message (`String(err)`)
+ * - No `suppressOn` → every error fires a toast
+ */
+export interface WithErrorToastOptions {
+  /** Toast text shown after successful resolution. Omit to skip. */
+  successMsg?: string;
+  /** Toast variant for success. Default: `'success'`. */
+  successVariant?: 'success' | 'info';
+  /**
+   * Error message strategy:
+   * - `string`: static text shown verbatim
+   * - `(err: unknown) => string`: derives the toast text from the
+   *   thrown value — typically `(err) => \`Failed to X: ${err}\``
+   * - omitted: uses `String(err)` (or `err.message` for Error
+   *   instances) as the toast text
+   */
+  errorMsg?: string | ((err: unknown) => string);
+  /**
+   * Case-insensitive substrings that, when present in the
+   * normalised error message, suppress the error toast. Useful for
+   * paths where rejection is expected — e.g. `['cancel']` for file
+   * picker dismissals where the user has already signalled intent
+   * to abort the action.
+   *
+   * The normalisation matches what `withErrorToast` would have
+   * displayed (the post-`errorMsg` string), so a custom `errorMsg`
+   * function can rewrite the comparison surface if needed.
+   */
+  suppressOn?: string[];
+}
+
+/**
+ * Run an async function and emit toasts based on its outcome.
+ *
+ * On success: returns the resolved value, optionally fires a
+ * success/info toast.
+ *
+ * On failure: returns `undefined`, fires an error toast (unless the
+ * normalised error message matches a `suppressOn` pattern). Errors
+ * are NOT re-thrown — callers that need the rejection to propagate
+ * (rare) should not use this helper.
+ *
+ * @example Simple use
+ *   await withErrorToast(() => deleteCrashReport(id), {
+ *     successMsg: 'Crash report deleted',
+ *     successVariant: 'info',
+ *     errorMsg: (err) => `Failed to delete crash report: ${err}`,
+ *   });
+ *
+ * @example Suppressed cancellation
+ *   await withErrorToast(() => exportQueue(), {
+ *     successMsg: 'Queue exported',
+ *     errorMsg: 'Failed to export queue',
+ *     suppressOn: ['cancel'], // user closed the file picker
+ *   });
+ *
+ * @example Conditional success toast (gate inside the wrapped fn)
+ *   const count = await withErrorToast(async () => {
+ *     const n = await exportQueue();
+ *     if (n > 0) useUiStore.getState().addToast(`Exported ${n}`, 'success');
+ *     return n;
+ *   }, { errorMsg: 'Failed to export queue' });
+ */
+export async function withErrorToast<T>(
+  fn: () => Promise<T>,
+  opts: WithErrorToastOptions = {},
+): Promise<T | undefined> {
+  const addToast = useUiStore.getState().addToast;
+  try {
+    const result = await fn();
+    if (opts.successMsg) {
+      addToast(opts.successMsg, opts.successVariant ?? 'success');
+    }
+    return result;
+  } catch (err) {
+    const rawMsg = err instanceof Error ? err.message : String(err);
+    const display =
+      typeof opts.errorMsg === 'function'
+        ? opts.errorMsg(err)
+        : (opts.errorMsg ?? rawMsg);
+    if (opts.suppressOn?.length) {
+      const lower = display.toLowerCase();
+      if (opts.suppressOn.some((p) => lower.includes(p.toLowerCase()))) {
+        return undefined;
+      }
+    }
+    addToast(display, 'error');
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Second implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #1 (async error → toast emission shape).

**New helper** [\`src/lib/withErrorToast.ts\`](../blob/refactor/audit-v2-with-error-toast/src/lib/withErrorToast.ts):

\`\`\`ts
await withErrorToast(() => ipc(), {
  successMsg: 'Success!',
  errorMsg: (err) => \`Failed to X: \${err}\`,
  suppressOn: ['cancel'],  // optional — silently swallow expected rejections
});
\`\`\`

Reads \`addToast\` via \`useUiStore.getState()\` so it works from any context (component handlers, store actions, async effects) without being a hook itself.

**13 unit tests** cover: success/error paths, static-string vs function-typed errorMsg, default vs 'info' successVariant, suppressOn case-insensitive matching against the displayed (post-errorMsg) text.

**Three call sites migrated** as proof:
- \`SettingsPage.tsx\` \`handleSave\` (7 LOC → 4)
- \`CrashReportSection.tsx\` \`handleDelete\` + \`handleDeleteAll\` (16 → 11)
- \`DownloadQueue.tsx\` 5 handlers (50 → 35)

All migrated sites' tests pass without modification.

Remaining ~25 call sites can opt in incrementally; no big-bang refactor.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (#733)
2. ✅ #1 useAsyncWithToast / withErrorToast (this PR)
3. #3 confirmation modal factory hook (next)
4. #6 settings field hook
5. #5 subprocess reader abstraction
6. #8 state injection docs
7. #2 useAsyncTask hook
8. #7 context_err! macro

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 422 pass (13 new, 0 regressions in 3 migrated files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)