### PR TITLE
fix(release): pipeline cleanup — stop placeholder, halt cadence drift

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -22,9 +22,14 @@
 name: Monthly Release
 
 on:
-  schedule:
-    # 00:00 UTC on the 1st of each month
-    - cron: '0 0 1 * *'
+  # Cron schedule disabled 2026-05-10 per project decision — see the
+  # weekly-release.yml note for rationale. Workflow remains available
+  # for `workflow_dispatch` if a one-off monthly cut is wanted.
+  # To re-enable the cron, uncomment the schedule block below.
+  #
+  # schedule:
+  #   # 00:00 UTC on the 1st of each month
+  #   - cron: '0 0 1 * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -41,8 +41,89 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Change-detection gate (added 2026-05-10).
+  #
+  # Before the cron-driven daily build kicks off, check whether
+  # anything has actually changed since the last nightly tag. If
+  # `main` AND every `origin/feat/*` branch are unchanged at HEAD
+  # since the previous nightly's commit, skip the whole pipeline —
+  # there's no point publishing a byte-identical rebuild.
+  #
+  # The manual `workflow_dispatch` trigger always bypasses this gate
+  # so a maintainer can force a build via the GitHub UI / CLI even
+  # on a quiet day (useful for re-running after a transient build
+  # failure or testing the workflow itself).
+  check:
+    name: Check for new commits since last nightly
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout main with full history + tags
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Detect changes since last nightly
+        id: detect
+        run: |
+          set -euo pipefail
+
+          # Manual triggers always proceed — change-detection is for
+          # the cron path only. Maintainers running `gh workflow run
+          # "Nightly Release"` mean it.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual trigger — bypassing change-detection"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual trigger" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Find the most recent nightly tag (lexically sorted by
+          # version — `git tag --sort=-v:refname` handles the
+          # `vX.Y.Z-nightly.YYYYMMDD` suffix correctly).
+          PREV_TAG=$(git tag --list 'v*-nightly.*' --sort=-v:refname | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous nightly tag found — first nightly will build"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=first nightly (no previous tag)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Previous nightly tag: $PREV_TAG"
+
+          # Did `main` advance since the previous nightly?
+          MAIN_NEW=$(git rev-list "$PREV_TAG..origin/main" --count)
+          echo "New commits on main since $PREV_TAG: $MAIN_NEW"
+
+          # Did any `feat/*` branch advance since the previous nightly?
+          # (The nightly build merges every feat/* branch, so a new
+          # commit on any of them is also a reason to rebuild.)
+          FEAT_NEW=0
+          FEAT_DETAILS=""
+          for ref in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/feat/*'); do
+            n=$(git rev-list "$PREV_TAG..$ref" --count)
+            if [ "$n" -gt 0 ]; then
+              FEAT_NEW=$((FEAT_NEW + n))
+              FEAT_DETAILS="$FEAT_DETAILS $ref(+$n)"
+            fi
+          done
+          echo "New commits on feat/* branches since $PREV_TAG: $FEAT_NEW ($FEAT_DETAILS)"
+
+          if [ "$MAIN_NEW" -eq 0 ] && [ "$FEAT_NEW" -eq 0 ]; then
+            echo "::notice::No new commits since $PREV_TAG — skipping nightly build"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no new commits since $PREV_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=main+$MAIN_NEW feat+$FEAT_NEW since $PREV_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
   nightly:
     name: Build nightly tag
+    needs: check
+    if: needs.check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1046,6 +1046,18 @@ jobs:
           # Get the current release body
           CURRENT_BODY=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
 
+          # Strip any leading "Release in progress..." placeholder + the
+          # optional `---` separator that follows it. The placeholder is
+          # inserted by the per-platform `gh release create --notes
+          # "Release in progress..."` race-guard calls earlier in this
+          # workflow (lines ~805 / ~873 / ~898). Without this strip the
+          # placeholder becomes persistent in the final body — see the
+          # 2026-05-10 release-pipeline-cleanup PR which backfilled 13
+          # historical releases that had this issue. One-line python
+          # invocation avoids YAML indentation interactions with a
+          # heredoc-style script.
+          CURRENT_BODY=$(printf '%s' "$CURRENT_BODY" | python3 -c "import re,sys;sys.stdout.write(re.sub(r'^Release in progress[^\n]*\n+(?:---\s*\n+)?', '', sys.stdin.read()))")
+
           # Check if the download guide has already been appended (idempotent)
           if echo "$CURRENT_BODY" | grep -q "Choose your download"; then
             echo "Download guide already present in release notes. Skipping."

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -22,9 +22,16 @@
 name: Weekly Release
 
 on:
-  schedule:
-    # 00:00 UTC every Sunday
-    - cron: '0 0 * * 0'
+  # Cron schedule disabled 2026-05-10 per project decision — weekly +
+  # monthly cadences were too aggressive given how few external
+  # signals reach those channels. Keep the workflow file so it's
+  # available for `workflow_dispatch` (manual invocation from the
+  # GitHub UI / CLI) when a one-off weekly cut is genuinely wanted.
+  # To re-enable the cron, uncomment the schedule block below.
+  #
+  # schedule:
+  #   # 00:00 UTC every Sunday
+  #   - cron: '0 0 * * 0'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary

Three CI/release fixes addressing user-reported issues:

### 1. Stop "Release in progress..." persistence (\`release.yml\`)

Per-platform build steps create the GitHub Release with \`gh release create --notes "Release in progress..."\` as a race-guard. The "Append download guide" step then appended to that body — leaving the placeholder as the leading line forever in every release that wasn't pre-populated by release-please-action.

**Backfill:** 13 historical releases cleaned via direct \`gh release edit\`:
\`v1.0.0-rc.1\`, \`v0.53.2-nightly.20260508\`, \`v0.53.2-nightly.20260507\`, \`v0.53.1-nightly.20260506\`, \`v0.52.4-nightly.20260505\`, \`v0.52.2-weekly.20260503\`, \`v0.52.2-nightly.20260503\`, \`v0.52.1-nightly.20260502\`, \`v0.52.1-monthly.20260501\`, \`v0.52.1-nightly.20260501\`, \`v0.51.0-nightly.20260430\`, \`v0.50.1-nightly.20260429\`, \`v0.49.2-nightly.20260428\`. Two May-10 tags were inaccessible at backfill time (returned "release not found").

**Workflow patch:** the "Append download guide" step now strips a leading \`Release in progress…\` line + optional \`---\` separator from the existing body before appending — placeholder can't survive into the final release.

### 2. Weekly + monthly cron schedules disabled

Per user direction. The \`schedule:\` blocks in [\`weekly-release.yml\`](../blob/fix/release-pipeline-cleanup/.github/workflows/weekly-release.yml) and [\`monthly-release.yml\`](../blob/fix/release-pipeline-cleanup/.github/workflows/monthly-release.yml) are commented out; \`workflow_dispatch\` remains so they can still be cut manually if wanted. To re-enable the cron, uncomment.

### 3. Nightly change-detection gate

The daily nightly cron previously always ran end-to-end, producing byte-identical rebuilds when nothing had changed.

New \`check\` job runs first on the cron path:
- Finds the most recent \`v*-nightly.*\` tag
- Counts new commits on \`main\` AND on every \`origin/feat/*\` branch since that tag
- Skips the build when both counts are zero

The \`nightly\` build job gates on \`needs.check.outputs.should_run == 'true'\`. Manual \`workflow_dispatch\` always bypasses the gate.

**Also fixed earlier this session** (no PR needed): v1.1.0 release notes deduplicated (149 → 133 bullets) via direct \`gh release edit\`.

## Test plan

- [x] All 4 YAMLs validate via \`yaml.safe_load\`
- [x] CI green (only PR title check + CodeQL should run; this PR doesn't touch buildable code)
- [ ] (Post-merge) Watch the next scheduled nightly cron — expect either a build or a "no new commits" skip notice depending on whether commits land tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)