### PR TITLE
fix: drop needless borrow on traceback url + override release to v1.3.3

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -9520,10 +9520,14 @@ async fn run_download_with_events(
             .map(|u| redact_url_query(u))
             .unwrap_or_default();
         let gamdl_version = crate::services::gamdl_capabilities::detected_version();
+        // `url_for_report` is already `&str` (redact_url_query returns
+        // a borrowed slice of its input). Passing `&url_for_report`
+        // would create `&&str` and trigger clippy's `needless_borrow`
+        // under Rust 1.95+, breaking CI.
         let outcome = crate::services::traceback_diagnostic::write_diagnostic_if_any(
             app,
             download_id,
-            &url_for_report,
+            url_for_report,
             gamdl_version.as_deref(),
             item_state,
             &raw_snapshot,


### PR DESCRIPTION
## Summary

Two-in-one fix:

1. **Clippy `needless_borrow` regression** breaking PR #761's three Backend CI checks. The `url_for_report` binding in [src/services/download_queue.rs:9523](src-tauri/src/services/download_queue.rs#L9523) is already `&str` (because `redact_url_query` returns a borrowed slice of its input), so passing `&url_for_report` created `&&str` and tripped clippy's lint under Rust 1.95 on CI. Local toolchains on rustc 1.93 didn't catch this.

2. **`Release-As: 1.3.3` trailer** — overrides release-please's automatic v1.4.0 calculation. The v1.3.2 batch contained `feat:` commits (#755, #756, #758) which by Conventional Commits semantics demand a minor bump, but the user-facing surface changes are small enough that a patch bump is preferred. Once this lands on main, release-please will recompute PR #761 to use v1.3.3 instead.

## Why no PR for the original v1.3.2 batch caught this

The earlier batch landed via direct push to `main` (no PR-level CI). The v1.3.2 retrospective PR (#760) only diffs a markdown file, so the per-platform Backend matrix didn't run on the affected Rust code. Going forward, the new branch + PR rule should catch this kind of toolchain-specific regression at PR time.

## Test plan

- [x] `cargo clippy -- -D warnings` clean locally on rustc 1.93.
- [ ] CI re-runs the three Backend checks on this PR.
- [ ] After merge, release-please refreshes PR #761 to title `chore(main): release 1.3.3` and updates the version files in the bot branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)