### PR TITLE
refactor(settings): finish useSettingsField migration — closes #757

### DIFF
--- a/src/components/settings/tabs/AdvancedTab.tsx
+++ b/src/components/settings/tabs/AdvancedTab.tsx
@@ -80,8 +80,12 @@
 
 import { useState, useEffect, useCallback } from 'react';
 
-// Zustand store for reading/writing advanced settings.
+// Zustand store hooks. `useSettingsStore` is retained for the
+// `saveSettings` and `loadSettings` actions only (used by the setup
+// wizard reset and DevToolsSection's deactivate flow). Per-field
+// reads/writes go through `useSettingsField` (audit v2 #6).
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useSettingsField } from '@/hooks/useSettingsField';
 
 // Shared form components: Select for mode dropdowns, Toggle for boolean switches,
 // Input for text/number fields, Button for actions.
@@ -157,10 +161,27 @@ const GAMDL_IDLE_TIMEOUT_OPTIONS = [
  * Diagnostics, API Credentials (with API Field Audit), and Setup.
  */
 export function AdvancedTab() {
-  /** Current settings snapshot */
-  const settings = useSettingsStore((s) => s.settings);
-  /** Partial-update function for persisting advanced setting changes */
-  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // Per-field bindings (audit v2 #6).
+  const downloadMode = useSettingsField('download_mode');
+  const remuxMode = useSettingsField('remux_mode');
+  const gamdlIdleTimeout = useSettingsField('gamdl_idle_timeout_minutes');
+  const truncate = useSettingsField('truncate');
+  const excludeTags = useSettingsField('exclude_tags');
+  const sentryEnabled = useSettingsField('sentry_enabled');
+  const analyticsEnabled = useSettingsField('analytics_enabled');
+  const verboseActivityLog = useSettingsField('verbose_activity_log');
+  const verboseGamdlExceptions = useSettingsField('verbose_gamdl_exceptions');
+  const activityLogPathOverride = useSettingsField('activity_log_path_override');
+  const useWrapper = useSettingsField('use_wrapper');
+  const autoRetryWithoutWrapper = useSettingsField('auto_retry_without_wrapper');
+  const wrapperAccountUrl = useSettingsField('wrapper_account_url');
+  const wrapperM3u8Ip = useSettingsField('wrapper_m3u8_ip');
+  const wrapperDecryptIp = useSettingsField('wrapper_decrypt_ip');
+  const musickitTeamId = useSettingsField('musickit_team_id');
+  const musickitKeyId = useSettingsField('musickit_key_id');
+  const acoustidApiKey = useSettingsField('acoustid_api_key');
+  const setupCompleted = useSettingsField('setup_completed');
+  const devAccessEnabled = useSettingsField('dev_access_enabled');
   /** Persist settings to disk (needed for setup wizard reset) */
   const saveSettings = useSettingsStore((s) => s.saveSettings);
   /** Platform detection for Wrapper feature gating (Linux x86_64 only) */
@@ -197,13 +218,13 @@ export function AdvancedTab() {
 
   /** Whether MusicKit credentials are configured (required for audit) */
   const hasMusicKitCredentials =
-    !!settings.musickit_team_id?.trim() && !!settings.musickit_key_id?.trim();
+    !!musickitTeamId.value?.trim() && !!musickitKeyId.value?.trim();
 
   // Reset test result when the wrapper URL changes
   useEffect(() => {
     setTestState('idle');
     setTestResult(null);
-  }, [settings?.wrapper_account_url]);
+  }, [wrapperAccountUrl.value]);
 
   // Check for stored MusicKit private key on mount
   useEffect(() => {
@@ -228,10 +249,10 @@ export function AdvancedTab() {
 
   /** Handles the "Test Connection" button click */
   const handleTestConnection = async () => {
-    if (!settings?.wrapper_account_url) return;
+    if (!wrapperAccountUrl.value) return;
     setTestState('testing');
     try {
-      const result = await testWrapperConnection(settings.wrapper_account_url);
+      const result = await testWrapperConnection(wrapperAccountUrl.value);
       setTestResult(result);
       setTestState(result.reachable ? 'success' : 'error');
     } catch {
@@ -260,8 +281,8 @@ export function AdvancedTab() {
     setValidationResult(null);
     try {
       const result = await validateMusicKitCredentialsWithInput(
-        settings.musickit_team_id ?? null,
-        settings.musickit_key_id ?? null
+        musickitTeamId.value ?? null,
+        musickitKeyId.value ?? null
       );
       setValidationResult(result);
     } catch (err) {
@@ -269,7 +290,7 @@ export function AdvancedTab() {
     } finally {
       setValidating(false);
     }
-  }, [settings.musickit_key_id, settings.musickit_team_id]);
+  }, [musickitKeyId.value, musickitTeamId.value]);
 
   /**
    * Opens a URL in the system default browser via the Tauri shell plugin.
@@ -304,24 +325,22 @@ export function AdvancedTab() {
           label="Download Mode"
           description="Which tool to use for downloading HLS streams"
           options={DOWNLOAD_MODE_OPTIONS}
-          value={settings.download_mode}
-          onChange={(e) => updateSettings({ download_mode: e.target.value as DownloadMode })}
+          value={downloadMode.value}
+          onChange={(e) => downloadMode.set(e.target.value as DownloadMode)}
         />
         <Select
           label="Remux Mode"
           description="Which tool to use for video remuxing. MP4Box handles subtitle/CC tracks better."
           options={REMUX_MODE_OPTIONS}
-          value={settings.remux_mode}
-          onChange={(e) => updateSettings({ remux_mode: e.target.value as RemuxMode })}
+          value={remuxMode.value}
+          onChange={(e) => remuxMode.set(e.target.value as RemuxMode)}
         />
         <Select
           label="GAMDL Idle Timeout"
           description="Kill the GAMDL process if no output arrives for this many minutes. The watchdog pauses automatically once post-processing (remux / decrypt) begins, so this won't cut short a slow remux on a network volume."
           options={GAMDL_IDLE_TIMEOUT_OPTIONS}
-          value={String(settings.gamdl_idle_timeout_minutes)}
-          onChange={(e) =>
-            updateSettings({ gamdl_idle_timeout_minutes: Number(e.target.value) })
-          }
+          value={String(gamdlIdleTimeout.value)}
+          onChange={(e) => gamdlIdleTimeout.set(Number(e.target.value))}
         />
       </SettingsSection>
 
@@ -333,24 +352,24 @@ export function AdvancedTab() {
           type="number"
           min={10}
           max={255}
-          value={settings.truncate?.toString() ?? ''}
+          value={truncate.value?.toString() ?? ''}
           placeholder="No limit"
           onChange={(e) => {
             const val = e.target.value;
-            updateSettings({ truncate: val ? parseInt(val, 10) : null });
+            truncate.set(val ? parseInt(val, 10) : null);
           }}
         />
         <Input
           label="Excluded Tags"
           description="Comma-separated list of metadata tags to exclude from downloaded files"
-          value={settings.exclude_tags.join(', ')}
+          value={excludeTags.value.join(', ')}
           placeholder="e.g., lyrics, comment"
           onChange={(e) => {
             const tags = e.target.value
               .split(',')
               .map((t) => t.trim())
               .filter(Boolean);
-            updateSettings({ exclude_tags: tags });
+            excludeTags.set(tags);
           }}
         />
       </SettingsSection>
@@ -360,14 +379,14 @@ export function AdvancedTab() {
         <Toggle
           label="Send Anonymous Crash Reports"
           description="When enabled, anonymous crash data (error message, stack trace, app version, OS) is sent to our error tracking service to help identify and fix bugs. No personal data, download history, or account information is ever included. Requires an app restart to take effect."
-          checked={settings.sentry_enabled}
-          onChange={(checked) => updateSettings({ sentry_enabled: checked })}
+          checked={sentryEnabled.value}
+          onChange={sentryEnabled.set}
         />
         <Toggle
           label="Anonymous Usage Analytics"
           description="Send anonymised feature usage data (which features are used, platform, download counts) to help prioritise development. No personal data, URLs, or content information is ever collected."
-          checked={settings.analytics_enabled ?? false}
-          onChange={(checked) => updateSettings({ analytics_enabled: checked })}
+          checked={analyticsEnabled.value ?? false}
+          onChange={analyticsEnabled.set}
         />
         <p className="text-xs text-content-tertiary">
           Error reports (crashes and download failures) are always saved locally to your app data
@@ -381,10 +400,10 @@ export function AdvancedTab() {
         <Toggle
           label="Verbose Activity Log"
           description="Emits detailed [VERBOSE] messages to the Activity Log for issue tracking and debugging. In pre-release versions (v0.x.x), this setting is preserved across restarts. In full releases, it resets to off on each restart as a safety measure."
-          checked={settings.verbose_activity_log}
-          onChange={(checked) => updateSettings({ verbose_activity_log: checked })}
+          checked={verboseActivityLog.value}
+          onChange={verboseActivityLog.set}
         />
-        {settings.verbose_activity_log && (
+        {verboseActivityLog.value && (
           <div className="p-3 rounded-lg bg-status-warning-bg border border-status-warning">
             <p className="text-xs font-semibold text-status-warning mb-1">
               Sensitive Data Warning
@@ -405,8 +424,8 @@ export function AdvancedTab() {
         <Toggle
           label="Show Full GAMDL Tracebacks"
           description="Stops MeedyaDL from passing --no-exceptions to GAMDL, so uncaught Python exceptions include the full stack trace instead of a single user-facing line. Useful for reporting bugs against upstream GAMDL; noisy for everyday use because v3.0 structlog lines interleave with raw tracebacks."
-          checked={settings.verbose_gamdl_exceptions}
-          onChange={(checked) => updateSettings({ verbose_gamdl_exceptions: checked })}
+          checked={verboseGamdlExceptions.value}
+          onChange={verboseGamdlExceptions.set}
         />
 
         {/* ── On-disk activity log location (#541) ── */}
@@ -428,7 +447,7 @@ export function AdvancedTab() {
                       title: 'Choose a folder for MeedyaDL activity logs',
                     });
                     if (typeof selected === 'string' && selected.length > 0) {
-                      updateSettings({ activity_log_path_override: selected });
+                      activityLogPathOverride.set(selected);
                     }
                   } catch {
                     /* User cancelled */
@@ -465,16 +484,16 @@ export function AdvancedTab() {
               <Button
                 variant="ghost"
                 size="sm"
-                disabled={!settings.activity_log_path_override}
-                onClick={() => updateSettings({ activity_log_path_override: '' })}
+                disabled={!activityLogPathOverride.value}
+                onClick={() => activityLogPathOverride.set('')}
               >
                 Reset
               </Button>
             </div>
           </div>
           <Input
-            value={settings.activity_log_path_override}
-            onChange={(e) => updateSettings({ activity_log_path_override: e.target.value })}
+            value={activityLogPathOverride.value}
+            onChange={(e) => activityLogPathOverride.set(e.target.value)}
             placeholder="Default — uses the app data directory"
             aria-label="On-disk activity log path override"
           />
@@ -502,7 +521,7 @@ export function AdvancedTab() {
                 'appear on next load to verify your dependencies. Continue?'
             );
             if (!confirmed) return;
-            updateSettings({ setup_completed: false });
+            setupCompleted.set(false);
             try {
               await saveSettings();
             } catch {
@@ -528,37 +547,37 @@ export function AdvancedTab() {
         <Toggle
           label="Use Wrapper"
           description="Use a locally-running wrapper service for authentication instead of browser cookies. The wrapper handles Apple ID login and DRM key exchange, providing more reliable access to Dolby Atmos and other protected formats. Most users should leave this disabled and use cookies instead."
-          checked={settings.use_wrapper}
-          onChange={(checked) => updateSettings({ use_wrapper: checked })}
+          checked={useWrapper.value}
+          onChange={useWrapper.set}
           helpTopic="wrapper"
         />
 
-        {settings.use_wrapper && (
+        {useWrapper.value && (
           <>
             <Toggle
               label="Auto-Retry without Wrapper"
               description="When a download fails after exhausting all retries, automatically re-queue it with wrapper disabled (falls back to cookie-based authentication). Without this, you'll be prompted to retry manually."
-              checked={settings.auto_retry_without_wrapper}
-              onChange={(checked) => updateSettings({ auto_retry_without_wrapper: checked })}
+              checked={autoRetryWithoutWrapper.value}
+              onChange={autoRetryWithoutWrapper.set}
             />
             <Input
               label="Wrapper Account URL"
               description="URL of your locally-running wrapper service. The default (http://127.0.0.1:30020) works if the wrapper is running on your machine with default settings. See Help > Wrapper for setup instructions."
-              value={settings.wrapper_account_url}
-              onChange={(e) => updateSettings({ wrapper_account_url: e.target.value })}
+              value={wrapperAccountUrl.value}
+              onChange={(e) => wrapperAccountUrl.set(e.target.value)}
             />
             <Input
               label="Wrapper m3u8 Address"
               description="GAMDL 3.1+ fetches the HLS master playlist URL from a TCP socket on this address (default: 127.0.0.1:20020). Your wrapper must expose an m3u8 service on this host:port. Ignored on GAMDL 3.0 and earlier."
-              value={settings.wrapper_m3u8_ip}
-              onChange={(e) => updateSettings({ wrapper_m3u8_ip: e.target.value })}
+              value={wrapperM3u8Ip.value}
+              onChange={(e) => wrapperM3u8Ip.set(e.target.value)}
               placeholder="127.0.0.1:20020"
             />
             <Input
               label="Wrapper Decryption Address"
               description="GAMDL opens a TCP connection to this address to send encrypted samples for FairPlay decryption (default: 127.0.0.1:10020). Set this to your wrapper's host:port — required when the wrapper runs on a different machine than MeedyaDL (e.g. a Raspberry Pi on the same LAN). Use the same host as the m3u8 address; the port differs (10020 vs 20020)."
-              value={settings.wrapper_decrypt_ip}
-              onChange={(e) => updateSettings({ wrapper_decrypt_ip: e.target.value })}
+              value={wrapperDecryptIp.value}
+              onChange={(e) => wrapperDecryptIp.set(e.target.value)}
               placeholder="127.0.0.1:10020"
             />
             <div className="flex items-center gap-2">
@@ -566,7 +585,7 @@ export function AdvancedTab() {
                 variant="secondary"
                 size="sm"
                 onClick={handleTestConnection}
-                disabled={testState === 'testing' || !settings.wrapper_account_url}
+                disabled={testState === 'testing' || !wrapperAccountUrl.value}
               >
                 {testState === 'testing' ? 'Testing...' : 'Test Connection'}
               </Button>
@@ -615,20 +634,16 @@ export function AdvancedTab() {
           <Input
             label="MusicKit Team ID"
             description="Your Apple Developer Team ID (10-character alphanumeric)"
-            value={settings.musickit_team_id ?? ''}
+            value={musickitTeamId.value ?? ''}
             placeholder="XXXXXXXXXX"
-            onChange={(e) =>
-              updateSettings({ musickit_team_id: e.target.value.toUpperCase() || null })
-            }
+            onChange={(e) => musickitTeamId.set(e.target.value.toUpperCase() || null)}
           />
           <Input
             label="MusicKit Key ID"
             description="The Key ID for your MusicKit private key (10-character alphanumeric)"
-            value={settings.musickit_key_id ?? ''}
+            value={musickitKeyId.value ?? ''}
             placeholder="XXXXXXXXXX"
-            onChange={(e) =>
-              updateSettings({ musickit_key_id: e.target.value.toUpperCase() || null })
-            }
+            onChange={(e) => musickitKeyId.set(e.target.value.toUpperCase() || null)}
           />
           <div className="space-y-2">
             <label className="block text-sm font-medium text-content-primary">
@@ -677,8 +692,8 @@ export function AdvancedTab() {
               onClick={handleTestCredentials}
               disabled={
                 validating ||
-                !settings.musickit_team_id?.trim() ||
-                !settings.musickit_key_id?.trim() ||
+                !musickitTeamId.value?.trim() ||
+                !musickitKeyId.value?.trim() ||
                 !keyStored
               }
             >
@@ -735,9 +750,9 @@ export function AdvancedTab() {
                 </>
               )
             }
-            value={settings.acoustid_api_key ?? ''}
+            value={acoustidApiKey.value ?? ''}
             placeholder={hasBuiltInKey ? 'Using built-in key' : 'Your AcoustID application API key'}
-            onChange={(e) => updateSettings({ acoustid_api_key: e.target.value })}
+            onChange={(e) => acoustidApiKey.set(e.target.value)}
           />
         </div>
 
@@ -850,7 +865,7 @@ export function AdvancedTab() {
       </SettingsSection>
 
       {/* ── Developer Tools (hidden unless dev access is active) ──── */}
-      {settings.dev_access_enabled && (
+      {devAccessEnabled.value && (
         <DevToolsSection />
       )}
     </div>
@@ -864,7 +879,11 @@ export function AdvancedTab() {
  * Shows token status, web player token management, and a deactivate button.
  */
 function DevToolsSection() {
-  const settings = useSettingsStore((s) => s.settings);
+  // Per-field bindings for the two MusicKit fields read by this
+  // section. `loadSettings` retained because the deactivate flow
+  // needs to refresh the entire settings snapshot from disk.
+  const musickitTeamId = useSettingsField('musickit_team_id');
+  const musickitKeyId = useSettingsField('musickit_key_id');
   const loadSettings = useSettingsStore((s) => s.loadSettings);
 
   const [webplayerStatus, setWebplayerStatus] = useState<boolean | null>(null);
@@ -877,7 +896,7 @@ function DevToolsSection() {
   }, []);
 
   const hasUserCreds =
-    !!settings.musickit_team_id?.trim() && !!settings.musickit_key_id?.trim();
+    !!musickitTeamId.value?.trim() && !!musickitKeyId.value?.trim();
 
   const handleClearWebplayerToken = async () => {
     await clearWebplayerToken();

--- a/src/components/settings/tabs/CookiesTab.tsx
+++ b/src/components/settings/tabs/CookiesTab.tsx
@@ -28,7 +28,7 @@
  * ## Validation Flow
  *
  * 1. User selects a cookies.txt file via the FilePickerButton.
- * 2. The path is persisted to `settings.cookies_path` in the store.
+ * 2. The path is persisted to `cookiesPath.value` in the store.
  * 3. User clicks "Validate Cookies", which calls
  *    `commands.validateCookiesFile(path)` (a Tauri IPC command).
  * 4. The Rust backend reads the file, counts cookies, checks for Apple Music
@@ -44,8 +44,8 @@
  *
  * ## Store Connection
  *
- * - **settingsStore**: Reads `settings.cookies_path`; writes via
- *   `updateSettings({ cookies_path })`.
+ * - **settingsStore**: Reads `cookies_path` via `useSettingsField`
+ *   (audit v2 #6).
  * - **Tauri commands**: Calls `validateCookiesFile`, `detectBrowsers`,
  *   `importCookiesFromBrowser`, `openAppleLogin`, `extractLoginCookies`,
  *   `closeAppleLogin` for backend operations.
@@ -88,8 +88,8 @@ import {
 // Tauri event listener for receiving events from the Rust backend.
 import { listen } from '@tauri-apps/api/event';
 
-// Zustand store for reading the cookies_path and writing path updates.
-import { useSettingsStore } from '@/stores/settingsStore';
+// Audit v2 #6 — per-field Zustand binding for `cookies_path`.
+import { useSettingsField } from '@/hooks/useSettingsField';
 
 // Tauri IPC command wrappers -- specifically `validateCookiesFile` which
 // invokes the Rust backend's cookie validation logic.
@@ -550,11 +550,9 @@ function ExpiryWarning({ expired, warnings }: { expired: boolean; warnings: stri
  */
 export function CookiesTab() {
   /* ---- Store bindings ---- */
-  /** Read the current application settings from the Zustand store */
-  const settings = useSettingsStore((s) => s.settings);
-
-  /** Obtain the settings mutation function to persist changes */
-  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // Per-field binding (audit v2 #6) — `cookies_path` is the only
+  // AppSettings key this tab touches.
+  const cookiesPath = useSettingsField('cookies_path');
 
   /* ---- Local state ---- */
   /**
@@ -615,8 +613,8 @@ export function CookiesTab() {
    * validation result. This drives the status badge display.
    */
   const cookieStatus = useMemo(
-    () => deriveCookieStatus(settings.cookies_path, validation),
-    [settings.cookies_path, validation]
+    () => deriveCookieStatus(cookiesPath.value, validation),
+    [cookiesPath.value, validation]
   );
 
   /* ---- Effects ---- */
@@ -667,7 +665,7 @@ export function CookiesTab() {
 
             // Update settings if cookies were saved successfully
             if (event.payload.success && event.payload.path) {
-              updateSettings({ cookies_path: event.payload.path });
+              cookiesPath.set(event.payload.path);
               setValidation(null); // Clear manual validation for fresh cookies
             }
           } catch (err) {
@@ -683,7 +681,7 @@ export function CookiesTab() {
     return () => {
       unlisten?.();
     };
-  }, [updateSettings]);
+  }, [cookiesPath]);
 
   /**
    * Listen for the "login-window-closed" event from the Rust backend.
@@ -723,15 +721,15 @@ export function CookiesTab() {
    * `!isValidating` to prevent duplicate concurrent requests.
    */
   useEffect(() => {
-    if (settings.cookies_path && validation === null && !isValidating) {
+    if (cookiesPath.value && validation === null && !isValidating) {
       setIsValidating(true);
       commands
-        .validateCookiesFile(settings.cookies_path)
+        .validateCookiesFile(cookiesPath.value)
         .then((result) => setValidation(result))
         .catch(() => setValidation(null))
         .finally(() => setIsValidating(false));
     }
-  }, [settings.cookies_path, validation, isValidating]);
+  }, [cookiesPath.value, validation, isValidating]);
 
   /* ---- Handlers ---- */
 
@@ -768,7 +766,7 @@ export function CookiesTab() {
 
       // Update settings store if import was successful
       if (result.success && result.path) {
-        updateSettings({ cookies_path: result.path });
+        cookiesPath.set(result.path);
         setValidation(null); // Clear manual validation since we have fresh cookies
       }
     } catch (err) {
@@ -777,7 +775,7 @@ export function CookiesTab() {
     }
 
     setIsImporting(false);
-  }, [selectedBrowser, platform, updateSettings]);
+  }, [selectedBrowser, platform, cookiesPath]);
 
   /**
    * Opens the embedded Apple Music login browser window.
@@ -812,7 +810,7 @@ export function CookiesTab() {
       setIsExtractingFromLogin(false);
 
       if (result.success && result.path) {
-        updateSettings({ cookies_path: result.path });
+        cookiesPath.set(result.path);
         setValidation(null);
       }
     } catch (err) {
@@ -820,7 +818,7 @@ export function CookiesTab() {
       setImportError(message);
       setIsExtractingFromLogin(false);
     }
-  }, [updateSettings]);
+  }, [cookiesPath]);
 
   /**
    * Cancels the embedded login flow by closing the login window
@@ -844,18 +842,18 @@ export function CookiesTab() {
    */
   const handleValidate = useCallback(async () => {
     /* Guard: nothing to validate if no file is selected */
-    if (!settings.cookies_path) return;
+    if (!cookiesPath.value) return;
 
     setIsValidating(true);
     try {
-      const result = await commands.validateCookiesFile(settings.cookies_path);
+      const result = await commands.validateCookiesFile(cookiesPath.value);
       setValidation(result);
     } catch {
       /* On error, reset validation so the UI does not show stale results */
       setValidation(null);
     }
     setIsValidating(false);
-  }, [settings.cookies_path]);
+  }, [cookiesPath.value]);
 
   /**
    * Copies the currently selected cookies file path to the system
@@ -863,10 +861,10 @@ export function CookiesTab() {
    * confirmation for 2 seconds before reverting the button text.
    */
   const handleCopyPath = useCallback(async () => {
-    if (!settings.cookies_path) return;
+    if (!cookiesPath.value) return;
 
     try {
-      await navigator.clipboard.writeText(settings.cookies_path);
+      await navigator.clipboard.writeText(cookiesPath.value);
       setCopySuccess(true);
 
       /* Reset the success indicator after 2 seconds.
@@ -877,7 +875,7 @@ export function CookiesTab() {
       /* Clipboard write can fail if the document is not focused or
          the permission was denied -- silently ignore. */
     }
-  }, [settings.cookies_path]);
+  }, [cookiesPath.value]);
 
   /**
    * Handles changes from the file picker. When a new file is
@@ -886,11 +884,11 @@ export function CookiesTab() {
    */
   const handleFileChange = useCallback(
     (path: string | null) => {
-      updateSettings({ cookies_path: path });
+      cookiesPath.set(path);
       setValidation(null);
       setCopySuccess(false);
     },
-    [updateSettings]
+    [cookiesPath]
   );
 
   /* ---- Render ---- */
@@ -1160,7 +1158,7 @@ export function CookiesTab() {
       <FilePickerButton
         label="Cookies File"
         description="Path to the Netscape-format cookies.txt file"
-        value={settings.cookies_path}
+        value={cookiesPath.value}
         onChange={handleFileChange}
         placeholder="No cookies file selected"
         filters={[{ name: 'Text Files', extensions: ['txt'] }]}
@@ -1172,7 +1170,7 @@ export function CookiesTab() {
           selected, a "Copy Cookie Path" button. Buttons are laid out
           horizontally with a gap.
           ============================================================ */}
-      {settings.cookies_path && (
+      {cookiesPath.value && (
         <div className="flex items-center gap-2">
           {/* Validate button -- triggers backend validation */}
           <Button variant="secondary" size="sm" loading={isValidating} onClick={handleValidate}>

--- a/src/components/settings/tabs/GeneralTab.tsx
+++ b/src/components/settings/tabs/GeneralTab.tsx
@@ -45,10 +45,11 @@
 
 import { useState } from 'react';
 
-// Zustand store providing the shared settings state and mutation function.
-// All settings tabs read from the same store instance, ensuring changes
-// in one tab are immediately reflected if the user switches tabs.
+// Zustand store hooks. `useSettingsStore` is retained for the
+// `loadSettings` action only (used by the import flow). All per-
+// field reads/writes go through `useSettingsField` (audit v2 #6).
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useSettingsField } from '@/hooks/useSettingsField';
 
 // Update store for manual update checking trigger.
 import { useUpdateStore } from '@/stores/updateStore';
@@ -238,10 +239,28 @@ const LANGUAGE_OPTIONS = [
  * "controlled" form that reads from and writes to the Zustand store.
  */
 export function GeneralTab() {
-  /** The full settings object (read-only snapshot from the store) */
-  const settings = useSettingsStore((s) => s.settings);
-  /** Applies a partial update to the settings; sets isDirty = true in the store */
-  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // Per-field Zustand bindings (audit v2 #6).
+  const outputPath = useSettingsField('output_path');
+  const themeOverride = useSettingsField('theme_override');
+  const highContrast = useSettingsField('high_contrast');
+  const colourBlindMode = useSettingsField('colour_blind_mode');
+  const uiLanguage = useSettingsField('ui_language');
+  const language = useSettingsField('language');
+  const storefront = useSettingsField('storefront');
+  const storefrontFallback = useSettingsField('storefront_fallback_on_failure');
+  const overwrite = useSettingsField('overwrite');
+  const autoStartQueue = useSettingsField('auto_start_queue');
+  const afterQueueAction = useSettingsField('after_queue_action');
+  const desktopNotifications = useSettingsField('desktop_notifications');
+  const notificationStyle = useSettingsField('notification_style');
+  const notificationDismissSeconds = useSettingsField('notification_auto_dismiss_seconds');
+  const smartRedownload = useSettingsField('smart_redownload_detection');
+  const clipboardMonitoring = useSettingsField('clipboard_monitoring');
+  const autoCheckUpdates = useSettingsField('auto_check_updates');
+  const updateCheckInterval = useSettingsField('update_check_interval_hours');
+  const checkPreReleases = useSettingsField('check_pre_releases');
+  const updateChannel = useSettingsField('update_channel');
+  const devAccessEnabled = useSettingsField('dev_access_enabled');
 
   /** Whether an update check is currently in progress */
   const isChecking = useUpdateStore((s) => s.isChecking);
@@ -275,7 +294,7 @@ export function GeneralTab() {
    * to prevent casual subscription. Existing subscribers keep their channel
    * even if they later disable Dev Access — they just can't re-pick it.
    */
-  const channelOptions = settings.dev_access_enabled
+  const channelOptions = devAccessEnabled.value
     ? UPDATE_CHANNEL_OPTIONS_FULL
     : UPDATE_CHANNEL_OPTIONS_PUBLIC;
 
@@ -285,11 +304,11 @@ export function GeneralTab() {
    * Stable (or to the channel already selected) bypasses the modal.
    */
   const handleChannelChange = (next: UpdateChannel) => {
-    if (next === settings.update_channel) return;
+    if (next === updateChannel.value) return;
     if (PRE_RELEASE_CHANNELS.includes(next)) {
       setPendingChannel(next);
     } else {
-      updateSettings({ update_channel: next });
+      updateChannel.set(next);
     }
   };
 
@@ -362,8 +381,8 @@ export function GeneralTab() {
         <FilePickerButton
           label="Output Directory"
           description="Where downloaded files will be saved"
-          value={settings.output_path || null}
-          onChange={(path) => updateSettings({ output_path: path || '' })}
+          value={outputPath.value || null}
+          onChange={(path) => outputPath.set(path || '')}
           directory
           placeholder="Default: ~/Music/Apple Music"
         />
@@ -382,11 +401,9 @@ export function GeneralTab() {
           label="Theme"
           description="Choose between light and dark mode, or follow your OS setting"
           options={THEME_OPTIONS}
-          value={settings.theme_override || 'auto'}
+          value={themeOverride.value || 'auto'}
           onChange={(e) =>
-            updateSettings({
-              theme_override: e.target.value === 'auto' ? null : e.target.value,
-            })
+            themeOverride.set(e.target.value === 'auto' ? null : e.target.value)
           }
         />
 
@@ -400,8 +417,8 @@ export function GeneralTab() {
         <Toggle
           label="High Contrast"
           description="Increase visual contrast for accessibility. Uses stronger borders, pure black/white text, and thicker focus indicators. Also auto-activates when your OS has high-contrast mode enabled."
-          checked={settings.high_contrast}
-          onChange={(checked) => updateSettings({ high_contrast: checked })}
+          checked={highContrast.value}
+          onChange={highContrast.set}
         />
 
         {/*
@@ -414,11 +431,9 @@ export function GeneralTab() {
           label="Colour Vision"
           description="Adjust status colours for colour vision deficiency. Remaps success, error, warning, and info colours to a palette distinguishable for the selected condition."
           options={COLOUR_VISION_OPTIONS}
-          value={settings.colour_blind_mode || 'none'}
+          value={colourBlindMode.value || 'none'}
           onChange={(e) =>
-            updateSettings({
-              colour_blind_mode: e.target.value === 'none' ? '' : e.target.value,
-            })
+            colourBlindMode.set(e.target.value === 'none' ? '' : e.target.value)
           }
         />
 
@@ -426,10 +441,10 @@ export function GeneralTab() {
           label="Language"
           description="Application display language (requires restart to take full effect)"
           options={UI_LANGUAGE_OPTIONS}
-          value={settings.ui_language || 'auto'}
+          value={uiLanguage.value || 'auto'}
           onChange={(e) => {
             const val = e.target.value;
-            updateSettings({ ui_language: val === 'auto' ? '' : val });
+            uiLanguage.set(val === 'auto' ? '' : val);
           }}
         />
       </SettingsSection>
@@ -442,8 +457,8 @@ export function GeneralTab() {
           label="Metadata Language"
           description="Language preference for track and album metadata"
           options={LANGUAGE_OPTIONS}
-          value={settings.language}
-          onChange={(e) => updateSettings({ language: e.target.value })}
+          value={language.value}
+          onChange={(e) => language.set(e.target.value)}
         />
 
         {/* Apple Music storefront region */}
@@ -453,8 +468,8 @@ export function GeneralTab() {
           </label>
           <select
             className="w-full rounded-platform border border-border-light bg-surface-elevated px-3 py-2 text-sm text-content-primary"
-            value={settings.storefront}
-            onChange={(e) => updateSettings({ storefront: e.target.value })}
+            value={storefront.value}
+            onChange={(e) => storefront.set(e.target.value)}
           >
             <option value="">Auto-detect</option>
             <option disabled>──────────</option>
@@ -517,24 +532,24 @@ export function GeneralTab() {
         <Toggle
           label="Auto-retry with your region when a URL's storefront fails"
           description="When a download fails because the album isn't published in the URL's storefront (e.g., a /us/ link your account can't access), retry once using your account region above. Only fires after the original URL has already failed, so it never overrides a working download."
-          checked={settings.storefront_fallback_on_failure}
-          onChange={(checked) => updateSettings({ storefront_fallback_on_failure: checked })}
+          checked={storefrontFallback.value}
+          onChange={storefrontFallback.set}
         />
 
         {/* Overwrite existing files */}
         <Toggle
           label="Overwrite Existing Files"
           description="Re-download and replace files that already exist in the output directory"
-          checked={settings.overwrite}
-          onChange={(checked) => updateSettings({ overwrite: checked })}
+          checked={overwrite.value}
+          onChange={overwrite.set}
         />
 
         {/* Auto-start queue processing */}
         <Toggle
           label="Auto-Start Downloads"
           description="Start processing immediately when items are added to the queue. When disabled, items are queued and you can start processing manually from the Queue page."
-          checked={settings.auto_start_queue}
-          onChange={(checked) => updateSettings({ auto_start_queue: checked })}
+          checked={autoStartQueue.value}
+          onChange={autoStartQueue.set}
         />
 
         {/* After-queue action */}
@@ -542,29 +557,27 @@ export function GeneralTab() {
           label="After Queue Completes"
           description="Action to perform automatically when all downloads finish. This is the persistent setting — use the right-click menu on the Download page for a one-time override."
           options={AFTER_QUEUE_OPTIONS}
-          value={settings.after_queue_action ?? 'do_nothing'}
-          onChange={(e) =>
-            updateSettings({ after_queue_action: e.target.value as AfterQueueAction })
-          }
+          value={afterQueueAction.value ?? 'do_nothing'}
+          onChange={(e) => afterQueueAction.set(e.target.value as AfterQueueAction)}
         />
 
         {/* Desktop notifications */}
         <Toggle
           label="Desktop Notifications"
           description="Show native OS notifications when downloads complete or fail. Notifications are only shown when the app window is not focused."
-          checked={settings.desktop_notifications}
-          onChange={(checked) => updateSettings({ desktop_notifications: checked })}
+          checked={desktopNotifications.value}
+          onChange={desktopNotifications.set}
         />
 
         {/* Notification style — controls how notifications are delivered */}
-        {settings.desktop_notifications && (
+        {desktopNotifications.value && (
           <Select
             label="Notification Style"
             description="How notifications are delivered. 'In-app only' shows toasts inside the app. 'Native + in-app' shows both OS notifications and in-app toasts. 'Native only' uses OS notifications exclusively."
             options={NOTIFICATION_STYLE_OPTIONS}
-            value={settings.notification_style ?? 'native_and_in_app'}
+            value={notificationStyle.value ?? 'native_and_in_app'}
             onChange={(e) =>
-              updateSettings({ notification_style: e.target.value as 'in_app_only' | 'native_and_in_app' | 'native_only' })
+              notificationStyle.set(e.target.value as 'in_app_only' | 'native_and_in_app' | 'native_only')
             }
           />
         )}
@@ -574,8 +587,8 @@ export function GeneralTab() {
             OS-level permission has been granted and the plugin pipeline works.
             On macOS this also forces the system permission prompt the first
             time it is invoked if the user dismissed the startup prompt. */}
-        {settings.desktop_notifications &&
-          (settings.notification_style ?? 'native_and_in_app') !== 'in_app_only' && (
+        {desktopNotifications.value &&
+          (notificationStyle.value ?? 'native_and_in_app') !== 'in_app_only' && (
             <div className="flex flex-col gap-1">
               <Button
                 variant="secondary"
@@ -618,15 +631,13 @@ export function GeneralTab() {
           )}
 
         {/* Notification auto-dismiss duration — only visible when notifications are enabled */}
-        {settings.desktop_notifications && (
+        {desktopNotifications.value && (
           <Select
             label="Notification Auto-Dismiss"
             description="How long transient notifications (download complete, added to queue) stay visible before auto-dismissing. Error and warning notifications always require manual dismissal."
             options={NOTIFICATION_DISMISS_OPTIONS}
-            value={String(settings.notification_auto_dismiss_seconds ?? 5)}
-            onChange={(e) =>
-              updateSettings({ notification_auto_dismiss_seconds: Number(e.target.value) })
-            }
+            value={String(notificationDismissSeconds.value ?? 5)}
+            onChange={(e) => notificationDismissSeconds.set(Number(e.target.value))}
           />
         )}
 
@@ -634,36 +645,34 @@ export function GeneralTab() {
         <Toggle
           label="Smart Re-Download Detection"
           description="When re-downloading an album, check if it has changed since your last download using the Apple Music API. Shows an info message if the album is unchanged, but still allows you to proceed."
-          checked={settings.smart_redownload_detection}
-          onChange={(checked) => updateSettings({ smart_redownload_detection: checked })}
+          checked={smartRedownload.value}
+          onChange={smartRedownload.set}
         />
 
         {/* Clipboard monitoring */}
         <Toggle
           label="Clipboard Monitoring"
           description="Detect supported URLs (e.g., Apple Music) copied to the clipboard and offer to download them. Only checks for URL patterns — clipboard contents are never stored."
-          checked={settings.clipboard_monitoring}
-          onChange={(checked) => updateSettings({ clipboard_monitoring: checked })}
+          checked={clipboardMonitoring.value}
+          onChange={clipboardMonitoring.set}
         />
 
         {/* Auto-check for updates */}
         <Toggle
           label="Auto-Check for Updates"
           description="Automatically check for GAMDL and tool updates on startup"
-          checked={settings.auto_check_updates}
-          onChange={(checked) => updateSettings({ auto_check_updates: checked })}
+          checked={autoCheckUpdates.value}
+          onChange={autoCheckUpdates.set}
         />
 
         {/* Update check interval — only visible when auto-check is enabled */}
-        {settings.auto_check_updates && (
+        {autoCheckUpdates.value && (
           <Select
             label="Check Interval"
             description="How often to check for updates while the app is running (takes effect on restart)"
             options={UPDATE_INTERVAL_OPTIONS}
-            value={String(settings.update_check_interval_hours)}
-            onChange={(e) =>
-              updateSettings({ update_check_interval_hours: Number(e.target.value) })
-            }
+            value={String(updateCheckInterval.value)}
+            onChange={(e) => updateCheckInterval.set(Number(e.target.value))}
           />
         )}
 
@@ -671,8 +680,8 @@ export function GeneralTab() {
         <Toggle
           label="Include Pre-Release Versions"
           description="Check for pre-release (beta/RC) versions in addition to stable releases. Pre-release versions may contain bugs or incomplete features and are not yet fully supported."
-          checked={settings.check_pre_releases}
-          onChange={(checked) => updateSettings({ check_pre_releases: checked })}
+          checked={checkPreReleases.value}
+          onChange={checkPreReleases.set}
         />
 
         {/* Update channel selector — guards auto-updates from crossing down the
@@ -682,7 +691,7 @@ export function GeneralTab() {
           label="Update Channel"
           description="Controls which release channel you receive updates from. Subscribing to a channel surfaces releases at-or-above that stability tier (e.g. Beta sees Beta, RC, Stable). Nightly/Weekly/Monthly/Alpha are hidden unless Dev Access is enabled. Switching to any pre-release channel requires explicit confirmation."
           options={channelOptions}
-          value={settings.update_channel}
+          value={updateChannel.value}
           onChange={(e) => handleChannelChange(e.target.value as UpdateChannel)}
         />
 
@@ -738,13 +747,13 @@ export function GeneralTab() {
           pre-release channel from the dropdown but not yet confirmed the
           switch. Confirming applies the change to the settings store;
           cancelling discards it (the dropdown still reflects the persisted
-          value, since `value={settings.update_channel}` was never updated). */}
+          value, since `value={updateChannel.value}` was never updated). */}
       {pendingChannel && (
         <ChannelSwitchWarning
           open={true}
           targetChannel={pendingChannel}
           onConfirm={() => {
-            updateSettings({ update_channel: pendingChannel });
+            updateChannel.set(pendingChannel);
             setPendingChannel(null);
           }}
           onCancel={() => setPendingChannel(null)}

--- a/src/components/settings/tabs/QualityTab.tsx
+++ b/src/components/settings/tabs/QualityTab.tsx
@@ -51,8 +51,8 @@
  * @see {@link @/types/index.ts}           -- SongCodec, VideoResolution, CompanionMode types
  */
 
-// Zustand store for reading/writing quality settings.
-import { useSettingsStore } from '@/stores/settingsStore';
+// Audit v2 #6 — per-field Zustand binding.
+import { useSettingsField } from '@/hooks/useSettingsField';
 
 // Shared form components.
 import { Select, Toggle, FallbackChainList, CheckboxGroup, SettingsSection } from '@/components/common';
@@ -120,10 +120,19 @@ function parseVideoCodecPriority(raw: string): VideoCodec[] {
  * narrow the string from the native <select> element to the expected union type.
  */
 export function QualityTab() {
-  /** Current settings snapshot from the Zustand store */
-  const settings = useSettingsStore((s) => s.settings);
-  /** Partial-update function that sets isDirty = true */
-  const updateSettings = useSettingsStore((s) => s.updateSettings);
+  // Per-field Zustand bindings (audit v2 #6).
+  const songCodec = useSettingsField('default_song_codec');
+  const fallbackEnabled = useSettingsField('fallback_enabled');
+  const companionMode = useSettingsField('companion_mode');
+  const customCompanionCodecs = useSettingsField('custom_companion_codecs');
+  const artistAutoSelectMulti = useSettingsField('artist_auto_select_multi');
+  const artistAutoSelect = useSettingsField('artist_auto_select');
+  const dupDetect = useSettingsField('duplicate_detection');
+  const videoResolution = useSettingsField('default_video_resolution');
+  const videoCodecPriority = useSettingsField('default_video_codec_priority');
+  const videoRemuxFormat = useSettingsField('default_video_remux_format');
+  const musicVideoCompanion = useSettingsField('music_video_companion');
+  const musicbrainzLookup = useSettingsField('musicbrainz_lookup');
 
   /**
    * Transform the SONG_CODEC_LABELS record into the array format expected
@@ -144,7 +153,7 @@ export function QualityTab() {
   }));
 
   /** Whether custom companion mode is active (shows codec checkboxes). */
-  const isCustomCompanion = settings.companion_mode === 'custom';
+  const isCustomCompanion = companionMode.value === 'custom';
 
   /**
    * Same transformation for video resolution labels.
@@ -188,8 +197,8 @@ export function QualityTab() {
             </>
           }
           options={codecOptions}
-          value={settings.default_song_codec}
-          onChange={(e) => updateSettings({ default_song_codec: e.target.value as SongCodec })}
+          value={songCodec.value}
+          onChange={(e) => songCodec.set(e.target.value as SongCodec)}
           helpTopic="audio-codecs"
         />
 
@@ -197,8 +206,8 @@ export function QualityTab() {
         <Toggle
           label="Enable Fallback Chain"
           description="When the preferred codec is unavailable, automatically try the next codec in the fallback chain"
-          checked={settings.fallback_enabled}
-          onChange={(checked) => updateSettings({ fallback_enabled: checked })}
+          checked={fallbackEnabled.value}
+          onChange={fallbackEnabled.set}
         />
 
         {/* Companion download mode */}
@@ -206,8 +215,8 @@ export function QualityTab() {
           label="Companion Downloads"
           description="Automatically download additional format versions alongside the primary download. Specialist formats get a suffix ([Dolby Atmos], [Lossless]); the most compatible companion uses a clean filename. Select 'Custom...' to pick exact codecs."
           options={companionModeOptions}
-          value={settings.companion_mode}
-          onChange={(e) => updateSettings({ companion_mode: e.target.value as CompanionMode })}
+          value={companionMode.value}
+          onChange={(e) => companionMode.set(e.target.value as CompanionMode)}
           helpTopic="audio-codecs"
         />
 
@@ -217,23 +226,22 @@ export function QualityTab() {
             label="Custom Companion Codecs"
             description="Select which codecs to download as companions alongside the primary format. Each selected codec runs as a separate download. The last codec in the list gets a clean filename; others get a suffix."
             options={SONG_CODEC_LABELS}
-            selected={settings.custom_companion_codecs}
-            onChange={(selected) => updateSettings({ custom_companion_codecs: selected })}
+            selected={customCompanionCodecs.value}
+            onChange={customCompanionCodecs.set}
           />
         )}
 
-        {/* Artist auto-select mode (multi-select) */}
+        {/* Artist auto-select mode (multi-select). Two writes per change
+            because the legacy `artist_auto_select` scalar is kept in
+            sync with the multi-select array for backwards compat. */}
         <CheckboxGroup<ArtistAutoSelect>
           label="Artist Auto-Select"
           description="When downloading from an artist URL, automatically download these content types. Select multiple to download each type separately (MeedyaDL creates one download per selected mode). Leave empty to use GAMDL's default behaviour. Requires GAMDL 2.9.1+."
           options={ARTIST_AUTO_SELECT_LABELS}
-          selected={settings.artist_auto_select_multi}
+          selected={artistAutoSelectMulti.value}
           onChange={(selected) => {
-            updateSettings({
-              artist_auto_select_multi: selected,
-              // Keep legacy field in sync for backwards compat
-              artist_auto_select: selected.length > 0 ? selected[0] : null,
-            });
+            artistAutoSelectMulti.set(selected);
+            artistAutoSelect.set(selected.length > 0 ? selected[0] : null);
           }}
         />
       </SettingsSection>
@@ -257,13 +265,11 @@ export function QualityTab() {
             value: v,
             label: DEDUP_SCOPE_LABELS[v],
           }))}
-          value={settings.duplicate_detection.scope}
+          value={dupDetect.value.scope}
           onChange={(e) =>
-            updateSettings({
-              duplicate_detection: {
-                ...settings.duplicate_detection,
-                scope: e.target.value as DuplicateDetectionScope,
-              },
+            dupDetect.set({
+              ...dupDetect.value,
+              scope: e.target.value as DuplicateDetectionScope,
             })
           }
         />
@@ -275,13 +281,11 @@ export function QualityTab() {
             value: v,
             label: DEDUP_KEY_LABELS[v],
           }))}
-          value={settings.duplicate_detection.key_strategy}
+          value={dupDetect.value.key_strategy}
           onChange={(e) =>
-            updateSettings({
-              duplicate_detection: {
-                ...settings.duplicate_detection,
-                key_strategy: e.target.value as DedupKeyStrategy,
-              },
+            dupDetect.set({
+              ...dupDetect.value,
+              key_strategy: e.target.value as DedupKeyStrategy,
             })
           }
         />
@@ -296,14 +300,12 @@ export function QualityTab() {
             skipped. Reorder to change which version is kept.
           </p>
           <FallbackChainList<ArtistAutoSelect>
-            items={settings.duplicate_detection.preference_order}
+            items={dupDetect.value.preference_order}
             labels={ARTIST_AUTO_SELECT_LABELS}
             onChange={(items) =>
-              updateSettings({
-                duplicate_detection: {
-                  ...settings.duplicate_detection,
-                  preference_order: items,
-                },
+              dupDetect.set({
+                ...dupDetect.value,
+                preference_order: items,
               })
             }
           />
@@ -318,12 +320,8 @@ export function QualityTab() {
           label="Default Video Resolution"
           description="The preferred resolution for music video downloads"
           options={resolutionOptions}
-          value={settings.default_video_resolution}
-          onChange={(e) =>
-            updateSettings({
-              default_video_resolution: e.target.value as VideoResolution,
-            })
-          }
+          value={videoResolution.value}
+          onChange={(e) => videoResolution.set(e.target.value as VideoResolution)}
         />
 
         {/* Video codec priority (reorderable list) */}
@@ -335,11 +333,9 @@ export function QualityTab() {
             Order of preferred video codecs for music video downloads (top = tried first)
           </p>
           <FallbackChainList<VideoCodec>
-            items={parseVideoCodecPriority(settings.default_video_codec_priority)}
+            items={parseVideoCodecPriority(videoCodecPriority.value)}
             labels={VIDEO_CODEC_LABELS}
-            onChange={(codecs) =>
-              updateSettings({ default_video_codec_priority: codecs.join(',') })
-            }
+            onChange={(codecs) => videoCodecPriority.set(codecs.join(','))}
           />
         </div>
 
@@ -348,19 +344,19 @@ export function QualityTab() {
           label="Video Remux Format"
           description="Container format for remuxed video files"
           options={remuxOptions}
-          value={settings.default_video_remux_format}
-          onChange={(e) => updateSettings({ default_video_remux_format: e.target.value })}
+          value={videoRemuxFormat.value}
+          onChange={(e) => videoRemuxFormat.set(e.target.value)}
         />
 
         {/* Music video companion downloads */}
         <Toggle
           label="Music Video Companions (Experimental)"
           description="When downloading audio, also download the music video for each track (if available on Apple Music). Uses the video quality settings above. Discovery via Apple Music API (requires MusicKit credentials) and/or MusicBrainz ISRC lookup (no credentials needed)."
-          checked={settings.music_video_companion}
-          onChange={(checked) => updateSettings({ music_video_companion: checked })}
+          checked={musicVideoCompanion.value}
+          onChange={musicVideoCompanion.set}
         />
 
-        {settings.music_video_companion && (
+        {musicVideoCompanion.value && (
           <div className="p-3 rounded-lg bg-status-warning-bg border border-status-warning">
             <p className="text-xs font-semibold text-status-warning mb-1">
               Experimental Feature
@@ -378,8 +374,8 @@ export function QualityTab() {
         <Toggle
           label="MusicBrainz Video Lookup"
           description="Use MusicBrainz database to discover music videos and cross-platform URLs via ISRC codes. No credentials required. Also used by Music Video Companions when MusicKit credentials are not configured."
-          checked={settings.musicbrainz_lookup}
-          onChange={(checked) => updateSettings({ musicbrainz_lookup: checked })}
+          checked={musicbrainzLookup.value}
+          onChange={musicbrainzLookup.set}
         />
       </SettingsSection>
     </div>


### PR DESCRIPTION
## Summary

Completes the **audit v2 finding #6** migration. With this PR, all 9 user-facing settings tabs use the `useSettingsField` hook for per-field Zustand bindings. Replaces the `settings.X` + `updateSettings({ X: v })` lambda pair with `field.value` + `field.set` — each control re-renders only when its bound field changes.

## Tabs migrated in this PR (4 of the original 9)

- **`CookiesTab.tsx`** — single field (`cookies_path`); validation + browser-import handlers all migrate cleanly.
- **`QualityTab.tsx`** — 12 fields including the nested `duplicate_detection` object (handled via `dupDetect.set({ ...dupDetect.value, key: v })`) and the artist-auto-select pair where the multi-select array AND the legacy scalar both fire `.set()` per change.
- **`GeneralTab.tsx`** — 21 fields. `useSettingsStore` retained only for the `loadSettings` action (used by the import flow).
- **`AdvancedTab.tsx`** — 20 fields, plus the `DevToolsSection` sub-component which migrates its two MusicKit reads. `useSettingsStore` retained for the two non-field actions: `saveSettings` (setup-wizard reset) and `loadSettings` (dev-access deactivate).

Combined with the 5 tabs already migrated in 815a0ce (`TemplatesTab`, `FallbackTab`, `CoverArtTab`, `LyricsTab`, `ToolsTab`), all 9 settings tabs are now on the new pattern.

## Why useSettingsField wins

- **Per-field subscriptions** — Zustand re-renders only the controls bound to a field that changed, not the entire tab.
- **Type-safe key access** — typos are compile-time errors (`useSettingsField('xyz_typo')` won't compile).
- **No key duplication** — the field key is supplied once at the hook call, not twice (read + write).
- **Memoised setters** — `.set` is stable across renders so memoised consumers don't re-render on parent re-render.

## Verification

- [x] `npx tsc --noEmit` clean.
- [x] `npm test -- --run` — 465 tests pass across 31 files.
- [ ] CI runs the full Backend + Frontend matrix on this PR.

## Branch base

This branch was created off `main` BEFORE PR #762 landed the clippy fix. CI will fail on the same Backend clippy lint until #762 merges and this branch rebases. Order of operations:

1. Merge #762 (clippy fix + Release-As trailer).
2. Rebase or merge `main` into this branch.
3. CI re-runs and passes.
4. Merge this PR.

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)