### PR TITLE
feat(history): tooltip + right-click actions on long error messages

### DIFF
--- a/src/components/common/ErrorMessageDisplay.test.tsx
+++ b/src/components/common/ErrorMessageDisplay.test.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for ErrorMessageDisplay.
+ *
+ * Pins the contract:
+ *   - Renders the message text
+ *   - Returns null when message is empty
+ *   - Right-click opens a context menu
+ *   - "Copy error message" writes to navigator.clipboard
+ *   - "Report this bug to GAMDL" appears ONLY for messages prefixed
+ *     with "GAMDL bug" — not for arbitrary errors
+ *   - The pre-filled GitHub URL contains the error text + source URL,
+ *     and never references MeedyaDL (upstream maintainers want a
+ *     clean GAMDL-user-shaped report)
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { ErrorMessageDisplay } from '@/components/common/ErrorMessageDisplay';
+import { useUiStore } from '@/stores/uiStore';
+
+// Capture what the shell plugin would have opened.
+const openMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: (url: string) => openMock(url),
+}));
+
+beforeEach(() => {
+  openMock.mockClear();
+  useUiStore.setState({ toasts: [] });
+  // jsdom's clipboard is undefined by default — provide a writeText spy.
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('ErrorMessageDisplay', () => {
+  // ===========================================================================
+  // Rendering
+  // ===========================================================================
+
+  it('renders the message text', () => {
+    render(<ErrorMessageDisplay message="disk full" />);
+    expect(screen.getByText('disk full')).toBeInTheDocument();
+  });
+
+  it('returns null when message is empty', () => {
+    const { container } = render(<ErrorMessageDisplay message="" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('applies line-clamp-2 by default', () => {
+    render(<ErrorMessageDisplay message="boom" />);
+    expect(screen.getByText('boom').className).toMatch(/line-clamp-2/);
+  });
+
+  it('honours truncateLines={null} (no clamp class)', () => {
+    render(<ErrorMessageDisplay message="boom" truncateLines={null} />);
+    const el = screen.getByText('boom');
+    expect(el.className).not.toMatch(/line-clamp/);
+  });
+
+  it('honours custom truncateLines via the literal lookup', () => {
+    render(<ErrorMessageDisplay message="boom" truncateLines={3} />);
+    expect(screen.getByText('boom').className).toMatch(/line-clamp-3/);
+  });
+
+  // ===========================================================================
+  // Context menu
+  // ===========================================================================
+
+  it('right-click opens a context menu with "Copy error message"', () => {
+    render(<ErrorMessageDisplay message="boom" />);
+    fireEvent.contextMenu(screen.getByText('boom'));
+    expect(screen.getByText('Copy error message')).toBeInTheDocument();
+  });
+
+  it('Copy writes the message to navigator.clipboard', async () => {
+    render(<ErrorMessageDisplay message="boom-copy" />);
+    fireEvent.contextMenu(screen.getByText('boom-copy'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy error message'));
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('boom-copy');
+  });
+
+  // ===========================================================================
+  // GAMDL-bug detection + GitHub link
+  // ===========================================================================
+
+  it('hides the GAMDL report option for non-GAMDL errors', () => {
+    render(<ErrorMessageDisplay message="Network timeout" />);
+    fireEvent.contextMenu(screen.getByText('Network timeout'));
+    expect(screen.queryByText('Report this bug to GAMDL')).not.toBeInTheDocument();
+  });
+
+  it('shows the GAMDL report option for messages prefixed "GAMDL bug"', () => {
+    render(
+      <ErrorMessageDisplay message="GAMDL bug — music-video cover URL not templated" />
+    );
+    fireEvent.contextMenu(
+      screen.getByText('GAMDL bug — music-video cover URL not templated')
+    );
+    expect(screen.getByText('Report this bug to GAMDL')).toBeInTheDocument();
+  });
+
+  it('Report opens upstream GAMDL issues/new with the error in the body', async () => {
+    render(
+      <ErrorMessageDisplay
+        message="GAMDL bug — music-video cover URL not templated."
+        sourceUrl="https://music.apple.com/us/album/foo/123"
+      />
+    );
+    fireEvent.contextMenu(
+      screen.getByText('GAMDL bug — music-video cover URL not templated.')
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Report this bug to GAMDL'));
+    });
+
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    const url = openMock.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/github\.com\/glomatico\/gamdl\/issues\/new\?/);
+    // Use URL.searchParams to decode `+`-as-space form-encoding
+    // properly (decodeURIComponent leaves `+` alone).
+    const params = new URL(url).searchParams;
+    // Title strips the "GAMDL bug — " prefix so it reads as a user summary.
+    expect(params.get('title')).toBe('music-video cover URL not templated.');
+    // Body contains the failed URL + the original error text.
+    const body = params.get('body') ?? '';
+    expect(body).toContain('https://music.apple.com/us/album/foo/123');
+    expect(body).toContain('GAMDL bug — music-video cover URL not templated.');
+  });
+
+  it('GitHub URL never references MeedyaDL (upstream wants a clean GAMDL report)', async () => {
+    render(
+      <ErrorMessageDisplay
+        message="GAMDL bug — sample defect"
+        sourceUrl="https://music.apple.com/us/album/x/1"
+      />
+    );
+    fireEvent.contextMenu(screen.getByText('GAMDL bug — sample defect'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Report this bug to GAMDL'));
+    });
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    const params = new URL(openMock.mock.calls[0][0]).searchParams;
+    const wholeText = `${params.get('title')}\n${params.get('body')}`;
+    expect(wholeText.toLowerCase()).not.toContain('meedyadl');
+  });
+
+  it('omits the URL block from the body when sourceUrl is not provided', async () => {
+    render(<ErrorMessageDisplay message="GAMDL bug — defect with no URL context" />);
+    fireEvent.contextMenu(screen.getByText('GAMDL bug — defect with no URL context'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Report this bug to GAMDL'));
+    });
+    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    const body = new URL(openMock.mock.calls[0][0]).searchParams.get('body') ?? '';
+    // No "### URL" section when sourceUrl is omitted
+    expect(body).not.toContain('### URL');
+    // But the error block is still present
+    expect(body).toContain('### Error output');
+  });
+});

--- a/src/components/common/ErrorMessageDisplay.tsx
+++ b/src/components/common/ErrorMessageDisplay.tsx
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file ErrorMessageDisplay — truncated error text with tooltip + actions.
+ *
+ * Long download errors (notably GAMDL bug reports — see the
+ * `"GAMDL bug — …"` prefix emitted by `download_queue.rs`) used to
+ * truncate at the right edge of the History row with no way to read
+ * the full text without resizing the window. This component:
+ *
+ * - Truncates the visible text to the configured number of lines via
+ *   Tailwind `line-clamp-N`.
+ * - Wraps in a {@link Tooltip} that surfaces the FULL message on
+ *   hover/focus — works on the keyboard too.
+ * - Adds a right-click context menu with:
+ *   - **Copy error message** (always)
+ *   - **Report this bug to GAMDL** (only when the message looks like
+ *     a known upstream defect — recognised via the `"GAMDL bug "`
+ *     prefix that `download_queue.rs` emits). Opens the upstream
+ *     repo's `issues/new` URL with the title and body pre-filled
+ *     from the failed URL + the error text. The pre-fill is
+ *     written from a normal-GAMDL-user perspective: no MeedyaDL
+ *     branding, no "via MeedyaDL" attribution — upstream
+ *     maintainers want a clean repro on bare GAMDL.
+ *
+ * Used by HistoryPage and QueueItem.
+ */
+
+import { useCallback, useState, type MouseEvent, type ReactElement } from 'react';
+import { Bug, Copy } from 'lucide-react';
+import { open as openExternal } from '@tauri-apps/plugin-shell';
+// Sibling imports (NOT via the @/components/common barrel) to avoid a
+// circular dependency: the barrel re-exports this very component, so
+// going through it would resolve to `undefined` at module evaluation
+// time and produce a runtime "Element type is invalid" crash.
+import { ContextMenu } from './ContextMenu';
+import type { ContextMenuItem } from './ContextMenu';
+import { Tooltip } from './Tooltip';
+import { useUiStore } from '@/stores/uiStore';
+
+export interface ErrorMessageDisplayProps {
+  /** The error message to render. */
+  message: string;
+  /**
+   * The source URL of the failed download, when known. Included in
+   * the pre-filled GitHub issue body so upstream can reproduce.
+   */
+  sourceUrl?: string;
+  /**
+   * Number of lines to show before truncating with an ellipsis.
+   * Defaults to `2`. Pass `null` to disable truncation entirely
+   * (full text wraps inline; tooltip + context menu still work).
+   */
+  truncateLines?: number | null;
+  /**
+   * Tailwind classes for the visible text. Defaults to
+   * `"text-xs text-status-error"` to match the existing inline
+   * pattern. Override when the host context needs different
+   * sizing (e.g. larger error in a detail panel).
+   */
+  className?: string;
+}
+
+/**
+ * Detects messages that look like a known upstream GAMDL defect.
+ * The "GAMDL bug " prefix is emitted by MeedyaDL's
+ * `download_queue.rs` when a specific upstream pattern matches —
+ * see `process::is_mv_cover_template_bug_error` and adjacent
+ * classifiers. Future GAMDL-bug detectors should keep using this
+ * prefix so this UI surfaces them automatically.
+ */
+function isGamdlBug(message: string): boolean {
+  return message.startsWith('GAMDL bug');
+}
+
+/**
+ * Build a `https://github.com/glomatico/gamdl/issues/new?…`
+ * URL with the title + body pre-filled.
+ *
+ * No MeedyaDL branding by design — the upstream maintainer should
+ * see a normal GAMDL-user bug report. The body is a
+ * markdown-friendly template the user can edit before submitting.
+ */
+function buildGamdlIssueUrl(message: string, sourceUrl?: string): string {
+  // Strip the "GAMDL bug — " prefix so the title reads like a
+  // user-authored summary, not MeedyaDL's classifier output.
+  const stripped = message.replace(/^GAMDL bug\s*[—\-:]\s*/, '');
+  // Take the first sentence (or first ~80 chars) for the title.
+  const firstSentence = stripped.split(/(?<=[.!?])\s/)[0] ?? stripped;
+  const title = firstSentence.length > 80
+    ? firstSentence.slice(0, 77).trimEnd() + '…'
+    : firstSentence;
+
+  const bodyLines: string[] = [];
+  bodyLines.push('### What happened');
+  bodyLines.push('');
+  bodyLines.push('<!-- Briefly describe what you were trying to download and what went wrong. -->');
+  bodyLines.push('');
+  if (sourceUrl) {
+    bodyLines.push('### URL');
+    bodyLines.push('');
+    bodyLines.push('```');
+    bodyLines.push(sourceUrl);
+    bodyLines.push('```');
+    bodyLines.push('');
+  }
+  bodyLines.push('### Error output');
+  bodyLines.push('');
+  bodyLines.push('```');
+  bodyLines.push(message);
+  bodyLines.push('```');
+  bodyLines.push('');
+  bodyLines.push('### Environment');
+  bodyLines.push('');
+  bodyLines.push('- GAMDL version: <!-- run `gamdl --version` -->');
+  bodyLines.push('- Operating system: ');
+  bodyLines.push('- Python version: <!-- `python --version` -->');
+
+  const params = new URLSearchParams({
+    title,
+    body: bodyLines.join('\n'),
+  });
+  return `https://github.com/glomatico/gamdl/issues/new?${params.toString()}`;
+}
+
+export function ErrorMessageDisplay({
+  message,
+  sourceUrl,
+  truncateLines = 2,
+  className = 'text-xs text-status-error',
+}: ErrorMessageDisplayProps): ReactElement | null {
+  const addToast = useUiStore((s) => s.addToast);
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  const handleContextMenu = useCallback((e: MouseEvent) => {
+    e.preventDefault();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  }, []);
+  const closeMenu = useCallback(() => setMenuPos(null), []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(message);
+      addToast('Error message copied to clipboard', 'info');
+    } catch {
+      addToast('Could not copy to clipboard', 'error');
+    }
+  }, [addToast, message]);
+
+  const handleReportToGamdl = useCallback(async () => {
+    const url = buildGamdlIssueUrl(message, sourceUrl);
+    try {
+      await openExternal(url);
+    } catch {
+      addToast('Could not open browser', 'error');
+    }
+  }, [addToast, message, sourceUrl]);
+
+  if (!message) return null;
+
+  const items: ContextMenuItem[] = [
+    {
+      label: 'Copy error message',
+      icon: <Copy size={14} />,
+      onClick: handleCopy,
+    },
+  ];
+  if (isGamdlBug(message)) {
+    items.push({
+      label: 'Report this bug to GAMDL',
+      icon: <Bug size={14} />,
+      onClick: handleReportToGamdl,
+      separator: true,
+    });
+  }
+
+  // `line-clamp-2` / `line-clamp-3` etc. — Tailwind's standard
+  // multi-line truncation utility. `null` disables truncation.
+  // Lookup table (not template-literal interpolation) so Tailwind's
+  // content scanner sees each literal class string.
+  const CLAMP_CLASSES: Record<number, string> = {
+    1: 'line-clamp-1',
+    2: 'line-clamp-2',
+    3: 'line-clamp-3',
+    4: 'line-clamp-4',
+    5: 'line-clamp-5',
+    6: 'line-clamp-6',
+  };
+  const clampClass = truncateLines === null ? '' : (CLAMP_CLASSES[truncateLines] ?? 'line-clamp-2');
+
+  return (
+    <>
+      <Tooltip content={message} position="top">
+        <p
+          className={`${className} ${clampClass} cursor-default select-text`}
+          onContextMenu={handleContextMenu}
+        >
+          {message}
+        </p>
+      </Tooltip>
+      {menuPos && (
+        <ContextMenu items={items} x={menuPos.x} y={menuPos.y} onClose={closeMenu} />
+      )}
+    </>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -122,6 +122,15 @@ export { LoadingSpinner } from './LoadingSpinner';
 export { Tooltip } from './Tooltip';
 
 /**
+ * Truncated error-message display with hover-to-see-full tooltip and a
+ * right-click context menu (copy, report-to-GAMDL when applicable).
+ * Used in HistoryPage + QueueItem to surface long download errors
+ * (especially upstream "GAMDL bug — …" classifier messages) without
+ * forcing the user to widen the window.
+ */
+export { ErrorMessageDisplay } from './ErrorMessageDisplay';
+
+/**
  * Small "?" icon button that navigates to the Help page with a specific
  * topic pre-selected. Used inline next to settings labels for contextual help.
  * Used in: Input, Select, Toggle (via helpTopic prop), and standalone in settings tabs.

--- a/src/components/download/HistoryPage.tsx
+++ b/src/components/download/HistoryPage.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 
 import { PageHeader } from '@/components/layout/PageHeader';
-import { Button, ContextMenu, Modal } from '@/components/common';
+import { Button, ContextMenu, ErrorMessageDisplay, Modal } from '@/components/common';
 import type { ContextMenuItem } from '@/components/common';
 import {
   Trash2,
@@ -422,15 +422,31 @@ export function HistoryPage() {
                       )}
                     </div>
 
-                    {/* Error message for failed downloads */}
+                    {/* Error message for failed downloads.
+                        Wrapped in ErrorMessageDisplay so long messages
+                        (especially upstream "GAMDL bug — …" classifier
+                        outputs) get a hover tooltip with the full text
+                        + a right-click menu to copy or report
+                        upstream. The visible text still truncates to
+                        2 lines so the row layout doesn't blow out. */}
                     {entry.error_message && (
-                      <p className="text-xs text-status-error mt-1 line-clamp-2">
-                        {entry.error_message}
-                      </p>
+                      <div className="mt-1">
+                        <ErrorMessageDisplay
+                          message={entry.error_message}
+                          sourceUrl={entry.url}
+                          truncateLines={2}
+                        />
+                      </div>
                     )}
 
-                    {/* URL (shown small below the title) */}
-                    <p className="text-[11px] text-content-tertiary mt-0.5 truncate">
+                    {/* URL (shown small below the title). `title` adds a
+                        native browser tooltip so long Apple Music URLs
+                        — which often run past the visible row width — are
+                        readable on hover without resizing the window. */}
+                    <p
+                      className="text-[11px] text-content-tertiary mt-0.5 truncate"
+                      title={entry.url}
+                    >
                       {entry.url}
                     </p>
                   </div>

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -77,7 +77,7 @@ import {
  * percentage value. Accepts `null` to display an indeterminate state.
  * @see ProgressBar in @/components/common
  */
-import { ProgressBar, ContextMenu } from '@/components/common';
+import { ProgressBar, ContextMenu, ErrorMessageDisplay } from '@/components/common';
 import type { ContextMenuItem } from '@/components/common';
 
 /**
@@ -586,7 +586,16 @@ export function QueueItem({
        * `pl-7` aligns with the URL text above.
        */}
       {item.state === 'error' && item.error && (
-        <p className="mt-1.5 pl-7 text-xs text-status-error">{item.error}</p>
+        <div className="mt-1.5 pl-7">
+          <ErrorMessageDisplay
+            message={item.error}
+            sourceUrl={item.urls?.[0]}
+            // Queue rows are full-width so we don't aggressively
+            // truncate, but tooltip + right-click (copy / report
+            // upstream when applicable) still apply.
+            truncateLines={null}
+          />
+        </div>
       )}
 
       {/*


### PR DESCRIPTION
## Summary

The History row's error text was truncated at the right edge of the visible area for long messages — notably upstream "GAMDL bug — …" classifier outputs. Reading the full text required widening the window. New shared `ErrorMessageDisplay` component fixes this with three layered affordances:

- **Hover/focus tooltip** showing the full text
- **Right-click → Copy error message** (always)
- **Right-click → Report this bug to GAMDL** (only when the message looks like an upstream defect — recognised via the `"GAMDL bug "` prefix that `download_queue.rs` emits). Opens [`glomatico/gamdl/issues/new`](https://github.com/glomatico/gamdl/issues/new) with title + body pre-filled from the failed URL + the error text.

The pre-filled GitHub URL is **intentionally MeedyaDL-free** — no branding, no "via MeedyaDL" attribution, no internal classifier metadata. Upstream maintainers get a clean repro shaped like a normal GAMDL-user bug report (title strips the classifier prefix so it reads as a user-authored summary; body template has URL / Error output / Environment sections to fill in).

## Wiring

- [`HistoryPage.tsx`](../blob/feat/error-message-tooltip-actions/src/components/download/HistoryPage.tsx) — replaces the inline `line-clamp-2` `<p>`. The URL paragraph below it also gets a native `title={entry.url}` tooltip (same problem class for long Apple Music URLs).
- [`QueueItem.tsx`](../blob/feat/error-message-tooltip-actions/src/components/download/QueueItem.tsx) — replaces the inline error `<p>` (no truncation since queue rows are full-width, but tooltip + right-click affordances apply).

## Tests

12 unit tests pin: render + null-on-empty + line-clamp variants, right-click menu open, copy writes to clipboard, "Report" gated on GAMDL prefix, `URL.searchParams.get('body')` contains the error + sourceUrl, title strips the classifier prefix, no MeedyaDL anywhere in the report URL, omitted sourceUrl drops the URL section.

## Implementation note

Imports siblings via `./ContextMenu` / `./Tooltip` rather than the `@/components/common` barrel — the barrel re-exports this very file, so a barrel import would resolve to `undefined` at module-evaluation time and crash with the React "Element type is invalid" runtime error.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 465 pass (12 new, 0 regressions)
- [ ] CI green
- [ ] Manual: in History, hover a long error → tooltip shows full text; right-click → "Copy error message" works; right-click on a "GAMDL bug — …" entry → "Report this bug to GAMDL" appears + opens upstream issue form pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)