### PR TITLE
refactor(utils): spawn_line_reader helper — audit v2 #5

### DIFF
--- a/src-tauri/src/services/engine_runner.rs
+++ b/src-tauri/src/services/engine_runner.rs
@@ -31,10 +31,10 @@
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use crate::utils::process;
+use crate::utils::subprocess_reader::spawn_line_reader;
 
 // ============================================================
 // Progress event payload (generic, replaces GAMDL-specific)
@@ -140,61 +140,44 @@ pub async fn run_engine(
         .take()
         .ok_or_else(|| format!("Failed to capture {engine_id} stderr"))?;
 
-    // Spawn stdout reader task
-    let stdout_task = {
+    // Spawn one reader task per stream via the shared helper. The
+    // per-line work is identical between stdout and stderr — parse,
+    // log, emit on the generic + legacy event channels — so we
+    // capture it once in a builder and invoke `spawn_line_reader`
+    // twice. Audit v2 #5: the helper is the truly-common shell
+    // (BufReader → next_line loop); the visitor body is the
+    // engine-specific work.
+    let make_emitter = |stream_label: &'static str| {
         let download_id = download_id.to_string();
         let engine = engine_id.to_string();
         let app = app.clone();
-        tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
+        move |line: String| {
+            let download_id = download_id.clone();
+            let engine = engine.clone();
+            let app = app.clone();
+            async move {
                 let event = process::parse_gamdl_output(&line);
-                log::debug!("[{engine} stdout] {line}");
+                log::debug!("[{engine} {stream_label}] {line}");
 
                 let progress = EngineProgress {
                     download_id: download_id.clone(),
-                    engine: engine.clone(),
+                    engine,
                     event: event.clone(),
                 };
-                // Emit on both the generic and legacy event channels
+                // Emit on both the generic and legacy event channels —
+                // the frontend still listens to the legacy "gamdl-output"
+                // alias for backwards compatibility.
                 let _ = app.emit("engine-output", &progress);
-                // Legacy compatibility: frontend still listens to "gamdl-output"
                 let legacy = super::gamdl_service::GamdlProgress {
-                    download_id: download_id.clone(),
+                    download_id,
                     event,
                 };
                 let _ = app.emit("gamdl-output", &legacy);
             }
-        })
+        }
     };
-
-    // Spawn stderr reader task
-    let stderr_task = {
-        let download_id = download_id.to_string();
-        let engine = engine_id.to_string();
-        let app = app.clone();
-        tokio::spawn(async move {
-            let reader = BufReader::new(stderr);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                let event = process::parse_gamdl_output(&line);
-                log::debug!("[{engine} stderr] {line}");
-
-                let progress = EngineProgress {
-                    download_id: download_id.clone(),
-                    engine: engine.clone(),
-                    event: event.clone(),
-                };
-                let _ = app.emit("engine-output", &progress);
-                let legacy = super::gamdl_service::GamdlProgress {
-                    download_id: download_id.clone(),
-                    event,
-                };
-                let _ = app.emit("gamdl-output", &legacy);
-            }
-        })
-    };
+    let stdout_task = spawn_line_reader(stdout, make_emitter("stdout"));
+    let stderr_task = spawn_line_reader(stderr, make_emitter("stderr"));
 
     // Wait for process exit
     let status = child

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -99,6 +99,19 @@ pub mod fs_walk;
 /// these; existing callers migrate opportunistically.
 pub mod http_client;
 
+/// Subprocess line-reader spawn helper (audit v2 finding #5).
+///
+/// `spawn_line_reader(stream, visitor)` captures the truly-common
+/// shell at every subprocess reader site (`BufReader → next_line
+/// loop → visitor call`) without forcing the per-line work into a
+/// generic shape. Direct enabler for new pip-engine implementations
+/// (Votify M9, yt-dlp M10) which follow the engine_runner pattern;
+/// callers with caller-specific per-stream state (companion
+/// supervisor's watchdog/accumulator, download queue's last-clean
+/// threading) keep their inline implementations and document the
+/// choice in-source.
+pub mod subprocess_reader;
+
 /// Atomic JSON file write helper (#716 finding #8).
 ///
 /// Replaces 5+ services that independently implement the same

