### PR TITLE
fix(ui): stop stale 'Finalising metadata' label + sync auto-scroll checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ When a wrapper download fails (all retries exhausted), MeedyaDL normally shows a
 
 When enabled, failed wrapper downloads are automatically re-queued with cookie-based authentication — no manual intervention needed. This is useful if your wrapper is intermittently unavailable and you want downloads to fall back gracefully.
 
+### Re-authenticating the Wrapper
+
+If the wrapper appears connected (the connection test passes, the pre-flight checks all clear) but every track skips with `Decryption is not available for media ID: …` in the Activity Log, the wrapper's stored Apple Music credentials have most likely gone stale and need re-authenticating.
+
+For Docker installs, stop the container, run the wrapper one-shot in **login mode** (`docker run --privileged --rm -it -v ./rootfs/data:/app/rootfs/data --entrypoint ./wrapper ghcr.io/worldobservationlog/wrapper:local -L "username:password" -H 0.0.0.0`), enter your 2FA code if prompted, Ctrl-C once login completes, then start the container again. For native installs, the equivalent is to run the binary once with `-L "username:password"` to re-sign-in. Full step-by-step + diagnostic guidance lives in the in-app help under [**Help > Troubleshooting > Wrapper Errors > "Decryption is not available" warnings**](help/troubleshooting.md#decryption-is-not-available-warnings-wrapper-enabled-downloads-still-skipping).
+
 ### Verifying Connectivity
 
 MeedyaDL checks wrapper connectivity in two ways:

--- a/help/troubleshooting.md
+++ b/help/troubleshooting.md
@@ -131,6 +131,65 @@ If wrapper downloads fail frequently, you can enable **Auto-Retry without Wrappe
 
 Without this setting enabled, failed wrapper downloads show a **"Retry without Wrapper"** button on the queue item, allowing you to manually retry with cookie-based auth.
 
+#### "Decryption is not available" warnings (wrapper enabled, downloads still skipping)
+
+This is a GAMDL warning that means: *"the wrapper accepted the connection, but it couldn't decrypt this track."* You'll see lines like this in the Activity Log:
+
+```text
+[Track 14/14] Skipping "Just Getting Started.": Decryption is not available for media ID: 1021848727
+```
+
+The most common cause when the wrapper is enabled is **stale wrapper authentication**. The wrapper service logs into Apple Music once with your credentials and keeps the resulting tokens in its data directory. Those tokens can expire over time — often after a few weeks or after Apple invalidates the session for any reason. When that happens, the wrapper still *appears* to be working: MeedyaDL's pre-download checks for the account / m3u8 / decryption services all pass (the sockets accept connections), the download starts, and the manifest fetch succeeds — but every per-track decryption request fails because the wrapper's stored Apple Music tokens are no longer valid.
+
+##### How to re-authenticate the wrapper
+
+You re-run the wrapper's one-off **login command** with your Apple Music username and password. The wrapper saves fresh tokens to its data directory; subsequent runs use those tokens normally.
+
+**If you're running the wrapper via Docker** (the most common setup):
+
+1. Stop the running wrapper container:
+
+   ```sh
+   docker compose down
+   ```
+
+2. Run the wrapper in **login mode** with your Apple credentials:
+
+   ```sh
+   docker run --privileged --rm -it \
+     -v ./rootfs/data:/app/rootfs/data \
+     --entrypoint ./wrapper \
+     ghcr.io/worldobservationlog/wrapper:local \
+     -L "your.apple.id@example.com:your-apple-password" \
+     -H 0.0.0.0
+   ```
+
+   The wrapper will sign into Apple Music. If your Apple ID has two-factor authentication, it will prompt for the 6-digit code — enter it and let the login finish.
+
+3. Once login completes (you'll see confirmation in the terminal), press **Ctrl-C** to quit.
+
+4. Start the wrapper normally again:
+
+   ```sh
+   docker compose up -d
+   ```
+
+**If you're running the wrapper natively** (not via Docker), the equivalent is to run the wrapper binary with the `-L "username:password"` flag once, let it sign in, quit, then start it again normally.
+
+##### How to tell if it's an auth issue vs a different problem
+
+Stale wrapper auth typically shows *every* track in a download skipping with the same "Decryption is not available" message. If only some tracks skip and others succeed, it's more likely that those specific tracks just aren't available in the requested codec — adjust the [Fallback Quality chain](fallback-quality.md) so MeedyaDL retries with a different format (ALAC / AAC) for the skipped ones. The Activity Log entries themselves look identical for both cases; the rate of skips is your diagnostic.
+
+##### Other possible causes
+
+- **You haven't enabled wrapper auth at all.** Atmos, AC-3 and other experimental codecs are wrapper-only — cookie-based auth alone can't decrypt them. Toggle **Use Wrapper** in Settings > Advanced if you haven't already.
+- **The track genuinely isn't available in the requested codec.** Some Apple Music regions have different mastering catalogues; not every track has an Atmos mix. The fallback chain handles this automatically when configured.
+- **The track was withdrawn or replaced.** Apple periodically replaces individual tracks (e.g., a song migrated from one album release to another). Re-fetching the album page in your browser may reveal it's been re-listed under a different ID.
+
+##### Does changing **Download Mode** help?
+
+No — Download Mode (yt-dlp vs N_m3u8DL-RE in Settings > Advanced) only changes the tool that downloads the encrypted HLS streams from Apple's CDN. It doesn't affect authentication or decryption. If decryption is failing, switching Download Mode won't fix it. (Some users see downloads "start working again" after switching modes because changing the setting forces a fresh attempt with reset state — not because of the mode itself.)
+
 #### Running the wrapper on a different device on your network
 
 You don't have to run the wrapper on the same computer as MeedyaDL. A common setup is to run MeedyaDL on a Mac or Windows PC and the wrapper on a separate Linux box — for example, a Raspberry Pi sitting on the same home network.

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -8018,10 +8018,31 @@ pub fn process_queue(
                                 "Download manifest saved to album folder",
                             );
 
-                            set_label(
-                                "Finalising metadata...",
-                                ProgressStage::Finalising.weight(),
-                            );
+                            // Enrichment is finished — clear the per-item label
+                            // so the bar caption reverts to the track context
+                            // (Path 2 in `formatActiveItemCaption`) until the
+                            // next stage takes over (companion supervisor's
+                            // `Companion: downloading…`, the post-companion
+                            // advisory pass's `Applying [Explicit]/[Clean]
+                            // suffixes…`, or `set_complete` clearing on the
+                            // happy path with neither configured).
+                            //
+                            // Pre-fix this line called `set_label("Finalising
+                            // metadata...", …)` AFTER the manifest write — but
+                            // at that point enrichment is *done*, not
+                            // finalising, and the label persisted as the
+                            // visible caption through every subsequent gap
+                            // (enrichment→companion handoff, companion→
+                            // advisory handoff, etc.). The screenshot the
+                            // user reported on 2026-05-11 caught one of those
+                            // gaps and showed "Finalising metadata…" while
+                            // the activity log was reporting fresh GAMDL
+                            // companion track downloads. Clearing here keeps
+                            // the caption honest.
+                            {
+                                let mut q = enrich_queue.lock().await;
+                                q.clear_processing_label(&enrich_dl_id);
+                            }
 
                             emit_download_log(
                                 &enrich_app,

--- a/src/components/download/ActivityLog.tsx
+++ b/src/components/download/ActivityLog.tsx
@@ -228,18 +228,30 @@ export function ActivityLog() {
    * Auto-scroll to bottom when new filtered entries arrive, unless paused.
    * Uses the virtualizer's scrollToIndex for accurate positioning with
    * dynamic row heights.
+   *
+   * Pre-fix this also gated on `userScrolledRef.current`, but that
+   * created a UX trap reported on 2026-05-11: scrolling up set the ref
+   * but NOT `paused`, so the checkbox kept showing "Auto-scroll: ON"
+   * while auto-scroll was effectively off. The handleScroll handler
+   * below now keeps `paused` in sync with the scroll position so the
+   * checkbox reflects reality and `paused` is the single source of
+   * truth.
    */
   useEffect(() => {
-    if (paused || userScrolledRef.current) return;
+    if (paused) return;
     if (filteredEntries.length > 0) {
       virtualizer.scrollToIndex(filteredEntries.length - 1, { align: 'end' });
     }
   }, [filteredEntries.length, paused, virtualizer]);
 
   /**
-   * Detect user scroll-up to auto-pause. If the user scrolls away from
-   * the bottom (more than 50px threshold), we pause auto-scroll. If they
-   * scroll back to the bottom, we resume.
+   * Detect user scroll position and sync the `paused` store flag with
+   * it. Scrolling up past the threshold sets `paused = true` (so the
+   * Auto-scroll checkbox visibly unchecks); scrolling back to the
+   * bottom sets `paused = false` (the existing intended behaviour).
+   * `userScrolledRef` is kept for the moment-of-scroll detection but
+   * is no longer the gate — the auto-scroll effect now reads `paused`
+   * exclusively.
    */
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
@@ -251,8 +263,23 @@ export function ActivityLog() {
       if (paused) setPaused(false);
     } else {
       userScrolledRef.current = true;
+      if (!paused) setPaused(true);
     }
   }, [paused, setPaused]);
+
+  /**
+   * Resume auto-scroll: scroll to the latest entry and clear the
+   * pause flag. Used by both the "Jump to latest" pill button (which
+   * appears whenever the user is scrolled away) and the Auto-scroll
+   * checkbox toggle.
+   */
+  const resumeAutoScroll = useCallback(() => {
+    userScrolledRef.current = false;
+    setPaused(false);
+    if (filteredEntries.length > 0) {
+      virtualizer.scrollToIndex(filteredEntries.length - 1, { align: 'end' });
+    }
+  }, [filteredEntries.length, setPaused, virtualizer]);
 
   /**
    * Export all log entries to a .log file via native save dialog.
@@ -335,18 +362,20 @@ export function ActivityLog() {
         subtitle={subtitle}
         actions={
           <div className="flex items-center gap-2">
-            <label className="flex items-center gap-1.5 text-xs text-content-secondary cursor-pointer select-none">
+            <label
+              className="flex items-center gap-1.5 text-xs text-content-secondary cursor-pointer select-none"
+              title={
+                paused
+                  ? 'Auto-scroll is paused (you scrolled up). Tick to scroll to the latest line and resume.'
+                  : 'Auto-scroll is following the latest line. Untick to pause, or scroll up.'
+              }
+            >
               <input
                 type="checkbox"
                 checked={!paused}
                 onChange={(e) => {
                   if (e.target.checked) {
-                    // Re-enable auto-scroll: scroll to bottom immediately
-                    userScrolledRef.current = false;
-                    setPaused(false);
-                    if (filteredEntries.length > 0) {
-                      virtualizer.scrollToIndex(filteredEntries.length - 1, { align: 'end' });
-                    }
+                    resumeAutoScroll();
                   } else {
                     setPaused(true);
                   }
@@ -468,11 +497,15 @@ export function ActivityLog() {
         </div>
       </div>
 
-      {/* Scrollable log container -- virtualized for performance */}
+      {/* Scrollable log container -- virtualized for performance.
+          Wrapped in a `relative` flex container so the floating
+          "Jump to latest" pill can be absolute-positioned over the
+          bottom-right corner when auto-scroll is paused. */}
+      <div className="relative flex-1 m-4 mt-0 min-h-0">
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto bg-surface-secondary rounded-platform m-4 mt-0 p-3 font-mono text-xs leading-relaxed select-text"
+        className="h-full overflow-y-auto bg-surface-secondary rounded-platform p-3 font-mono text-xs leading-relaxed select-text"
         role="log"
         aria-live="polite"
         aria-label="Activity log"
@@ -546,6 +579,23 @@ export function ActivityLog() {
               );
             })}
           </div>
