### PR TITLE
refactor(hooks): useSettingsField — audit v2 #6

### DIFF
--- a/src/components/settings/tabs/MetadataTab.tsx
+++ b/src/components/settings/tabs/MetadataTab.tsx
@@ -13,44 +13,36 @@
  *     fetched. Maps to `settings.fetch_extra_tags`.
  *
  *   - **AcoustID Fingerprinting** (opt-in) -- When enabled, generates
- *     Chromaprint audio fingerprints using the embedded fingerprinting engine and looks up AcoustID
- *     identifiers from acoustid.org. Writes `Acoustid Id` and
- *     `Acoustid Fingerprint` freeform atoms. Maps to
+ *     Chromaprint audio fingerprints using the embedded fingerprinting
+ *     engine and looks up AcoustID identifiers from acoustid.org. Writes
+ *     `Acoustid Id` and `Acoustid Fingerprint` freeform atoms. Maps to
  *     `settings.acoustid_enabled`. Release builds ship with a built-in
  *     API key; users can optionally override it with their own.
  *
  *   - **ReplayGain Analysis** (opt-in) -- When enabled, analyses audio
  *     loudness using FFmpeg's EBU R128 filter and writes non-destructive
- *     ReplayGain metadata tags (`replaygain_track_gain`,
- *     `replaygain_track_peak`). Maps to `settings.replaygain_enabled`.
+ *     ReplayGain metadata tags. Maps to `settings.replaygain_enabled`.
  *
- * ## Store Connection
+ * ## Field wiring
  *