--- a/src-tauri/src/utils/subprocess_reader.rs
+++ b/src-tauri/src/utils/subprocess_reader.rs
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// Subprocess line-reader helper.
+// ==============================
+//
+// Audit v2 finding #5 surveyed four subprocess reader sites
+// (engine_runner stdout+stderr, companion_supervisor stdout+stderr,
+// download_queue stdout+stderr — six readers total across three
+// services). All share the same outer shell:
+//
+//     tokio::spawn(async move {
+//         let reader = BufReader::new(stream);
+//         let mut lines = reader.lines();
+//         while let Ok(Some(line)) = lines.next_line().await {
+//             // per-line work
+//         }
+//     })
+//
+// The per-line work, however, varies wildly:
+//
+// - **engine_runner** parses the line via `process::parse_gamdl_output`,
+//   wraps it in `EngineProgress`, and emits two Tauri events. The
+//   stdout and stderr readers are *truly identical* except for the
+//   stream label.
+//
+// - **companion_supervisor** updates an `AtomicU64` watchdog
+//   timestamp, sets a `post_processing` `AtomicBool` for stdout-only
+//   lines that signal the post-processing phase, accumulates the line
+//   into a `Mutex<String>` for forensic capture, and calls a
+//   per-call `emit_line` closure that returns an `Option<String>`
+//   (used by stderr to remember the last clean error message).
+//
+// - **download_queue** calls `emit_companion_stream_line` directly
+//   on each line; stderr also remembers the last clean line.
+//
+// Because the per-line work diverges so far, a generic visitor
+// signature that satisfies all three sites would have to carry
+// state for the watchdog, accumulator, post-processing flag, and
+// "last clean" return value — at which point the abstraction
+// is bigger than the inline code it replaces.
+//
+// **What this module does:** provides ONE primitive,
+// `spawn_line_reader`, that captures the truly-common shell
+// (`BufReader → next_line loop → visitor`). Each callsite that
+// adopts it sheds ~5 lines of plumbing. **Migration is opt-in;**
+// the engine_runner pair is the natural first adopter (its two
+// readers are identical except for stream label, so they collapse
+// to one helper called twice). Future engine implementations
+// (Votify M9, yt-dlp M10) follow the same shape and adopt the
+// primitive from day one.
+//
+// **What this module deliberately doesn't do:** force the
+// companion_supervisor / download_queue sites to migrate. Their
+// per-line state (watchdog, mutex accumulator, return value
+// threading) wants to live in the same closure as the per-line
+// work, not threaded through a generic visitor signature. They
+// keep their inline implementations and document the choice
+// in-source.
+
+use std::future::Future;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::task::JoinHandle;
+
+/// Spawn a tokio task that reads `stream` line-by-line and invokes
+/// `visitor` for each line. The task exits cleanly when the stream
+/// closes (process exit) or when `visitor` panics — read errors
+/// (broken pipe, etc.) terminate the loop without re-emitting.
+///
+/// The visitor closure is `async`, so callers can `.await` Tauri
+/// event emission, mutex acquisition, or other async work per line
+/// without spawning further tasks.
+///
+/// Returns the `JoinHandle<()>` so callers can `.await` it after
+/// `child.wait()` to drain remaining buffered output before exiting
+/// — match the existing pattern at every callsite.
+///
+/// **Type bounds:** the visitor must be `Send + 'static` so it can
+/// be moved into the spawned task. The future it returns must be
+/// `Send` for the same reason. Captured state (e.g. an `Arc<Mutex>`
+/// accumulator) must be `Send + Sync` accordingly — same constraint
+/// as today's inline `tokio::spawn` blocks.
+///
+/// # Example
+///
+/// ```ignore
+/// let task = spawn_line_reader(stdout, move |line| {
+///     let app = app.clone();
+///     let dl_id = dl_id.clone();
+///     async move {
+///         let event = process::parse_gamdl_output(&line);
+///         let _ = app.emit("engine-output", &EngineProgress {
+///             download_id: dl_id, engine: "gamdl".into(), event,
+///         });
+///     }
+/// });
+/// // ... later
+/// let _ = task.await;
+/// ```
+pub fn spawn_line_reader<S, F, Fut>(stream: S, mut visitor: F) -> JoinHandle<()>
+where
+    S: AsyncRead + Unpin + Send + 'static,
+    F: FnMut(String) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send,
+{
+    tokio::spawn(async move {
+        let reader = BufReader::new(stream);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            visitor(line).await;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::io::AsyncWriteExt;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn reads_lines_from_a_stream_until_close() {
+        // Use an in-memory duplex pipe so we control both ends.
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let collected: Arc<Mutex<Vec<String>>> = Arc::default();
+        let acc = collected.clone();
+
+        let task = spawn_line_reader(reader, move |line| {
+            let acc = acc.clone();
+            async move {
+                acc.lock().await.push(line);
+            }
+        });
+
+        writer.write_all(b"first\nsecond\nthird\n").await.unwrap();
+        // Closing the writer half signals EOF, so the reader loop exits.
+        drop(writer);
+        let _ = task.await;
+
+        let lines = collected.lock().await;
+        assert_eq!(*lines, vec!["first", "second", "third"]);
+    }
+
+    #[tokio::test]
+    async fn handles_partial_final_line_without_trailing_newline() {
+        // Lines without a trailing \n still surface — tokio's
+        // `lines()` yields the final unterminated buffer at EOF.
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let collected: Arc<Mutex<Vec<String>>> = Arc::default();
+        let acc = collected.clone();
+
+        let task = spawn_line_reader(reader, move |line| {
+            let acc = acc.clone();
+            async move {
+                acc.lock().await.push(line);
+            }
+        });
+
+        writer.write_all(b"unterminated").await.unwrap();
+        drop(writer);
+        let _ = task.await;
+
+        let lines = collected.lock().await;
+        assert_eq!(*lines, vec!["unterminated"]);
+    }
+
+    #[tokio::test]
+    async fn empty_stream_produces_zero_visitor_calls() {
+        let (writer, reader) = tokio::io::duplex(64);
+        let collected: Arc<Mutex<Vec<String>>> = Arc::default();
+        let acc = collected.clone();
+
+        let task = spawn_line_reader(reader, move |line| {
+            let acc = acc.clone();
+            async move {
+                acc.lock().await.push(line);
+            }
+        });
+
+        drop(writer); // EOF immediately
+        let _ = task.await;
+
+        assert!(collected.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn visitor_can_share_mutable_state_across_invocations() {
+        // Mirrors the companion_supervisor "accumulator" pattern —
+        // proves the helper supports the same caller-owned state
+        // that the inline blocks use today.
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let count: Arc<Mutex<usize>> = Arc::default();
+        let count_clone = count.clone();
+
+        let task = spawn_line_reader(reader, move |_line| {
+            let c = count_clone.clone();
+            async move {
+                *c.lock().await += 1;
+            }
+        });
+
+        writer.write_all(b"a\nb\nc\nd\ne\n").await.unwrap();
+        drop(writer);
+        let _ = task.await;
+
+        assert_eq!(*count.lock().await, 5);
+    }
+}


### PR DESCRIPTION
## Summary

Fifth implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #5 (subprocess reader abstraction).

**Honest scope assessment:** the audit estimated ~120 LOC saved across 4 reader sites. After surveying the actual code, that estimate was optimistic — companion_supervisor and download_queue carry per-stream state (watchdog timestamps, mutex accumulators, last-clean return-value threading) that doesn't generalise into a clean visitor signature without making the abstraction bigger than the inline code it replaces.

**What this PR ships:**
- New helper [\`utils/subprocess_reader.rs\`](../blob/refactor/audit-v2-subprocess-reader/src-tauri/src/utils/subprocess_reader.rs) with one primitive: \`spawn_line_reader(stream, async_visitor) -> JoinHandle<()>\`
- 4 unit tests pinning the contract: reads-until-close, partial-final-line, empty-stream, visitor mutable-state sharing (proves the helper *could* host the more complex sites if a future audit decides it's worth it)
- engine_runner's two readers migrated — they were byte-identical except for the stream label. Net ~25 LOC saved on this single site
- companion_supervisor and download_queue **stay inline**; the file-level docstring documents why honestly

**Real long-term value:** the primitive is a clean foundation for M9 (Votify) and M10 (yt-dlp) pip-engines, which will follow the engine_runner pattern. They can adopt this from day one rather than re-implementing the BufReader+next_line scaffold.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (#733)
2. ✅ #1 withErrorToast (#734)
3. ✅ #3 useConfirmation (#735)
4. ✅ #6 useSettingsField (#736)
5. ✅ #5 subprocess reader (this PR)
6. #8 state injection docs (next)
7. #2 useAsyncTask hook
8. #7 context_err! macro

## Test plan

- [x] \`cargo clippy --tests -- -D warnings\` clean
- [x] \`cargo test --lib\` — 1003 pass, 1 ignored (4 new)
- [x] \`npm run type-check\` clean
- [x] \`npm run test\` — 444 pass (unchanged)
- [ ] CI green
- [ ] (Manual smoke: start a download, confirm engine output still streams to UI / activity log via both event channels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)