### PR TITLE
refactor(hooks): useAsyncTask — audit v2 #2

### DIFF
--- a/src/components/download/DownloadForm.tsx
+++ b/src/components/download/DownloadForm.tsx
@@ -112,6 +112,9 @@ import {
 /** Apple Music URL parser for multi-URL validation. */
 import { parseAppleMusicUrl } from '@/lib/url-parser';
 
+/** Single-operation async lifecycle hook (audit v2 #2). */
+import { useAsyncTask } from '@/hooks/useAsyncTask';
+
 /**
  * Type imports for Apple Music content types and audio codecs.
  * @see AppleMusicContentType in @/types/index.ts -- 'song' | 'album' | ... | 'unknown'
@@ -266,8 +269,15 @@ export function DownloadForm() {
    */
   const [cookieError, setCookieError] = useState<string | null>(null);
 
-  /** Whether preflight checks are running (disables submit button). */
-  const [isChecking, setIsChecking] = useState(false);
+  // `submitTask` wraps the full preflight + submit flow via
+  // useAsyncTask (audit v2 #2). `submitTask.isRunning` replaces the
+  // hand-rolled `isChecking` boolean; `submitTask.run()` handles the
+  // try/finally toggle internally. The lambda captures
+  // `runPreflightAndSubmit` lazily so the hoisting order doesn't
+  // matter (the const is in the TDZ at hook-call time but
+  // initialised by the time the user clicks Submit).
+  const submitTask = useAsyncTask(() => runPreflightAndSubmit());
+  const isChecking = submitTask.isRunning;
 
   /** Navigation to the Settings page (for the "Go to Settings" link). */
   const setPage = useUiStore((s) => s.setPage);
@@ -367,13 +377,8 @@ export function DownloadForm() {
    * Shows a success toast on success, a warning toast when offline, or an
    * error toast on failure.
    */
-  const handleSubmit = async () => {
-    setIsChecking(true);
-    try {
-      await runPreflightAndSubmit();
-    } finally {
-      setIsChecking(false);
-    }
+  const handleSubmit = () => {
+    void submitTask.run();
   };
 
   /** Internal: run preflight checks then submit. Separated so setIsChecking wraps the full flow. */

--- a/src/hooks/useAsyncTask.test.tsx
+++ b/src/hooks/useAsyncTask.test.tsx
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for useAsyncTask (audit v2 #2).
+ *
+ * Pins the hook contract:
+ *   - Initial state: isRunning=false, error=null
+ *   - run() flips isRunning during the call, back to false after
+ *   - run() returns the resolved value on success
+ *   - run() returns undefined + sets error on rejection
+ *   - run() clears error at the start of each new invocation
+ *   - run() is referentially stable across renders
+ *   - Wrapped fn is captured FRESHLY on each render (no stale closure)
+ *   - Args forwarded through run() to fn
+ *   - Non-Error rejections stringify cleanly
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useAsyncTask } from '@/hooks/useAsyncTask';
+
+describe('useAsyncTask', () => {
+  // ===========================================================================
+  // Initial state
+  // ===========================================================================
+
+  it('starts with isRunning=false, error=null', () => {
+    const { result } = renderHook(() => useAsyncTask(async () => 'ok'));
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  // ===========================================================================
+  // Success path
+  // ===========================================================================
+
+  it('run() returns the resolved value on success', async () => {
+    const { result } = renderHook(() => useAsyncTask(async () => 42));
+    let returned: number | undefined;
+    await act(async () => {
+      returned = await result.current.run();
+    });
+    expect(returned).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('isRunning flips true during the call and false after', async () => {
+    let resolveOuter: ((v: string) => void) | undefined;
+    const fn = () =>
+      new Promise<string>((resolve) => {
+        resolveOuter = resolve;
+      });
+    const { result } = renderHook(() => useAsyncTask(fn));
+
+    let runPromise: Promise<string | undefined> | undefined;
+    act(() => {
+      runPromise = result.current.run();
+    });
+    expect(result.current.isRunning).toBe(true);
+
+    await act(async () => {
+      resolveOuter!('done');
+      await runPromise;
+    });
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  // ===========================================================================
+  // Error path
+  // ===========================================================================
+
+  it('run() returns undefined and surfaces error on rejection', async () => {
+    const { result } = renderHook(() =>
+      useAsyncTask(async () => {
+        throw new Error('boom');
+      }),
+    );
+    let returned: unknown;
+    await act(async () => {
+      returned = await result.current.run();
+    });
+    expect(returned).toBeUndefined();
+    expect(result.current.error).toBe('boom');
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('non-Error rejections stringify cleanly', async () => {
+    const { result } = renderHook(() =>
+      useAsyncTask(async () => {
+        throw 'plain string';
+      }),
+    );
+    await act(async () => {
+      await result.current.run();
+    });
+    expect(result.current.error).toBe('plain string');
+  });
+
+  it('run() clears prior error at the start of a new invocation', async () => {
+    let shouldFail = true;
+    const fn = async () => {
+      if (shouldFail) throw new Error('first failure');
+      return 'ok';
+    };
+    const { result, rerender } = renderHook(({ f }) => useAsyncTask(f), {
+      initialProps: { f: fn },
+    });
+
+    await act(async () => {
+      await result.current.run();
+    });
+    expect(result.current.error).toBe('first failure');
+
+    shouldFail = false;
+    rerender({ f: fn });
+    await act(async () => {
+      await result.current.run();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  // ===========================================================================
+  // Args forwarding
+  // ===========================================================================
+
+  it('forwards args to the wrapped fn', async () => {
+    const fn = vi.fn(async (a: number, b: string) => `${a}-${b}`);
+    const { result } = renderHook(() => useAsyncTask(fn));
+    let returned: string | undefined;
+    await act(async () => {
+      returned = await result.current.run(7, 'x');
+    });
+    expect(fn).toHaveBeenCalledWith(7, 'x');
+    expect(returned).toBe('7-x');
+  });
+
+  // ===========================================================================
+  // Stable run reference + fresh closure
+  // ===========================================================================
+
+  it('run is referentially stable across renders', () => {
+    const { result, rerender } = renderHook(() => useAsyncTask(async () => 'x'));
+    const firstRun = result.current.run;
+    rerender();
+    expect(result.current.run).toBe(firstRun);
+  });
+
+  it('always invokes the LATEST wrapped closure (no stale-closure bug)', async () => {
+    let callCount = 0;
+    const makeFn = (label: string) =>
+      vi.fn(async () => {
+        callCount += 1;
+        return label;
+      });
+
+    const fnA = makeFn('A');
+    const fnB = makeFn('B');
+    const { result, rerender } = renderHook(({ f }) => useAsyncTask(f), {
+      initialProps: { f: fnA },
+    });
+
+    // Capture run from the first render (when fnA was the wrapped fn).
+    const stableRun = result.current.run;
+
+    // Re-render with a different fn — `run` should still point to the
+    // same callback identity, but now invoke fnB.
+    rerender({ f: fnB });
+
+    let returned: string | undefined;
+    await act(async () => {
+      returned = await stableRun();
+    });
+
+    expect(returned).toBe('B');
+    expect(fnA).not.toHaveBeenCalled();
+    expect(fnB).toHaveBeenCalledTimes(1);
+    expect(callCount).toBe(1);
+  });
+});

--- a/src/hooks/useAsyncTask.ts
+++ b/src/hooks/useAsyncTask.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file useAsyncTask — component-local one-shot async lifecycle hook.
+ *
+ * Audit v2 finding #2: ~10 components hand-roll the same shape:
+ *
+ *   const [isLoading, setIsLoading] = useState(false);
+ *   const [error, setError] = useState<string | null>(null);
+ *
+ *   const run = async () => {
+ *     setIsLoading(true);
+ *     setError(null);
+ *     try {
+ *       await ipc();
+ *     } catch (err) {
+ *       setError(err instanceof Error ? err.message : String(err));
+ *     } finally {
+ *       setIsLoading(false);
+ *     }
+ *   };
+ *
+ * `createAsyncResourceStore` (v1.0.7) covers the *store-level*
+ * shape — full data + load + save + dirty tracking. This hook is
+ * the **component-local** sibling: a single async function with
+ * `isRunning` + `error` state, no shared store, no debounce.
+ *
+ *   const submit = useAsyncTask(runPreflight);
+ *   <Button loading={submit.isRunning} onClick={() => submit.run()}>
+ *     Submit
+ *   </Button>
+ *   {submit.error && <p className="text-status-error">{submit.error}</p>}
+ *
+ * Pairs naturally with `withErrorToast` when the call site wants a
+ * toast in addition to local error state:
+ *
+ *   const submit = useAsyncTask(() =>
+ *     withErrorToast(runPreflight, { errorMsg: 'Submit failed' }),
+ *   );
+ *
+ * The wrapped fn can take arbitrary arguments, forwarded through
+ * `run(...args)`. Captured fresh on each render via a ref so
+ * stale-closure bugs don't bite — `run` itself is referentially
+ * stable so it can be passed directly to onClick handlers.
+ *
+ * @see createAsyncResourceStore — store-level sibling (full data + load + save)
+ * @see withErrorToast — natural pairing for toast-on-error
+ * @see audit doc finding #2 in
+ *      [.github/audits/codebase-unification-audit-v2.md]
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseAsyncTaskReturn<TArgs extends unknown[], TResult> {
+  /**
+   * Invoke the wrapped function with `args`. Returns the resolved
+   * value on success, `undefined` on rejection. Errors are NOT
+   * re-thrown — they're surfaced via the `error` state.
+   *
+   * Referentially stable across renders, so it's safe to pass
+   * directly to a button's `onClick` without `useCallback` wrapping.
+   */
+  run: (...args: TArgs) => Promise<TResult | undefined>;
+  /** True while the most recent `run` invocation is in flight. */
+  isRunning: boolean;
+  /**
+   * Error message from the most recent rejection, or `null` if the
+   * last run succeeded (or has not been called yet). Cleared at the
+   * start of each new run.
+   */
+  error: string | null;
+}
+
+/**
+ * Wrap a single async function with `isRunning` + `error` state.
+ *
+ * The wrapped function is captured by ref so the *latest* closure
+ * always runs — pass it inline without worrying about stale state.
+ *
+ * @param fn — the async function to wrap. Re-captured on every render.
+ *
+ * @example No-args
+ *   const submit = useAsyncTask(runPreflight);
+ *   <Button onClick={() => submit.run()}>Submit</Button>
+ *
+ * @example With args
+ *   const del = useAsyncTask((id: string) => deleteCrashReport(id));
+ *   <Button onClick={() => del.run(report.id)}>Delete</Button>
+ *
+ * @example Composed with withErrorToast
+ *   const save = useAsyncTask(() =>
+ *     withErrorToast(saveSettings, {
+ *       successMsg: 'Saved',
+ *       errorMsg: 'Save failed',
+ *     }),
+ *   );
+ */
+export function useAsyncTask<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+): UseAsyncTaskReturn<TArgs, TResult> {
+  // Capture the latest closure on every render so `run` always
+  // calls the current version. Without this, a button wired to a
+  // stable `run` would close over the *first* render's `fn`.
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // `run` is intentionally stable (empty dep array). Captured-by-ref
+  // pattern above keeps the closure fresh without dep churn.
+  const run = useCallback(
+    async (...args: TArgs): Promise<TResult | undefined> => {
+      setIsRunning(true);
+      setError(null);
+      try {
+        return await fnRef.current(...args);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+        return undefined;
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [],
+  );
+
+  return { run, isRunning, error };
+}


### PR DESCRIPTION
## Summary

Seventh implementation cycle of [audit v2](.github/audits/codebase-unification-audit-v2.md). Closes finding #2 (component-local async lifecycle).

**New hook** [\`src/hooks/useAsyncTask.ts\`](../blob/refactor/audit-v2-use-async-task/src/hooks/useAsyncTask.ts) — the component-local sibling of \`createAsyncResourceStore\` (which covers the store-level shape).

\`\`\`ts
const submit = useAsyncTask(runPreflight);
<Button loading={submit.isRunning} onClick={() => submit.run()}>Submit</Button>
{submit.error && <p className="text-status-error">{submit.error}</p>}
\`\`\`

- Args forwarded through \`run(...args)\` — wrapped fn can take arbitrary parameters
- Wrapped fn captured fresh on every render via a ref → no stale-closure bugs
- \`run\` is referentially stable → safe to pass to onClick without \`useCallback\`
- Composes naturally with \`withErrorToast\` when callers want a toast on top

**9 unit tests** pin the contract: initial state, value/error/undefined returns, isRunning toggle timing, prior-error clearing on new run, args forwarding, run reference stability, **always invokes the latest closure** (the captured-by-ref pattern — captured run from render 1 still calls render 2's fn).

**DownloadForm migrated** as proof — replaced the hand-rolled \`isChecking\` boolean + handleSubmit's try/finally toggle with \`submitTask.isRunning\` + \`submitTask.run()\`. The lambda wrapper \`() => runPreflightAndSubmit()\` is required because the wrapped fn is declared after the hook call (TS2448 TDZ otherwise) — captures the binding lazily so click-time the binding is initialised.

**Audit v2 PR plan:**
1. ✅ #4 fixtures (#733)
2. ✅ #1 withErrorToast (#734)
3. ✅ #3 useConfirmation (#735)
4. ✅ #6 useSettingsField (#736)
5. ✅ #5 subprocess reader (#737)
6. ✅ #8 commands README (#738)
7. ✅ #2 useAsyncTask (this PR)
8. #7 context_err! macro (last one)

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 453 pass (9 new, 0 regressions in DownloadForm's 15 tests)
- [ ] CI green
- [ ] (Manual smoke: paste an Apple Music URL, confirm Add to Queue button shows loading state during preflight + clears on completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)