### PR TITLE
fix(test): drop rerender() that flakes on Windows CI

### DIFF
--- a/src/components/download/ActivityLog.test.tsx
+++ b/src/components/download/ActivityLog.test.tsx
@@ -110,15 +110,23 @@ describe('ActivityLog', () => {
         entries: [makeEntry({ _id: 1 })],
       });
     });
-    const { rerender } = render(<ActivityLog />);
+    render(<ActivityLog />);
     expect(screen.getByText('1 line')).toBeInTheDocument();
 
+    // Drive the second assertion through a Zustand state update — the
+    // component subscribes to the store, so React re-renders
+    // automatically. The previous implementation called
+    // `rerender(<ActivityLog />)` which forced @tanstack/react-virtual
+    // to re-measure under jsdom, causing intermittent 5s timeouts on
+    // the Windows GitHub Actions runner specifically (jsdom DOM
+    // measurement is slower on win32 due to Node test harness
+    // differences). Single-render + store-driven re-render keeps the
+    // virtualiser instance stable across the two assertions.
     act(() => {
       useActivityStore.setState({
         entries: [makeEntry({ _id: 1 }), makeEntry({ _id: 2 })],
       });
     });
-    rerender(<ActivityLog />);
     expect(screen.getByText('2 lines')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

The Windows GitHub Actions runner has been intermittently timing out on a single ActivityLog test — `'subtitle pluralises lines correctly'` — while macOS and Ubuntu pass cleanly. Latest hit: the v1.4.1 release commit (df6549c) on main, breaking the post-merge CI run.

## Root cause

The test called:

```tsx
const { rerender } = render(<ActivityLog />);
expect(screen.getByText('1 line')).toBeInTheDocument();

act(() => { useActivityStore.setState({ entries: [...] }); });
rerender(<ActivityLog />);
expect(screen.getByText('2 lines')).toBeInTheDocument();
```

The explicit `rerender()` forces a remount-style render. `ActivityLog` uses `@tanstack/react-virtual` which re-measures DOM nodes on remount. jsdom's DOM measurement is slower on the Windows runner than on macOS / Ubuntu (a known win32 Node test-harness quirk), and the remeasure occasionally exceeded the default 5000ms test timeout.

## Fix

Drop the `rerender()` call. The component subscribes to the Zustand activity store via `useActivityStore`, so a `setState` inside `act()` triggers a normal React re-render — no need to remount. Keeps the virtualiser instance stable across the two assertions.

## Verification

- [x] `npm test -- --run src/components/download/ActivityLog.test.tsx` — 18 / 18 pass locally.
- [ ] CI runs the full Windows + macOS + Ubuntu Frontend matrix on this PR.

## Why a separate PR

Following the new "branch + PR for everything except `[skip ci]` doc/chore" rule established in PR #760's retrospective. The fix is one-test-file but the policy applies uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)