- * Reads and writes the Zustand `settingsStore`.
- *
- * @see {@link ../SettingsPage.tsx}        -- Parent container
- * @see {@link @/stores/settingsStore.ts}  -- Zustand store
+ * Each form control uses the `useSettingsField` hook (audit v2 #6) so
+ * the field key appears once instead of three times (settings read +
+ * onChange lambda + updateSettings({ key: v }) write).
  */
 
-// Zustand store for reading/writing metadata enrichment settings.
-import { useSettingsStore } from '@/stores/settingsStore';
-
-// Shared form components: Toggle for boolean switches.
 import { Toggle, SettingsSection } from '@/components/common';
+import { useSettingsField } from '@/hooks/useSettingsField';
 
-/**
- * MetadataTab -- Renders the Metadata settings tab.
- *
- * Contains three sections: an informational block about automatic tags,
- * an AcoustID toggle, and a ReplayGain toggle. The automatic tags
- * section is read-only (no controls) since those tags are always written
- * when applicable.
- */
 export function MetadataTab() {
-  /** Current settings snapshot */
-  const settings = useSettingsStore((s) => s.settings);
-  /** Partial-update function for persisting metadata setting changes */
-  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // One hook call per field; `value` + `set` replace the
+  // `settings.X` / `updateSettings({ X: v })` boilerplate.
+  const fetchExtraTags = useSettingsField('fetch_extra_tags');
+  const contentAdvisoryInFilenames = useSettingsField('content_advisory_in_filenames');
+  const acoustidEnabled = useSettingsField('acoustid_enabled');
+  const replaygainEnabled = useSettingsField('replaygain_enabled');
+  const replaygainReferenceLevel = useSettingsField('replaygain_reference_level');
+  const replaygainPreventClipping = useSettingsField('replaygain_prevent_clipping');
+  const replaygainAlbumGain = useSettingsField('replaygain_album_gain');
 
   return (
     <div className="space-y-3">
@@ -69,15 +61,15 @@ export function MetadataTab() {
         <Toggle
           label="Fetch Extra Tags"
           description="Fetch additional metadata from Apple Music (normalization, spatial/lossless properties, smooth playback info). Adds a small delay per track. Disable if you only want basic codec/source tags. Only applies to GAMDL 2.x — GAMDL 3.0 removed this option, and MeedyaDL automatically skips emitting it when v3.0+ is installed."
-          checked={settings.fetch_extra_tags}
-          onChange={(checked) => updateSettings({ fetch_extra_tags: checked })}
+          checked={fetchExtraTags.value}
+          onChange={fetchExtraTags.set}
         />
 
         <Toggle
           label="Content Advisory in Filenames"
           description="Append [Explicit] or [Clean] to album folder names and track filenames based on Apple Music content ratings. Useful for distinguishing explicit and clean versions of the same album."
-          checked={settings.content_advisory_in_filenames}
-          onChange={(checked) => updateSettings({ content_advisory_in_filenames: checked })}
+          checked={contentAdvisoryInFilenames.value}
+          onChange={contentAdvisoryInFilenames.set}
         />
       </SettingsSection>
 
@@ -88,11 +80,11 @@ export function MetadataTab() {
           <Toggle
             label="Enable AcoustID Fingerprinting"
             description="Generate audio fingerprints and look up AcoustID identifiers for each track. Enables music identification via MusicBrainz. Processes each file individually."
-            checked={settings.acoustid_enabled}
-            onChange={(checked) => updateSettings({ acoustid_enabled: checked })}
+            checked={acoustidEnabled.value}
+            onChange={acoustidEnabled.set}
           />
 
-          {settings.acoustid_enabled && (
+          {acoustidEnabled.value && (
             <p className="text-xs text-content-tertiary">
               Release builds include a built-in API key. To use your own key, configure it in
               Settings &gt; Advanced &gt; API Credentials.
@@ -107,11 +99,11 @@ export function MetadataTab() {
           <Toggle
             label="Enable ReplayGain Analysis"
             description="Analyse audio loudness using FFmpeg and embed non-destructive ReplayGain metadata. Compatible players (foobar2000, VLC, Kodi, AIMP, Poweramp) use these tags to normalise volume without altering the audio."
-            checked={settings.replaygain_enabled}
-            onChange={(checked) => updateSettings({ replaygain_enabled: checked })}
+            checked={replaygainEnabled.value}
+            onChange={replaygainEnabled.set}
           />
 
-          {settings.replaygain_enabled && (
+          {replaygainEnabled.value && (
             <>
               <p className="text-xs text-content-secondary mt-2 mb-3 p-3 rounded-platform bg-surface-elevated border border-border-light">
                 <strong>What&apos;s written to each file:</strong><br />
@@ -128,10 +120,8 @@ export function MetadataTab() {
                 </label>
                 <select
                   className="w-full rounded-platform border border-border-light bg-surface-elevated px-3 py-2 text-sm text-content-primary"
-                  value={settings.replaygain_reference_level}
-                  onChange={(e) =>
-                    updateSettings({ replaygain_reference_level: parseFloat(e.target.value) })
-                  }
+                  value={replaygainReferenceLevel.value}
+                  onChange={(e) => replaygainReferenceLevel.set(parseFloat(e.target.value))}
                 >
                   <option value={-18}>-18.0 LUFS (EBU R128 — recommended for music)</option>
                   <option value={-14}>-14.0 LUFS (Spotify / YouTube style — louder)</option>
@@ -146,15 +136,15 @@ export function MetadataTab() {
               <Toggle
                 label="Prevent Clipping"
                 description="Limit gain so that the loudest peak in each track never exceeds 0 dBFS after the gain adjustment. Recommended for tracks mastered at high loudness (modern pop, EDM). Disabling allows more precise loudness matching but risks distortion on some tracks."
-                checked={settings.replaygain_prevent_clipping}
-                onChange={(checked) => updateSettings({ replaygain_prevent_clipping: checked })}
+                checked={replaygainPreventClipping.value}
+                onChange={replaygainPreventClipping.set}
               />
 
               <Toggle
                 label="Include Album Gain"
                 description="Compute and write album-level ReplayGain tags alongside track tags. Album gain preserves the intended dynamic range between quiet and loud tracks when listening to an album in order. When disabled, only per-track gain tags are written (better for shuffle-only listeners)."
-                checked={settings.replaygain_album_gain}
-                onChange={(checked) => updateSettings({ replaygain_album_gain: checked })}
+                checked={replaygainAlbumGain.value}
+                onChange={replaygainAlbumGain.set}
               />
             </>
           )}

--- a/src/hooks/useSettingsField.test.ts
+++ b/src/hooks/useSettingsField.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for useSettingsField (audit v2 #6).
+ *
+ * Pins the hook contract:
+ *   - `value` reflects the current settings field value
+ *   - `value` updates reactively when the store changes
+ *   - `set(next)` writes via updateSettings without duplicating the key
+ *   - `set` is referentially stable across renders (useCallback)
+ *   - Different field types (boolean, string, number, union) all work
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useSettingsField } from '@/hooks/useSettingsField';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+beforeEach(() => {
+  // Reset to a known shape — only fields the tests care about matter.
+  // We use real updateSettings so we exercise the store's actual
+  // write path (shallow merge + isDirty flag).
+  act(() => {
+    useSettingsStore.setState({
+      isDirty: false,
+      settings: {
+        ...useSettingsStore.getState().settings,
+        acoustid_enabled: false,
+        ui_language: 'en-US',
+        update_check_interval_hours: 6,
+        colour_blind_mode: '' as '' | 'deuteranopia' | 'protanopia' | 'tritanopia',
+      },
+    });
+  });
+});
+
+describe('useSettingsField', () => {
+  // ===========================================================================
+  // Read path
+  // ===========================================================================
+
+  it('returns the current value of a boolean field', () => {
+    const { result } = renderHook(() => useSettingsField('acoustid_enabled'));
+    expect(result.current.value).toBe(false);
+  });
+
+  it('returns the current value of a string field', () => {
+    const { result } = renderHook(() => useSettingsField('ui_language'));
+    expect(result.current.value).toBe('en-US');
+  });
+
+  it('returns the current value of a numeric field', () => {
+    const { result } = renderHook(() => useSettingsField('update_check_interval_hours'));
+    expect(result.current.value).toBe(6);
+  });
+
+  it('reflects external store updates reactively', () => {
+    const { result } = renderHook(() => useSettingsField('acoustid_enabled'));
+    expect(result.current.value).toBe(false);
+    act(() => {
+      useSettingsStore.getState().updateSettings({ acoustid_enabled: true });
+    });
+    expect(result.current.value).toBe(true);
+  });
+
+  // ===========================================================================
+  // Write path
+  // ===========================================================================
+
+  it('set() writes the new value via updateSettings', () => {
+    const { result } = renderHook(() => useSettingsField('acoustid_enabled'));
+    act(() => {
+      result.current.set(true);
+    });
+    expect(useSettingsStore.getState().settings.acoustid_enabled).toBe(true);
+    expect(useSettingsStore.getState().isDirty).toBe(true);
+  });
+
+  it('set() does not touch other fields (shallow merge)', () => {
+    const { result } = renderHook(() => useSettingsField('acoustid_enabled'));
+    const beforeLang = useSettingsStore.getState().settings.ui_language;
+    act(() => {
+      result.current.set(true);
+    });
+    const afterLang = useSettingsStore.getState().settings.ui_language;
+    expect(afterLang).toBe(beforeLang);
+  });
+
+  it('set() works for string fields', () => {
+    const { result } = renderHook(() => useSettingsField('ui_language'));
+    act(() => {
+      result.current.set('fr-FR');
+    });
+    expect(useSettingsStore.getState().settings.ui_language).toBe('fr-FR');
+  });
+
+  it('set() works for numeric fields', () => {
+    const { result } = renderHook(() => useSettingsField('update_check_interval_hours'));
+    act(() => {
+      result.current.set(24);
+    });
+    expect(useSettingsStore.getState().settings.update_check_interval_hours).toBe(24);
+  });
+
+  it('set() works for union-typed fields (colour_blind_mode)', () => {
+    const { result } = renderHook(() => useSettingsField('colour_blind_mode'));
+    act(() => {
+      result.current.set('deuteranopia');
+    });
+    expect(useSettingsStore.getState().settings.colour_blind_mode).toBe('deuteranopia');
+  });
+
+  // ===========================================================================
+  // Setter stability
+  // ===========================================================================
+
+  it('set is referentially stable across renders for the same key', () => {
+    const { result, rerender } = renderHook(() => useSettingsField('acoustid_enabled'));
+    const firstSet = result.current.set;
+    rerender();
+    expect(result.current.set).toBe(firstSet);
+  });
+
+  it('set is independent per key (different hooks return different setters)', () => {
+    const { result: a } = renderHook(() => useSettingsField('acoustid_enabled'));
+    const { result: b } = renderHook(() => useSettingsField('ui_language'));
+    expect(a.current.set).not.toBe(b.current.set);
+  });
+});

--- a/src/hooks/useSettingsField.ts
+++ b/src/hooks/useSettingsField.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file useSettingsField — typed selector + setter for one AppSettings key.
+ *
+ * Audit v2 finding #6: every settings tab opens with the same
+ * boilerplate plus per-control wiring:
+ *
+ *   const settings = useSettingsStore((s) => s.settings);
+ *   const updateSettings = useSettingsStore((s) => s.updateSettings);
+ *   // ...
+ *   <Toggle
+ *     checked={settings.acoustid_enabled}
+ *     onChange={(checked) => updateSettings({ acoustid_enabled: checked })}
+ *   />
+ *
+ * 10 tabs × ~20 form controls × ~3 lines of wiring per control =
+ * ~600 LOC of identical lambdas. Each one duplicates the field key
+ * (once in `settings.X` read, once in `{ X: v }` write) — a future
+ * rename has to walk every site.
+ *
+ * This hook collapses the wiring to:
+ *
+ *   const acoustid = useSettingsField('acoustid_enabled');
+ *   <Toggle checked={acoustid.value} onChange={acoustid.set} />
+ *
+ * The key is supplied once. TypeScript checks `K extends keyof
+ * AppSettings`, so a typo is a compile error and `value`/`set` are
+ * narrowly typed to the field's actual type.
+ *
+ * **Subscription efficiency:** each `useSettingsField('X')` call
+ * subscribes to `state.settings.X` only — Zustand re-renders the
+ * consumer only when that field changes, not on unrelated settings
+ * updates. The audit-v1 selector pattern is preserved per-field
+ * automatically.
+ *
+ * **Multi-service relevance:** the M8/M9/M10 per-service settings
+ * tabs (BBC iPlayer session, Spotify credentials, YouTube API key)
+ * will land roughly 20 form controls each. Without this hook, each
+ * tab adds another ~60 LOC of identical lambdas. With it: ~10 LOC.
+ *
+ * @see useSettingsStore — the underlying Zustand store
+ * @see audit doc finding #6 in
+ *      [.github/audits/codebase-unification-audit-v2.md]
+ */
+
+import { useCallback } from 'react';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { AppSettings } from '@/types';
+
+/**
+ * Reactive accessor for a single AppSettings key.
+ *
+ * `value` is narrowed to the field's actual type (e.g. `boolean` for
+ * a toggle, `string` for a text input, `number` for a numeric slider,
+ * union types like `'normal' | 'wide'` preserved verbatim).
+ *
+ * `set` accepts the same type and calls
+ * `updateSettings({ [key]: newValue })` under the hood — no key
+ * duplication at the call site.
+ */
+export interface SettingsField<T> {
+  /** Current value of the field. Re-renders when this field changes. */
+  value: T;
+  /** Set the field to a new value. Marks settings as dirty. */
+  set: (next: T) => void;
+}
+
+/**
+ * Read + set a single field from the AppSettings Zustand store.
+ *
+ * @param key — a key of the AppSettings interface
+ * @returns `{ value, set }` — narrowly typed to `AppSettings[K]`
+ *
+ * @example Toggle wiring
+ *   const enabled = useSettingsField('acoustid_enabled');
+ *   <Toggle checked={enabled.value} onChange={enabled.set} />
+ *
+ * @example Select with a custom string conversion
+ *   const lang = useSettingsField('ui_language');
+ *   <Select value={lang.value} onChange={(v) => lang.set(v)} options={...} />
+ *
+ * @example Numeric input requiring parsing
+ *   const interval = useSettingsField('update_check_interval_hours');
+ *   <input
+ *     type="number"
+ *     value={interval.value}
+ *     onChange={(e) => interval.set(parseInt(e.target.value, 10))}
+ *   />
+ */
+export function useSettingsField<K extends keyof AppSettings>(
+  key: K,
+): SettingsField<AppSettings[K]> {
+  const value = useSettingsStore((s) => s.settings[key]);
+  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // Memoise the setter so consumers can pass `field.set` directly to
+  // onChange without per-render reference churn (matters for memoised
+  // components downstream).
+  const set = useCallback(
+    (next: AppSettings[K]) => {
+      updateSettings({ [key]: next } as Partial<AppSettings>);
+    },
+    [key, updateSettings],
+  );
+  return { value, set };
+}


### PR DESCRIPTION
## Summary

Fourth implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #6 (settings tab boilerplate).

**New hook** [\`src/hooks/useSettingsField.ts\`](../blob/refactor/audit-v2-settings-field-hook/src/hooks/useSettingsField.ts):

\`\`\`ts
const acoustid = useSettingsField('acoustid_enabled');
<Toggle checked={acoustid.value} onChange={acoustid.set} />
\`\`\`

The key is supplied once. TypeScript narrows \`value\` and \`set\` to the field's actual type (\`boolean\` / \`string\` / \`number\` / union) automatically. Each call subscribes to \`state.settings.X\` only — re-renders only on that field's change, preserving audit-v1's per-selector pattern. \`set\` is \`useCallback\`-stable.

**11 unit tests** pin: read for each field type, reactive updates from external store mutations, set writes via updateSettings without touching other fields, set works for union-typed fields, set is referentially stable per key.

**MetadataTab migrated** as proof — 7 controls converted from the inline \`(checked) => updateSettings({ X: checked })\` lambda pattern. Net ~25 LOC saved on this single tab.

**Multi-service relevance: very high.** M8/M9/M10 per-service settings tabs (BBC iPlayer session, Spotify credentials, YouTube API key) will land ~20 controls each. Without this hook: ~60 LOC of identical lambdas per service. With it: ~10 LOC. Direct enabler for M8.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (#733)
2. ✅ #1 withErrorToast (#734)
3. ✅ #3 useConfirmation (#735)
4. ✅ #6 useSettingsField (this PR)
5. #5 subprocess reader abstraction (next, before M9/M10)
6. #8 state injection docs
7. #2 useAsyncTask hook
8. #7 context_err! macro

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 444 pass (11 new, 0 regressions)
- [ ] CI green
- [ ] (Manual: open Settings > Metadata, toggle every control, save, reload — confirm values round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)