### PR TITLE
refactor(lib): useConfirmation hook — audit v2 #3

### DIFF
--- a/src/components/download/DownloadQueue.tsx
+++ b/src/components/download/DownloadQueue.tsx
@@ -62,6 +62,7 @@ import { useDownloadStore } from '@/stores/downloadStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useUiStore } from '@/stores/uiStore';
 import { withErrorToast } from '@/lib/withErrorToast';
+import { useConfirmation } from '@/lib/useConfirmation';
 
 /** Reusable UI components from the common library. */
 import { Button, Modal } from '@/components/common';
@@ -167,26 +168,14 @@ export function DownloadQueue() {
   /** Shows a toast notification for action feedback. */
   const addToast = useUiStore((s) => s.addToast);
 
-  /** Confirmation modal state for "Clear All". */
-  const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
-
   /**
    * Confirmation modal target for per-item Delete (#685). Holds the
    * full queue item snapshot so the modal can render a meaningful label
    * (URL, current track) without re-querying the store. `null` means the
-   * modal is closed.
+   * modal is closed. Per-item delete needs the full target snapshot in
+   * its description so it stays as plain Modal state, not useConfirmation.
    */
   const [deleteTarget, setDeleteTarget] = useState<QueueItemStatus | null>(null);
-
-  /**
-   * Confirmation modal state for "Retry All Failed" (#665). Bulk retry
-   * iterates every queue item with `state === 'error'` and calls the
-   * existing `retryDownload` IPC for each, preserving per-item options.
-   * The smart manifest-driven retry path (#667) inside the backend means
-   * already-downloaded tracks are skipped — bulk retry of 12 items only
-   * re-fetches the actually-failed tracks across them.
-   */
-  const [showRetryAllConfirm, setShowRetryAllConfirm] = useState(false);
 
   /**
    * Confirmation modal state for "Abort Queue" (#620). The destructive
@@ -361,9 +350,9 @@ export function DownloadQueue() {
     }
   };
 
-  /** Clear ALL non-active items after user confirms. */
+  /** Clear ALL non-active items. The useConfirmation hook auto-closes
+   *  on resolve, so this just runs the action and surfaces the toast. */
   const handleClearAllConfirmed = async () => {
-    setShowClearAllConfirm(false);
     const removed = await withErrorToast(() => clearAll(), {
       errorMsg: 'Failed to clear queue',
     });
@@ -414,7 +403,6 @@ export function DownloadQueue() {
    * independently; one bad item shouldn't abort the whole batch.
    */
   const handleRetryAllFailedConfirmed = async () => {
-    setShowRetryAllConfirm(false);
     const failedItems = queueItems.filter((i) => i.state === 'error');
     if (failedItems.length === 0) {
       addToast('No failed downloads to retry', 'info');
@@ -522,6 +510,57 @@ export function DownloadQueue() {
   }, [queueItems]);
 
   // ---------------------------------------------------------------
+  // Confirmation modal hooks (audit v2 #3)
+  // ---------------------------------------------------------------
+  // Each `useConfirmation` returns { open, modal }: `open` wires to a
+  // trigger button's onClick; `modal` renders once in the JSX. The
+  // hook owns its own open/close state and auto-closes on a
+  // successful onConfirm. Stays open if onConfirm throws so the user
+  // can retry — onConfirm surfaces its own error toast.
+  //
+  // The Abort + per-item Delete modals stay as inline <Modal>s for now:
+  // Abort has a "don't ask again" checkbox that mutates separate
+  // settings state; Delete needs the full target snapshot in its
+  // description. Both could migrate but are slightly off the happy path
+  // of the hook.
+
+  const retryAllConfirm = useConfirmation({
+    title: 'Retry All Failed Downloads',
+    description: (
+      <>
+        <p className="mb-4">
+          This will re-queue {failedCount} failed download
+          {failedCount !== 1 ? 's' : ''}. The smart retry path skips
+          already-downloaded tracks via the manifest, so only the
+          actually-failed tracks will be re-fetched.
+        </p>
+        <p>
+          For wrapper-related failures, use the per-item &quot;Retry
+          without Wrapper&quot; option instead.
+        </p>
+      </>
+    ),
+    confirmLabel: 'Retry All',
+    onConfirm: handleRetryAllFailedConfirmed,
+  });
+
+  const clearAllConfirm = useConfirmation({
+    title: 'Clear All Queue Items',
+    description: (
+      <>
+        <p className="mb-4">
+          This will remove all queued, completed, failed, and cancelled
+          items from the download queue. Active downloads will not be
+          interrupted.
+        </p>
+        <p>This action cannot be undone.</p>
+      </>
+    ),
+    confirmLabel: 'Clear All',
+    onConfirm: handleClearAllConfirmed,
+  });
+
+  // ---------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------
   return (
@@ -609,7 +648,7 @@ export function DownloadQueue() {
                 variant="ghost"
                 size="sm"
                 icon={<RotateCcw size={14} />}
-                onClick={() => setShowRetryAllConfirm(true)}
+                onClick={retryAllConfirm.open}
               >
                 Retry All Failed ({failedCount})
               </Button>
@@ -620,7 +659,7 @@ export function DownloadQueue() {
                 variant="ghost"
                 size="sm"
                 icon={<Trash2 size={14} />}
-                onClick={() => setShowClearAllConfirm(true)}
+                onClick={clearAllConfirm.open}
               >
                 Clear All
               </Button>
@@ -733,60 +772,14 @@ export function DownloadQueue() {
         )}
       </div>
 
-      {/* Confirmation modal for "Retry All Failed" (#665) */}
-      <Modal
-        open={showRetryAllConfirm}
-        onClose={() => setShowRetryAllConfirm(false)}
-        title="Retry All Failed Downloads"
-      >
-        <p className="text-sm text-content-secondary mb-4">
-          This will re-queue {failedCount} failed download
-          {failedCount !== 1 ? 's' : ''}. The smart retry path skips
-          already-downloaded tracks via the manifest, so only the actually-
-          failed tracks will be re-fetched.
-        </p>
-        <p className="text-sm text-content-secondary mb-6">
-          For wrapper-related failures, use the per-item &quot;Retry without
-          Wrapper&quot; option instead.
-        </p>
-        <div className="flex justify-end gap-2">
-          <Button variant="ghost" onClick={() => setShowRetryAllConfirm(false)}>
-            Cancel
-          </Button>
-          <Button variant="primary" onClick={handleRetryAllFailedConfirmed}>
-            Retry All
-          </Button>
-        </div>
-      </Modal>
-
-      {/* Confirmation modal for "Clear All" */}
-      <Modal
-        open={showClearAllConfirm}
-        onClose={() => setShowClearAllConfirm(false)}
-        title="Clear All Queue Items"
-      >
-        <p className="text-sm text-content-secondary mb-4">
-          This will remove all queued, completed, failed, and cancelled items
-          from the download queue. Active downloads will not be interrupted.
-        </p>
-        <p className="text-sm text-content-secondary mb-6">
-          This action cannot be undone.
-        </p>
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="ghost"
-            onClick={() => setShowClearAllConfirm(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            onClick={handleClearAllConfirmed}
-          >
-            Clear All
-          </Button>
-        </div>
-      </Modal>
+      {/*
+        Retry All Failed (#665) + Clear All confirmation modals — both
+        owned by useConfirmation hooks declared above (audit v2 #3).
+        The hooks render their own <Modal> here; the trigger buttons
+        in the actions row call their `.open` methods.
+      */}
+      {retryAllConfirm.modal}
+      {clearAllConfirm.modal}
 
       {/* Confirmation modal for per-item Delete (#685) */}
       <Modal

--- a/src/lib/useConfirmation.test.tsx
+++ b/src/lib/useConfirmation.test.tsx
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for useConfirmation (audit v2 #3).
+ *
+ * Pins the hook contract:
+ *   - Modal closed by default (open() shows it)
+ *   - Confirm fires onConfirm + auto-closes on success
+ *   - Confirm stays open if onConfirm throws
+ *   - Cancel fires onCancel (if provided) + closes
+ *   - Backdrop / Escape also closes via onCancel
+ *   - close() programmatically hides without firing onCancel
+ *   - Custom labels (confirmLabel / cancelLabel)
+ *   - Description accepts arbitrary ReactNode (paragraphs, checkboxes, etc.)
+ */
+
+import { useState } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { useConfirmation } from '@/lib/useConfirmation';
+
+// Don't mock lucide-react here — the hook pulls in Modal + Button +
+// ToastContainer transitively via the common index, which uses several
+// icons (CheckCircle, AlertCircle, etc.). The real SVG icons render
+// fine in jsdom; mocking would require enumerating each one.
+
+/**
+ * Test harness: a tiny component that wires the hook to a trigger
+ * button so tests can drive open/close from the user's perspective.
+ */
+function Harness({
+  onConfirm,
+  onCancel,
+  title = 'Confirm action',
+  description = 'Are you sure?',
+  confirmLabel,
+  cancelLabel,
+}: Partial<Parameters<typeof useConfirmation>[0]> & {
+  onConfirm: () => void | Promise<void>;
+}) {
+  const confirm = useConfirmation({
+    title,
+    description,
+    confirmLabel,
+    cancelLabel,
+    onConfirm,
+    onCancel,
+  });
+  return (
+    <>
+      <button type="button" onClick={confirm.open}>
+        Trigger
+      </button>
+      <button type="button" onClick={confirm.close}>
+        Programmatic close
+      </button>
+      {confirm.modal}
+    </>
+  );
+}
+
+describe('useConfirmation', () => {
+  // ===========================================================================
+  // Default visibility
+  // ===========================================================================
+
+  it('modal is not visible until open() is called', () => {
+    render(<Harness onConfirm={vi.fn()} />);
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+  });
+
+  it('open() shows the modal with title + description + buttons', () => {
+    render(<Harness onConfirm={vi.fn()} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Confirm path
+  // ===========================================================================
+
+  it('Confirm calls onConfirm and auto-closes on success', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(<Harness onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // Auto-closed → modal title gone
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+  });
+
+  it('Confirm with synchronous onConfirm closes immediately', () => {
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('Confirm stays OPEN if onConfirm rejects (so user can retry)', async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error('disk full'));
+    render(<Harness onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // Modal still rendered for retry
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Cancel path
+  // ===========================================================================
+
+  it('Cancel button closes the modal', () => {
+    render(<Harness onConfirm={vi.fn()} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+  });
+
+  it('Cancel button fires onCancel callback when provided', () => {
+    const onCancel = vi.fn();
+    render(<Harness onConfirm={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape key dismisses the modal AND fires onCancel', () => {
+    const onCancel = vi.fn();
+    render(<Harness onConfirm={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Programmatic close
+  // ===========================================================================
+
+  it('close() hides the modal WITHOUT firing onCancel', () => {
+    const onCancel = vi.fn();
+    render(<Harness onConfirm={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('Trigger'));
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Programmatic close'));
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  // ===========================================================================
+  // Custom labels
+  // ===========================================================================
+
+  it('honours custom confirmLabel and cancelLabel', () => {
+    render(
+      <Harness
+        onConfirm={vi.fn()}
+        confirmLabel="Delete"
+        cancelLabel="Keep it"
+      />
+    );
+    fireEvent.click(screen.getByText('Trigger'));
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep it' })).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Rich description
+  // ===========================================================================
+
+  it('description accepts arbitrary ReactNode (multi-paragraph + interactive)', () => {
+    function ParentWithCheckbox() {
+      const [checked, setChecked] = useState(false);
+      const confirm = useConfirmation({
+        title: 'Abort Queue',
+        description: (
+          <>
+            <p>This will cancel every queued item.</p>
+            <p>This cannot be undone.</p>
+            <label>
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => setChecked(e.target.checked)}
+                aria-label="dont-ask-again"
+              />
+              Don't ask again
+            </label>
+          </>
+        ),
+        onConfirm: vi.fn(),
+      });
+      return (
+        <>
+          <button type="button" onClick={confirm.open}>
+            Trigger
+          </button>
+          <span data-testid="checkbox-state">{checked ? 'on' : 'off'}</span>
+          {confirm.modal}
+        </>
+      );
+    }
+    render(<ParentWithCheckbox />);
+    fireEvent.click(screen.getByText('Trigger'));
+    expect(screen.getByText('This will cancel every queued item.')).toBeInTheDocument();
+    expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+    // Toggle the checkbox via parent state
+    fireEvent.click(screen.getByLabelText('dont-ask-again'));
+    expect(screen.getByTestId('checkbox-state')).toHaveTextContent('on');
+  });
+});

--- a/src/lib/useConfirmation.tsx
+++ b/src/lib/useConfirmation.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file useConfirmation — confirmation modal hook.
+ *
+ * Audit v2 finding #3: every destructive action across the app shows
+ * a confirmation modal with the same shape — title, body text, Cancel
+ * + Confirm buttons. DownloadQueue.tsx alone has four (Retry All,
+ * Clear All, Delete Item, Abort Queue), each ~20 lines of inline JSX.
+ * CrashReportSection, future per-service "Revoke credentials" actions,
+ * and other gates will all hit the same shape.
+ *
+ * This hook centralises the chrome:
+ *
+ *   const confirmDelete = useConfirmation({
+ *     title: 'Delete crash report',
+ *     description: 'This cannot be undone.',
+ *     confirmLabel: 'Delete',
+ *     onConfirm: () => deleteCrashReport(id),
+ *   });
+ *
+ *   return (
+ *     <>
+ *       <Button onClick={confirmDelete.open}>Delete</Button>
+ *       {confirmDelete.modal}
+ *     </>
+ *   );
+ *
+ * The hook owns the open/close state. `description` accepts any
+ * ReactNode so callers can include item details, "don't ask again"
+ * checkboxes (bound to parent state), etc. Auto-closes on successful
+ * `onConfirm`; stays open if `onConfirm` throws so the user can
+ * retry — `onConfirm` should surface its own error toast (typically
+ * via withErrorToast).
+ *
+ * @see audit doc finding #3 in
+ *      [.github/audits/codebase-unification-audit-v2.md]
+ * @see withErrorToast — natural pairing for the onConfirm body
+ */
+
+import { useCallback, useState, type ReactNode } from 'react';
+import { Button, Modal } from '@/components/common';
+
+export interface UseConfirmationOptions {
+  /** Modal title (rendered in the header bar). */
+  title: string;
+  /**
+   * Modal body content. Accepts any ReactNode — paragraphs, item
+   * details, secondary action checkboxes (bound to parent state),
+   * etc. Caller controls spacing via wrapper elements.
+   */
+  description: ReactNode;
+  /** Confirm button label. Default: `"Confirm"`. */
+  confirmLabel?: string;
+  /** Cancel button label. Default: `"Cancel"`. */
+  cancelLabel?: string;
+  /**
+   * Called when the user clicks Confirm. The modal auto-closes after
+   * a successful resolution. If `onConfirm` throws (or returns a
+   * rejected promise), the modal stays open so the user can retry —
+   * `onConfirm` should surface its own error feedback.
+   */
+  onConfirm: () => void | Promise<void>;
+  /**
+   * Called when the user dismisses the modal (Cancel button, backdrop
+   * click, Escape key). Optional — most callers don't need it.
+   */
+  onCancel?: () => void;
+}
+
+export interface UseConfirmationReturn {
+  /** Show the modal. Typically wired to a trigger button's onClick. */
+  open: () => void;
+  /**
+   * Hide the modal programmatically without firing `onCancel`. Rarely
+   * needed — the auto-close on confirm + dismiss handlers cover most
+   * cases. Useful for parent-driven race conditions (e.g. an external
+   * event invalidates the action while the modal is up).
+   */
+  close: () => void;
+  /** True while the modal is rendered. Caller can use this for
+   *  styling or to disable the trigger button. */
+  isOpen: boolean;
+  /** Render this once in your component's JSX. Returns null when closed. */
+  modal: ReactNode;
+}
+
+/**
+ * Confirmation modal hook. See file header for the API + rationale.
+ */
+export function useConfirmation(opts: UseConfirmationOptions): UseConfirmationReturn {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  const handleCancel = useCallback(() => {
+    opts.onCancel?.();
+    setIsOpen(false);
+  }, [opts]);
+
+  const handleConfirm = useCallback(async () => {
+    try {
+      await opts.onConfirm();
+      setIsOpen(false);
+    } catch {
+      // Stay open so the user can retry. onConfirm is expected to
+      // surface its own error feedback (typically via withErrorToast).
+    }
+  }, [opts]);
+
+  const modal = (
+    <Modal open={isOpen} onClose={handleCancel} title={opts.title}>
+      <div className="text-sm text-content-secondary mb-6">
+        {opts.description}
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={handleCancel}>
+          {opts.cancelLabel ?? 'Cancel'}
+        </Button>
+        <Button variant="primary" onClick={handleConfirm}>
+          {opts.confirmLabel ?? 'Confirm'}
+        </Button>
+      </div>
+    </Modal>
+  );
+
+  return { open, close, isOpen, modal };
+}


### PR DESCRIPTION
## Summary

Third implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #3 (confirmation modal factory).

**New hook** [\`src/lib/useConfirmation.tsx\`](../blob/refactor/audit-v2-use-confirmation/src/lib/useConfirmation.tsx):

\`\`\`ts
const confirmDelete = useConfirmation({
  title: 'Delete crash report',
  description: 'This cannot be undone.',
  confirmLabel: 'Delete',
  onConfirm: () => deleteCrashReport(id),
});

return (
  <>
    <Button onClick={confirmDelete.open}>Delete</Button>
    {confirmDelete.modal}
  </>
);
\`\`\`

The hook owns open/close state. \`description\` accepts \`ReactNode\` so callers can include item details, secondary checkboxes (bound to parent state), or multi-paragraph copy. Auto-closes on successful \`onConfirm\`; **stays open if \`onConfirm\` throws** so the user can retry — \`onConfirm\` is expected to surface its own error toast (natural pairing with \`withErrorToast\`).

**11 unit tests** pin: default visibility, open(), confirm + auto-close, stay-open-on-reject, cancel/escape fire onCancel, programmatic close(), custom labels, rich ReactNode description with parent-state checkbox.

**Two DownloadQueue modals migrated** as proof:
- "Retry All Failed" (#665) — ~25 LOC of inline modal JSX gone
- "Clear All" — ~28 LOC gone

Two modals deliberately deferred:
- Per-item Delete (#685) — needs \`deleteTarget\` snapshot in description
- Abort Queue (#620) — has "don't ask again" checkbox bound to separate state

Both could migrate (hook supports both via rich descriptions) but are slightly off the happy path.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (#733)
2. ✅ #1 withErrorToast (#734)
3. ✅ #3 useConfirmation (this PR)
4. #6 settings field hook (next, before M8)
5. #5 subprocess reader abstraction
6. #8 state injection docs
7. #2 useAsyncTask hook
8. #7 context_err! macro

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 433 pass (11 new, 0 regressions in 2 migrated modals)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)