+        )}
+      </div>
+
+        {/* Floating "Jump to latest" pill — visible only when the user
+            has scrolled away from the bottom (auto-scroll paused).
+            Gives a one-click resume that's more discoverable than
+            unticking and re-ticking the Auto-scroll checkbox. */}
+        {paused && entries.length > 0 && (
+          <button
+            type="button"
+            onClick={resumeAutoScroll}
+            className="absolute bottom-3 right-3 z-10 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-accent text-content-inverse text-xs font-medium shadow-md hover:bg-accent-hover transition-colors cursor-pointer"
+            title="Scroll to the latest line and resume auto-scroll"
+            aria-label="Jump to latest activity log line and resume auto-scroll"
+          >
+            ↓ Jump to latest
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two related UX bugs reported on 2026-05-11 — both about the queue/activity-log surfaces showing state that doesn't match reality.

### Bug 1: Progress bar caption staleness

The enrichment task ended with `set_label("Finalising metadata...", …)` immediately followed by the "All enrichment stages completed" activity-log line. That label then **persisted as the per-item caption through every subsequent gap** — between enrichment ending and the companion supervisor spawning its first GAMDL, between companion finishing and the post-companion advisory pass starting, etc. Your screenshot caught one of those gaps showing "Finalising metadata…" while the activity log was reporting fresh GAMDL companion track downloads.

**Fix:** replace the trailing `set_label` with `clear_processing_label`. When enrichment ends, the caption falls back to track context until the next stage (companion supervisor / advisory pass / set_complete) takes over with its own label. Every subsequent stage already updates the label; this just stops enrichment from leaving a stale one behind.

### Bug 2: Auto-scroll checkbox lying about state

When you scrolled up in the activity log, `handleScroll` set `userScrolledRef.current = true` to suppress auto-scroll, but did **not** update the `paused` store flag. The checkbox kept showing "ON" even though auto-scroll was effectively "OFF" — no visible signal, no obvious re-trigger.

**Two fixes:**

1. `handleScroll` now keeps `paused` in sync — scrolling up sets `paused = true` (checkbox visibly unticks), scrolling back to the bottom sets `paused = false`. `paused` becomes the single source of truth (the redundant `userScrolledRef` gate is dropped from the auto-scroll effect).
2. New floating **"↓ Jump to latest"** pill button in the bottom-right of the log, visible only when paused. One click scrolls to the latest line + clears `paused`. More discoverable than the checkbox toggle.

## Test plan

- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test --lib` — 1009 pass
- [x] `npm run type-check` + `lint` + `test` — 465 pass, no regressions
- [ ] CI green
- [ ] **Manual (you have a live reproducer):** start a download with companions on, watch the Activity tab — the progress bar caption should change from "Finalising metadata…" to a track-context caption as soon as enrichment ends, then to "Companion: downloading…" when the supervisor starts.
- [ ] **Manual:** in the Activity Log, scroll up while a download is running. The Auto-scroll checkbox should untick automatically, and a "↓ Jump to latest" pill should appear in the bottom-right. Clicking it scrolls to the latest line and re-ticks the checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)