### PR TITLE
docs(audits): retrospective sign-off for the v1.3.2 batch

### DIFF
--- a/.github/audits/v1.3.2-batch-retrospective.md
+++ b/.github/audits/v1.3.2-batch-retrospective.md
@@ -1,0 +1,77 @@
+# v1.3.2 batch retrospective
+
+**Date:** 2026-05-11
+**Author:** Lance + Claude pair-programming session
+**Branch the work landed on:** `main` (direct push, no PR — see "Process notes" below)
+**Tag pushed:** `v1.3.2`
+
+This document is a **retrospective** sign-off artifact: the six commits below were merged into `main` via a fast-forward push rather than through a Pull Request. This page exists so the batch has a single reviewable surface alongside the auto-generated CHANGELOG entry.
+
+## Commits in the batch
+
+| SHA | Type | Issue | Summary |
+| --- | --- | --- | --- |
+| `169e708` | feat | [#755](https://github.com/MWBMPartners/MeedyaDL/issues/755) | Per-download GAMDL version + capability flags emitted to the activity log |
+| `a891067` | fix  | [#577](https://github.com/MWBMPartners/MeedyaDL/issues/577) | Filesystem-sidecar guard extended to BPM / lyrics / ASS / SRT / VTT walkers |
+| `f494a74` | feat | [#756](https://github.com/MWBMPartners/MeedyaDL/issues/756) | Cover-art RAW → PNG → JPEG fallback when GAMDL cover write fails |
+| `3e60285` | feat | [#758](https://github.com/MWBMPartners/MeedyaDL/issues/758) | Python traceback diagnostic capture into crash-report infrastructure |
+| `815a0ce` | refactor | [#757](https://github.com/MWBMPartners/MeedyaDL/issues/757) (partial) | 5 of 9 settings tabs migrated to `useSettingsField` |
+| `5d30f45` | chore | — | Version bump `1.3.1` → `1.3.2` |
+
+## What each change does (short)
+
+### `169e708` — Per-download GAMDL version logging (#755)
+
+Adds one line per queue item start: `GAMDL <version> — capabilities: <comma list>`. Reads the existing `gamdl_capabilities::detected_version()` cache — no extra subprocess spawn. Lands in both the Tauri event activity log and the on-disk forensic record. Surfaces in any subsequent crash report so the GAMDL version that produced a bug is always recoverable.
+
+### `a891067` — Filesystem-sidecar walker guard (#577)
+
+The codec / ReplayGain / AcoustID walkers already used `utils::fs_safe::is_filesystem_sidecar`. The BPM, enhanced-lyrics, ASS, WebVTT, Rich SRT (× 2 walkers in that file), music-video subtitle copier, and lyrics-coverage counter did not. Adds the same predicate to all seven. AppleDouble `._*` shadows on exFAT / FAT32 / HFS volumes no longer trigger spurious parse failures, redundant subprocess spawns, or duplicate sidecar outputs.
+
+### `f494a74` — Cover-art fallback chain (#756)
+
+When `cover_format = raw` and GAMDL's upstream `httpx` cover fetch raises, the album folder ends up with no static cover sidecar. New `services/cover_art_fallback` runs after `rename_cover_art()`: checks for an existing `Cover.<ext>` ≥ 4 KiB across all conventional stems and extensions; if missing, substitutes `{w}/{h}/{c}/{f}` into the API-supplied artwork URL template and fetches PNG, then JPEG. Atomic write (temp + rename). 9 unit tests. Three new `AlbumMetadata` fields (`artwork_url_template`, `artwork_width`, `artwork_height`) extract the template once during the existing enrichment-Step-1 API call — no extra request.
+
+### `3e60285` — Python traceback diagnostic capture (#758)
+
+Scans the per-download `raw_output_lines` buffer at GAMDL exit (any path: success, error, soft-error). Extracts traceback groups (header → frames → PEP 657 source-context → exception summary), deduplicates identical groups with an occurrence count, and writes a `CrashReport` with `source = "traceback_diagnostic"` via the existing `save_error_report` path. Healthy-download fast path: one buffer scan, early return on no `Traceback` header. URL is redacted via the existing `redact_url_query` helper. 10 unit tests cover single-group capture, dedup, PEP 657 context lines, distinct groups, structlog interrupts, dangling tracebacks, lone-header discard.
+
+### `815a0ce` — `useSettingsField` partial migration (#757)
+
+Audit v2 finding #6. Migrated tabs:
+
+- `TemplatesTab.tsx`
+- `FallbackTab.tsx`
+- `CoverArtTab.tsx`
+- `LyricsTab.tsx` (booleans only — `handleFormatToggle` retains `updateSettings` for multi-key writes)
+- `ToolsTab.tsx` (`temp_path` only — dynamic tool-path map keeps the store hook because keys are runtime-resolved)
+
+Pure refactor — per-field Zustand subscriptions reduce re-render churn. Tracked as **partial**; the remaining four large tabs (`AdvancedTab`, `GeneralTab`, `QualityTab`, `CookiesTab`) live in a follow-up under [#757](https://github.com/MWBMPartners/MeedyaDL/issues/757).
+
+### `5d30f45` — Version bump
+
+Manifests bumped across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, `.release-please-manifest.json`. No code changes.
+
+## New follow-ups created during this session
+
+- **[#759](https://github.com/MWBMPartners/MeedyaDL/issues/759)** — Enrichment gap-fill (Library Scan) covering **all** current and future enrichments via per-stage manifest tracking and an `EnrichmentStage` registry. Motivated by a user-supplied screenshot of a 13-minute enrichment timeout on a 19-track live album where ReplayGain / AcoustID / MusicBrainz were left missing.
+
+## Process notes — why no PR at commit time
+
+The user instruction was *"Then Push to 'main' with an updated versison number incrementing the build number only"*. I took that literally and pushed fast-forward. In hindsight that was the wrong default for feature commits in this repo — recent feature work (#744, #743, #719) has consistently gone through PRs.
+
+This retrospective PR is the corrective artifact. Going forward, the working default should be **branch + PR even on fast iteration cycles**; direct-push to `main` reserved for explicit `[skip ci]` docs / chore edits.
+
+## Verification
+
+- `cargo check`: clean.
+- `cargo test --lib services::gamdl_capabilities`: 23 passed (3 new).
+- `cargo test --lib services::cover_art_fallback`: 9 passed.
+- `cargo test --lib services::traceback_diagnostic`: 10 passed.
+- `npm run type-check`: clean.
+
+## Issue closures
+
+- #755, #577, #756, #758 — auto-closed via the `Closes #N` trailer on each commit when the push reached origin.
+- #757 — kept open; partial-completion comment added with the remaining four-tab checklist.
+- #759 — new, open, ready for prioritisation.


### PR DESCRIPTION
## Summary

The six commits that landed v1.3.2 (#755, #577, #756, #758, #757 partial, version bump) were pushed fast-forward directly to `main` rather than through a PR. This PR is the **retrospective sign-off artifact** — a single reviewable surface for the batch.

See [`.github/audits/v1.3.2-batch-retrospective.md`](.github/audits/v1.3.2-batch-retrospective.md) for the full breakdown: commit-by-commit summary, test verification, follow-up issues, and the process note explaining why no PR at commit time.

## Batch contents

| SHA | Issue | Summary |
| --- | --- | --- |
| `169e708` | #755 | Per-download GAMDL version + capability flags in activity log |
| `a891067` | #577 | Filesystem-sidecar guard extended to 7 walkers |
| `f494a74` | #756 | Cover-art RAW → PNG → JPEG fallback |
| `3e60285` | #758 | Python traceback diagnostic capture |
| `815a0ce` | #757 partial | 5 of 9 settings tabs migrated to useSettingsField |
| `5d30f45` | — | Version bump 1.3.1 → 1.3.2 |

## Diff scope

Single new file: `.github/audits/v1.3.2-batch-retrospective.md`. No production code touched in this PR — the production changes are already on `main` (commits above).

## Action requested

- [ ] Sign-off on the batch as documented.
- [ ] Confirm the going-forward rule: branch + PR for feature work, direct-push reserved for `[skip ci]` doc/chore edits.

## Test plan

- [x] Production code already validated on `main` (cargo check + targeted test suites pass — see retrospective doc).
- [x] This PR adds only a markdown file; CI runs on it as belt-and-braces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)