### PR TITLE
refactor(utils): context_err! macro — audit v2 #7 (closes audit v2)

### DIFF
--- a/src-tauri/src/commands/README.md
+++ b/src-tauri/src/commands/README.md
@@ -97,12 +97,22 @@ sync function directly inside an `async fn`.
 ## Error handling
 
 Always use `Result<T, String>`. Map errors with a context-bearing
-prefix:
+prefix via the `context_err!` macro (audit v2 #7):
 
 ```rust
-let entry = keyring::Entry::new(SERVICE_NAME, &key)
-    .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
+use crate::context_err;
+
+let entry = context_err!(
+    keyring::Entry::new(SERVICE_NAME, &key),
+    "Failed to create keyring entry"
+)?;
 ```
+
+This expands to `result.map_err(|e| format!("...: {e}"))?`. Format
+args (`{key}`, `{count}`, etc.) are resolved against the surrounding
+scope — same semantics as `format!()`. New code should always reach
+for the macro; legacy `.map_err(|e| format!(...))?` sites migrate
+opportunistically.
 
 The message reaches the frontend verbatim, so it should be:
 
@@ -148,7 +158,7 @@ so callers don't have to remember the snake_case command string.
 
 When a new service lands, prefer one command module per service:
 
-```
+```text
 commands/
 ├── apple_music.rs   ← future home for AM-specific commands
 ├── bbc_iplayer.rs   ← M8 (BBC iPlayer session, auth)

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -38,6 +38,8 @@
 // - macOS Keychain Services: https://developer.apple.com/documentation/security/keychain_services
 // - Windows Credential Manager: https://learn.microsoft.com/en-us/windows/win32/secauthn/credential-manager
 
+use crate::context_err;
+
 /// The service name used as the namespace in the OS keychain.
 /// All credentials stored by this app use this identifier.
 ///
@@ -86,14 +88,17 @@ pub async fn store_credential(key: String, value: String) -> Result<(), String> 
     // Create a keyring entry handle for the (service, key) pair.
     // Entry::new() can fail if the OS keychain backend is unavailable.
     // See: https://docs.rs/keyring/latest/keyring/struct.Entry.html#method.new
-    let entry = keyring::Entry::new(SERVICE_NAME, &key)
-        .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
+    let entry = context_err!(
+        keyring::Entry::new(SERVICE_NAME, &key),
+        "Failed to create keyring entry"
+    )?;
 
     // Store the credential in the OS keychain.
     // set_password() creates or overwrites the credential atomically.
-    entry
-        .set_password(&value)
-        .map_err(|e| format!("Failed to store credential '{key}': {e}"))?;
+    context_err!(
+        entry.set_password(&value),
+        "Failed to store credential '{key}'"
+    )?;
 
     // Log the key name only (never the value) for debugging and auditing
     log::info!("Credential '{key}' stored securely");
@@ -128,8 +133,10 @@ pub async fn store_credential(key: String, value: String) -> Result<(), String> 
 #[tauri::command]
 pub async fn get_credential(key: String) -> Result<Option<String>, String> {
     // Create a keyring entry handle for the lookup
-    let entry = keyring::Entry::new(SERVICE_NAME, &key)
-        .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
+    let entry = context_err!(
+        keyring::Entry::new(SERVICE_NAME, &key),
+        "Failed to create keyring entry"
+    )?;
 
     // Attempt to retrieve the stored password.
     // The keyring crate distinguishes between "not found" and other errors,
@@ -170,8 +177,10 @@ pub async fn get_credential(key: String) -> Result<Option<String>, String> {
 #[tauri::command]
 pub async fn delete_credential(key: String) -> Result<(), String> {
     // Create a keyring entry handle for the deletion
-    let entry = keyring::Entry::new(SERVICE_NAME, &key)
-        .map_err(|e| format!("Failed to create keyring entry: {e}"))?;
+    let entry = context_err!(
+        keyring::Entry::new(SERVICE_NAME, &key),
+        "Failed to create keyring entry"
+    )?;
 
     // Attempt to delete the credential from the OS keychain.
     // We explicitly handle NoEntry as a success case for idempotency.

--- a/src-tauri/src/utils/error_context.rs
+++ b/src-tauri/src/utils/error_context.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// `context_err!` macro for command-handler error wrapping.
+// =========================================================
+//
+// Audit v2 finding #7: ~30-40 sites across `commands/` repeat the
+// same error-wrapping incantation:
+//
+//     entry.set_password(&value)
+//         .map_err(|e| format!("Failed to store credential '{key}': {e}"))?;
+//
+// The `.map_err(|e| format!("...: {e}"))` is pure plumbing — the
+// caller wants to add a context prefix and propagate. This macro
+// collapses it to:
+//
+//     context_err!(
+//         entry.set_password(&value),
+//         "Failed to store credential '{key}'"
+//     )?;
+//
+// **Real value isn't LOC saved** (~30 chars per site, modest). It's
+// having one place to evolve error formatting — e.g. if we ever
+// decide to swap the `:` separator for `—`, hook all errors into
+// `tracing` events, or migrate to a `CommandError` enum with
+// structured logging, the change touches one macro, not 40 sites.
+//
+// **Naming:** `context_err!` (not `try_with_context!` or similar)
+// to match Rust's `anyhow::Context` ecosystem vocabulary — the
+// concept ("attach a context message to an error before propagating")
+// is the same, just without the `anyhow` dep weight for now.
+//
+// **Migration is opt-in.** New commands should use the macro from
+// the start; existing sites migrate opportunistically. The macro
+// produces byte-for-byte identical output to the inline pattern
+// (same `String` shape: `"<message>: <error display>"`), so a partial
+// migration is observably equivalent to a full one — error messages
+// reaching the frontend stay stable.
+//
+// @see audit doc finding #7 in
+//      [.github/audits/codebase-unification-audit-v2.md]
+
+/// Wrap a `Result<T, E>` with a context-bearing message.
+///
+/// Expands to `result.map_err(|e| format!("{message}: {e}"))`.
+/// The `?` operator stays at the call site so the caller decides
+/// the return type (no implicit propagation).
+///
+/// Format-string args (`{key}`, `{count}`, etc.) are resolved
+/// against the surrounding scope — same semantics as `format!()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Simple static message
+/// let entry = context_err!(
+///     keyring::Entry::new(SERVICE_NAME, &key),
+///     "Failed to create keyring entry"
+/// )?;
+///
+/// // With format args from the surrounding scope
+/// entry.set_password(&value)
+///     .map_err_context("Failed to store credential")?;
+/// // ...is equivalent to:
+/// context_err!(
+///     entry.set_password(&value),
+///     "Failed to store credential '{key}'"
+/// )?;
+/// ```
+#[macro_export]
+macro_rules! context_err {
+    ($result:expr, $($arg:tt)+) => {
+        $result.map_err(|e| format!("{}: {}", format_args!($($arg)+), e))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    // Note: the macro is defined with #[macro_export], so it's
+    // available as `crate::context_err!` everywhere. The tests just
+    // exercise it directly.
+
+    #[test]
+    fn passes_ok_through_unchanged() {
+        let result: Result<i32, String> =
+            context_err!(Ok::<i32, String>(42), "should never appear");
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn prefixes_static_error_message() {
+        let result: Result<(), String> = context_err!(
+            Err::<(), &str>("disk full"),
+            "Failed to write file"
+        );
+        assert_eq!(result, Err("Failed to write file: disk full".to_string()));
+    }
+
+    #[test]
+    fn supports_format_args_from_surrounding_scope() {
+        let key = "musickit_jwt";
+        let result: Result<(), String> = context_err!(
+            Err::<(), &str>("locked"),
+            "Failed to fetch credential '{key}'"
+        );
+        assert_eq!(
+            result,
+            Err("Failed to fetch credential 'musickit_jwt': locked".to_string())
+        );
+    }
+
+    #[test]
+    fn works_with_question_mark_in_a_function() {
+        // Mirrors the real call-site shape — the macro returns a
+        // Result that the caller propagates with `?`.
+        fn doit() -> Result<i32, String> {
+            let value = context_err!(
+                "abc".parse::<i32>(),
+                "Failed to parse number"
+            )?;
+            Ok(value * 2)
+        }
+        let err = doit().unwrap_err();
+        assert!(err.starts_with("Failed to parse number: "));
+    }
+
+    #[test]
+    fn preserves_underlying_error_display() {
+        // Errors that implement Display via #[derive(Debug)] only
+        // would render via `{:?}` — the macro uses `{}` (Display),
+        // matching the existing inline pattern's behaviour.
+        #[derive(Debug)]
+        struct DisplayErr;
+        impl std::fmt::Display for DisplayErr {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "custom display")
+            }
+        }
+        let result: Result<(), String> = context_err!(
+            Err::<(), DisplayErr>(DisplayErr),
+            "Operation failed"
+        );
+        assert_eq!(result, Err("Operation failed: custom display".to_string()));
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -99,6 +99,16 @@ pub mod fs_walk;
 /// these; existing callers migrate opportunistically.
 pub mod http_client;
 
+/// `context_err!` macro for Tauri command error wrapping (audit v2 #7).
+///
+/// Replaces ~30-40 sites of `.map_err(|e| format!("...: {e}"))?`
+/// with `context_err!(result, "...")?`. The macro is exported via
+/// `#[macro_export]` so it lives at crate root (`crate::context_err!`)
+/// rather than under `utils::error_context::`. Real value isn't LOC
+/// saved — it's having one place to evolve error formatting if we
+/// ever migrate to a structured `CommandError` type.
+pub mod error_context;
+
 /// Subprocess line-reader spawn helper (audit v2 finding #5).
 ///
 /// `spawn_line_reader(stream, visitor)` captures the truly-common


### PR DESCRIPTION
## Summary

**Final audit v2 cycle.** Closes finding #7 (Tauri command error-wrapping macro). With this PR merged, **all 8 audit v2 findings ship**.

**New macro** [\`src-tauri/src/utils/error_context.rs\`](../blob/refactor/audit-v2-context-err-macro/src-tauri/src/utils/error_context.rs):

\`\`\`rust
use crate::context_err;

let entry = context_err!(
    keyring::Entry::new(SERVICE_NAME, &key),
    "Failed to create keyring entry"
)?;
\`\`\`

Expands to \`result.map_err(|e| format!("...: {e}"))?\`. Format args resolve against the surrounding scope. Exported via \`#[macro_export]\` so the call site is \`crate::context_err!\`.

**Honest scope assessment.** Per-site savings are modest (~30 chars). The real value: one place to evolve error formatting (separator change, structured logging, migration to a \`CommandError\` enum) — without the macro, that's a 40-site search-and-replace.

**5 unit tests** pin: Ok pass-through, static prefix, format args from scope, function-body usage with \`?\`, Display preservation.

**Three credentials.rs sites migrated** as proof. \`commands/README.md\` updated to point new code at the macro.

## Audit v2 — final scoreboard

| # | Title | PR | Status |
|---|---|---|---|
| 4 | Test fixture builders | #733 | ✅ |
| 1 | withErrorToast helper | #734 | ✅ |
| 3 | useConfirmation hook | #735 | ✅ |
| 6 | useSettingsField hook | #736 | ✅ |
| 5 | Subprocess reader | #737 | ✅ |
| 8 | Commands authoring guide | #738 | ✅ |
| 2 | useAsyncTask hook | #739 | ✅ |
| 7 | context_err! macro | this | ✅ |

## Test plan

- [x] \`cargo clippy --tests -- -D warnings\` clean
- [x] \`cargo test --lib\` — 1008 pass, 1 ignored (5 new)
- [x] \`npm run type-check + lint + test\` unchanged from last cycle (no frontend touch)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)