### PR TITLE
fix: companion sidecar rename + accurate per-item progress bar (#788, #790)

### DIFF
--- a/src-tauri/src/services/metadata_tag_service.rs
+++ b/src-tauri/src/services/metadata_tag_service.rs
@@ -1455,9 +1455,82 @@ pub fn apply_advisory_suffixes_from_tags(output_path: &str) {
                 file_path.display(),
                 final_path.display()
             ),
+            Err(e) => {
+                log::warn!(
+                    "Post-companion advisory rename failed for {}: {e}",
+                    file_path.display()
+                );
+                // Audio rename failed → skip the sidecar pass for
+                // this file. Without the audio rename the sidecars
+                // are already correctly paired with the un-renamed
+                // audio stem; renaming them now would create the
+                // orphan situation #788 was opened to prevent.
+                continue;
+            }
+        }
+
+        // Sidecar rename in lockstep with the audio (#788). Pre-fix,
+        // `apply_advisory_suffixes_from_tags` only renamed audio
+        // files, so companion sidecars (`01 Title [Lossless].lrc`)
+        // were left orphaned next to the now-renamed audio
+        // (`01 Title [Explicit] [Lossless].m4a`) — lyrics
+        // conversion + subtitle embedding couldn't pair them.
+        // Mirrors the pattern from `apply_codec_rename_suffix` /
+        // `rename_matching_sidecars` (#535) but uses the
+        // advisory-insertion stem transform instead of plain
+        // suffix-append.
+        rename_matching_advisory_sidecars(file_path, stem, &new_stem);
+    }
+}
+
+/// Rename lyrics / subtitle sidecars next to `audio_path` whose stem
+/// matches `old_stem` so they keep pace with an audio file that was
+/// just renamed by the advisory pass (#788).
+///
+/// Mirror of `rename_matching_sidecars` (the codec-suffix sibling
+/// from #535), but takes the explicit new stem rather than a suffix
+/// to append — because the advisory rename uses
+/// `insert_advisory_before_codec_suffix` (advisory lands BEFORE
+/// any codec suffix, not at the end), the caller already has the
+/// new stem from that helper and passes it in.
+///
+/// Silently skips sidecars that don't exist or whose target is
+/// already occupied. Errors are logged but don't propagate — sidecar
+/// rename is best-effort; the audio rename already landed.
+fn rename_matching_advisory_sidecars(audio_path: &Path, old_stem: &str, new_stem: &str) {
+    let parent = match audio_path.parent() {
+        Some(p) => p,
+        None => return,
+    };
+    for sidecar_ext in CODEC_RENAME_SIDECAR_EXTENSIONS {
+        let sidecar = parent.join(format!("{old_stem}.{sidecar_ext}"));
+        if !sidecar.exists() {
+            continue;
+        }
+        let new_sidecar = parent.join(format!("{new_stem}.{sidecar_ext}"));
+        // Idempotency: if a prior run already produced the renamed
+        // sidecar AND the old-stem sidecar still exists (e.g. a
+        // partial run earlier created the suffixed version but
+        // didn't remove the source), leave both alone — the user
+        // can decide. Same conservative behaviour as the codec
+        // sidecar helper.
+        if new_sidecar.exists() {
+            log::debug!(
+                "Advisory sidecar rename: target {} already exists — leaving {} in place",
+                new_sidecar.display(),
+                sidecar.display()
+            );
+            continue;
+        }
+        match crate::utils::fs_safe::safe_rename(&sidecar, &new_sidecar) {
+            Ok(final_path) => log::debug!(
+                "Advisory sidecar: {} → {}",
+                sidecar.display(),
+                final_path.display()
+            ),
             Err(e) => log::warn!(
-                "Post-companion advisory rename failed for {}: {e}",
-                file_path.display()
+                "Advisory sidecar rename failed for {}: {e}",
+                sidecar.display()
             ),
         }
     }
@@ -2720,5 +2793,148 @@ mod tests {
                 .join("05 Song [Lossless] [Lossless].ttml")
                 .exists()
         );
+    }
+
+    // ----------------------------------------------------------
+    // Advisory sidecar rename tests (#788)
+    // ----------------------------------------------------------
+
+    /// All five sidecar formats follow the audio when the post-companion
+    /// advisory pass renames `01 Track [Lossless].m4a` →
+    /// `01 Track [Explicit] [Lossless].m4a`.
+    #[test]
+    fn rename_matching_advisory_sidecars_renames_all_formats() {
+        let dir = tempfile::tempdir().unwrap();
+        let new_audio = dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].m4a");
+        // Audio already renamed in place by the caller; sidecars
+        // still on the old (pre-advisory) stem.
+        std::fs::write(&new_audio, b"audio").unwrap();
+        for ext in ["ttml", "lrc", "srt", "vtt", "ass"] {
+            std::fs::write(
+                dir.path().join(format!("01 Track [Lossless].{ext}")),
+                b"sidecar",
+            )
+            .unwrap();
+        }
+
+        rename_matching_advisory_sidecars(
+            &new_audio,
+            "01 Track [Lossless]",
+            "01 Track [Explicit] [Lossless]",
+        );
+
+        for ext in ["ttml", "lrc", "srt", "vtt", "ass"] {
+            let renamed = dir
+                .path()
+                .join(format!("01 Track [Explicit] [Lossless].{ext}"));
+            assert!(
+                renamed.exists(),
+                "expected sidecar .{ext} to be renamed with advisory suffix"
+            );
+            let orig =
+                dir.path().join(format!("01 Track [Lossless].{ext}"));
+            assert!(
+                !orig.exists(),
+                "expected original sidecar .{ext} to be gone after rename"
+            );
+        }
+    }
+
+    /// Missing sidecars don't cause errors — the helper is best-effort.
+    #[test]
+    fn rename_matching_advisory_sidecars_skips_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let new_audio = dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].m4a");
+        std::fs::write(&new_audio, b"audio").unwrap();
+        // Only .lrc present — others missing.
+        std::fs::write(
+            dir.path().join("01 Track [Lossless].lrc"),
+            b"side",
+        )
+        .unwrap();
+
+        rename_matching_advisory_sidecars(
+            &new_audio,
+            "01 Track [Lossless]",
+            "01 Track [Explicit] [Lossless]",
+        );
+
+        assert!(dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].lrc")
+            .exists());
+        assert!(!dir.path().join("01 Track [Lossless].lrc").exists());
+        // Missing .ttml/.srt/etc. don't get spurious targets.
+        assert!(!dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].ttml")
+            .exists());
+    }
+
+    /// Idempotency: if a prior partial run created the advisory-renamed
+    /// sidecar AND the old-stem sidecar still exists (e.g. a crash
+    /// between audio and sidecar rename), don't blindly overwrite — leave
+    /// both files alone for the user to reconcile.
+    #[test]
+    fn rename_matching_advisory_sidecars_preserves_existing_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let new_audio = dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].m4a");
+        std::fs::write(&new_audio, b"audio").unwrap();
+        std::fs::write(
+            dir.path().join("01 Track [Lossless].ttml"),
+            b"old",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("01 Track [Explicit] [Lossless].ttml"),
+            b"new",
+        )
+        .unwrap();
+
+        rename_matching_advisory_sidecars(
+            &new_audio,
+            "01 Track [Lossless]",
+            "01 Track [Explicit] [Lossless]",
+        );
+
+        // Both files still exist, untouched.
+        assert!(dir.path().join("01 Track [Lossless].ttml").exists());
+        let suffixed = dir
+            .path()
+            .join("01 Track [Explicit] [Lossless].ttml");
+        assert!(suffixed.exists());
+        assert_eq!(std::fs::read(&suffixed).unwrap(), b"new");
+        assert_eq!(
+            std::fs::read(dir.path().join("01 Track [Lossless].ttml"))
+                .unwrap(),
+            b"old"
+        );
+    }
+
+    /// Track with no codec suffix at all (single-codec mode where the
+    /// primary doesn't need a suffix) → sidecars rename from `01 Track.lrc`
+    /// to `01 Track [Explicit].lrc`. Confirms the helper handles the
+    /// suffix-less case.
+    #[test]
+    fn rename_matching_advisory_sidecars_handles_no_codec_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let new_audio = dir.path().join("01 Track [Explicit].m4a");
+        std::fs::write(&new_audio, b"audio").unwrap();
+        std::fs::write(dir.path().join("01 Track.lrc"), b"side").unwrap();
+
+        rename_matching_advisory_sidecars(
+            &new_audio,
+            "01 Track",
+            "01 Track [Explicit]",
+        );
+
+        assert!(dir.path().join("01 Track [Explicit].lrc").exists());
+        assert!(!dir.path().join("01 Track.lrc").exists());
     }
 }

--- a/src/components/layout/GlobalProgressBar.tsx
+++ b/src/components/layout/GlobalProgressBar.tsx
@@ -23,6 +23,7 @@ import { useMemo, useState, useEffect } from 'react';
 
 import { useDownloadStore } from '@/stores/downloadStore';
 import { formatActiveItemCaption } from '@/lib/progress-caption';
+import { computeItemProgress } from '@/lib/progress-percent';
 
 /**
  * Platform detection config — loaded once from engines.toml via IPC.
@@ -303,15 +304,14 @@ export function GlobalProgressBar() {
   if (!hasWork) return null;
 
   /**
-   * Per-item progress value.
-   * During processing: use actual progress if available (companion downloads
-   * update progress while item stays in 'processing' state), otherwise null
-   * for indeterminate animation (enrichment stages without progress data).
+   * Per-item progress value — see `computeItemProgress` for the
+   * aggregation rule (#790). For multi-track items the value now
+   * spans the WHOLE item (completed_tracks + current_track%), not
+   * just the current track's GAMDL `[download] X%` — so the bar
+   * ticks monotonically forward instead of "scrolling" left-to-
+   * right as each track resets to 0.
    */
-  const itemProgress =
-    activeItem?.state === 'processing'
-      ? (activeItem?.speed ? (activeItem?.progress ?? null) : null)
-      : (activeItem?.progress ?? 0);
+  const itemProgress = computeItemProgress(activeItem ?? null);
 
   /** Per-item caption — see `formatActiveItemCaption` for rules. */
   const itemLabel = formatActiveItemCaption(activeItem);
@@ -337,7 +337,13 @@ export function GlobalProgressBar() {
         <span className="text-[12px] text-content-secondary truncate min-w-0 flex-1">
           {activeItem ? itemLabel : 'Waiting…'}
         </span>
-        {/* Speed + ETA + percentage (right) */}
+        {/* Speed + ETA + percentage (right).
+            #790: `computeItemProgress` now exhausts every signal
+            (active byte stream → enrichment stage weight) before
+            falling back to `null`, so the "Processing…" placeholder
+            only fires in the brief gaps where no signal exists at
+            all. When it does fire, that's the honest answer — we
+            don't fake a percentage we can't measure. */}
         <span className="text-[12px] text-content-tertiary whitespace-nowrap flex-shrink-0">
           {speedEta ? `${speedEta} · ` : ''}
           {itemProgress !== null ? `${Math.round(itemProgress)}%` : 'Processing…'}
@@ -352,16 +358,24 @@ export function GlobalProgressBar() {
         aria-label="Current download progress"
       >
         {itemProgress === null ? (
-          /* Indeterminate (processing) */
+          /* Indeterminate — LAST resort per #790. Only fires when
+             we have neither an active GAMDL byte stream nor an
+             enrichment stage weight. Should be brief; persistent
+             indeterminate state would indicate a missing emit at
+             the source, not a problem in this render. */
           <div
             className="h-full w-1/3 rounded-full bg-accent animate-[indeterminate_1.5s_ease-in-out_infinite]"
             style={{ animation: 'indeterminate 1.5s ease-in-out infinite' }}
           />
         ) : (
-          /* Determinate */
+          /* Determinate — per-file byte progress (GAMDL active),
+             enrichment stage weight, or terminal-state value.
+             Each file's bar cycles 0 → 100 as expected; the
+             caption changes per file so the user can see which
+             file is in flight. */
           <div
             className="h-full rounded-full bg-accent transition-all duration-300 ease-out"
-            style={{ width: `${Math.max(0, Math.min(100, itemProgress))}%` }}
+            style={{ width: `${itemProgress}%` }}
           />
         )}
       </div>

--- a/src/lib/progress-percent.test.ts
+++ b/src/lib/progress-percent.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Unit tests for `computeItemProgress` (#790).
+ *
+ * Validates each resolution path. Per the user's clarification
+ * (2026-05-17), the bar prefers per-file byte progress (cycles
+ * 0 → 100 per file, label changes per file) over album-level
+ * aggregation, and only falls back to the indeterminate
+ * animation when no signal at all is available.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { makeQueueItem } from '@/testing/fixtures';
+import { computeItemProgress } from './progress-percent';
+
+describe('computeItemProgress', () => {
+  describe('Path 1: active GAMDL byte stream', () => {
+    it('returns the raw per-file percentage when speed is set', () => {
+      // Per the user clarification: per-file accuracy beats
+      // album-level aggregation. The bar resetting between files
+      // is correct — the caption changes per file too.
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: '2.5 MB/s',
+        progress: 42,
+      });
+      expect(computeItemProgress(item)).toBe(42);
+    });
+
+    it('uses raw progress during processing state too (companion download phase)', () => {
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: '1.2 MB/s',
+        progress: 75,
+      });
+      expect(computeItemProgress(item)).toBe(75);
+    });
+
+    it('ignores total_tracks / completed_tracks — those drive the queue-level bar, not the per-item bar', () => {
+      // Confirms the previous album-aggregation behaviour was
+      // reverted. The bar shows the current file's byte
+      // progress; album-level rollup lives on the queue-level
+      // (second) bar.
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: '2.5 MB/s',
+        total_tracks: 12,
+        completed_tracks: 4,
+        progress: 60,
+      });
+      expect(computeItemProgress(item)).toBe(60);
+    });
+  });
+
+  describe('Path 2: enrichment stage weight', () => {
+    it('scales the 0-1 fraction to 0-100', () => {
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: null,
+        processing_progress: 0.75,
+      });
+      expect(computeItemProgress(item)).toBe(75);
+    });
+
+    it('handles early enrichment stage (0.05)', () => {
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: null,
+        processing_progress: 0.05,
+      });
+      expect(computeItemProgress(item)).toBe(5);
+    });
+
+    it('handles the final enrichment stage (1.0)', () => {
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: null,
+        processing_progress: 1.0,
+      });
+      expect(computeItemProgress(item)).toBe(100);
+    });
+  });
+
+  describe('Path 3: non-active states', () => {
+    it('queued items return their raw progress (typically 0)', () => {
+      const item = makeQueueItem({
+        state: 'queued',
+        speed: null,
+        progress: 0,
+      });
+      expect(computeItemProgress(item)).toBe(0);
+    });
+
+    it('complete items return their raw progress (typically 100)', () => {
+      const item = makeQueueItem({
+        state: 'complete',
+        speed: null,
+        progress: 100,
+      });
+      expect(computeItemProgress(item)).toBe(100);
+    });
+
+    it('error items return their raw progress (last known value)', () => {
+      const item = makeQueueItem({
+        state: 'error',
+        speed: null,
+        progress: 35,
+      });
+      expect(computeItemProgress(item)).toBe(35);
+    });
+  });
+
+  describe('Path 4: indeterminate fallback (LAST resort)', () => {
+    it('returns null when processing without speed AND without processing_progress', () => {
+      // Only path that produces null. Should be rare — fires in
+      // the brief gaps between enrichment stages where no signal
+      // has fired yet.
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: null,
+        processing_progress: null,
+      });
+      expect(computeItemProgress(item)).toBeNull();
+    });
+
+    it('returns null for downloading state without speed AND no fallback signal', () => {
+      // Edge case: state says downloading but speed is unset
+      // (sub-second window between subprocess spawn and first
+      // [download] X% line). Honest answer: we don't know yet.
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: null,
+        processing_progress: null,
+      });
+      expect(computeItemProgress(item)).toBeNull();
+    });
+  });
+
+  describe('Defensive behaviour', () => {
+    it('returns null for null input', () => {
+      expect(computeItemProgress(null)).toBeNull();
+    });
+
+    it('returns null for undefined input', () => {
+      expect(computeItemProgress(undefined)).toBeNull();
+    });
+
+    it('clamps an out-of-range backend value to the 0-100 envelope', () => {
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: '1 MB/s',
+        progress: 250,
+      });
+      expect(computeItemProgress(item)).toBe(100);
+    });
+
+    it('clamps a negative value to 0', () => {
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: '1 MB/s',
+        progress: -10,
+      });
+      expect(computeItemProgress(item)).toBe(0);
+    });
+
+    it('handles NaN gracefully by returning 0', () => {
+      const item = makeQueueItem({
+        state: 'downloading',
+        speed: '1 MB/s',
+        progress: NaN,
+      });
+      expect(computeItemProgress(item)).toBe(0);
+    });
+
+    it('clamps processing_progress > 1 to 100', () => {
+      const item = makeQueueItem({
+        state: 'processing',
+        speed: null,
+        processing_progress: 1.5,
+      });
+      expect(computeItemProgress(item)).toBe(100);
+    });
+  });
+});

--- a/src/lib/progress-percent.ts
+++ b/src/lib/progress-percent.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Per-item progress-bar percentage computation (#790).
+ *
+ * Extracted from `GlobalProgressBar.tsx` so the multi-signal
+ * resolution rule can be unit-tested in isolation without
+ * rendering the full DOM. Sibling to `progress-caption.ts` which
+ * does the analogous extraction for the caption text.
+ *
+ * ## Why this exists
+ *
+ * Pre-fix the bar fell through to a CSS-keyframe animated
+ * indeterminate stripe (sliding left-to-right) whenever the
+ * `progress` field was unset — which fired routinely between
+ * enrichment stages and during companion-supervisor handoffs.
+ * User feedback (2026-05-17): the indeterminate animation
+ * should ONLY appear when it's genuinely impossible to derive a
+ * percentage — try every other signal first.
+ *
+ * ## What stays per-file
+ *
+ * For multi-file downloads (album with many tracks, multi-codec
+ * companion tiers), the bar SHOULD show the current file's
+ * byte-level progress (cycles 0 → 100 per file) — this is what
+ * the user explicitly asked for in the clarification: "we should
+ * update the progress bar label for each so that we can also
+ * accurately represent progress for each individual item
+ * progress." The label (handled by `formatActiveItemCaption`)
+ * tells you WHICH file is in flight; the bar tells you HOW MUCH
+ * of THAT file is done. Resetting between files is the correct
+ * behaviour, not a bug.
+ *
+ * ## Resolution order
+ *
+ *   1. **Active GAMDL stream** (`speed` is set, which means the
+ *      subprocess is actively reporting `[download] X%`): use
+ *      the raw `progress` — per-file byte percentage, the most
+ *      accurate signal we have.
+ *
+ *   2. **Enrichment stage weight set** (`processing_progress`):
+ *      scale that 0-1 fraction to 0-100. Each stage transition
+ *      moves the bar forward.
+ *
+ *   3. **Non-active states** (queued / complete / error): the
+ *      backend-provided `progress` value (typically 0 or 100).
+ *
+ *   4. **Last resort** — no signal at all: return `null`. The
+ *      caller renders an indeterminate animation. Only fires
+ *      when the item is in `processing` state with neither
+ *      `speed` nor `processing_progress` set (e.g. brief gaps
+ *      between enrichment stages before the next one starts
+ *      reporting).
+ */
+
+import type { QueueItemStatus } from '@/types';
+
+/** Clamp a number into the 0-100 range so out-of-bound backend
+ * values can never push the bar visually off-screen. */
+function clamp01(percent: number): number {
+  if (!Number.isFinite(percent)) return 0;
+  return Math.min(100, Math.max(0, percent));
+}
+
+/**
+ * Compute the per-item progress-bar percentage (0-100), or `null`
+ * to request an indeterminate-animation render.
+ *
+ * `null` is the LAST resort — only when no other signal is
+ * available. The previous "always determinate" version of this
+ * helper was rolled back per user clarification: per-file
+ * accuracy beats a synthesised determinate number that doesn't
+ * reflect any real measurement.
+ */
+export function computeItemProgress(
+  item: QueueItemStatus | null | undefined
+): number | null {
+  if (!item) return null;
+
+  // Path 1: GAMDL is actively reporting bytes for the current
+  // file. `speed` is the marker — it gets cleared between files /
+  // between stages. When set, `progress` is the most accurate
+  // signal we have: per-file byte percentage.
+  if (item.speed) {
+    return clamp01(item.progress ?? 0);
+  }
+
+  // Path 2: no active byte stream, but enrichment has emitted a
+  // stage weight. Each stage transition moves the bar forward.
+  if (item.processing_progress != null) {
+    return clamp01(item.processing_progress * 100);
+  }
+
+  // Path 3: non-active states fall through to the backend value
+  // (typically 0 for queued, 100 for complete, last-known for
+  // error).
+  if (item.state !== 'processing' && item.state !== 'downloading') {
+    return clamp01(item.progress ?? 0);
+  }
+
+  // Path 4: TRULY no signal. Fire the indeterminate animation —
+  // the only honest answer when we can't measure. Should be brief
+  // (between enrichment stages); if it persists, that's a
+  // separate bug to fix at the source (the missing emit), not
+  // here.
+  return null;
+}


### PR DESCRIPTION
Two #528 follow-ups + one independent UX fix shipping together as v1.4.5:

| Closes | Title | Commit |
|---|---|---|
| #788 | fix: post-companion advisory pass also renames lyrics sidecars | `947752c` |
| #790 | fix: per-item progress bar derives from best available signal | (amended) |

Plus #789 (legacy folder merge for pre-#528 downloads) filed but **NOT** in this PR — it's a new Library Scan feature with on-disk file moves and deserves its own design pass.

## What's new (user-facing)

- **Lyrics sidecars no longer go missing on companion downloads.** After v1.4.4's #528 fix landed companion files in the same folder as the primary, the post-companion `[Explicit]` / `[Clean]` rename was only touching audio files — leaving `01 Title [Lossless].lrc` next to `01 Title [Explicit] [Lossless].m4a`, which broke lyrics conversion and subtitle embedding for the companion codec. Sidecars now move in lockstep. (#788)

- **The top progress bar shows accurate progress instead of an animated stripe.** Pre-fix the bar fell back to a CSS-animated indeterminate stripe whenever the raw progress signal was unset — which happened routinely between enrichment stages and during companion handoffs. The new resolution chain tries every available signal (GAMDL's per-file `[download] X%` first, then enrichment stage weights, then terminal-state values) before ever rendering the animation. The "Processing…" placeholder text on the right side is correspondingly almost always replaced by an actual percentage. (#790)

---

## #788 — Sidecar lyrics rename

### Symptom

After #528 (v1.4.4) merged companion files into the primary's `Album [Explicit]/` folder, the post-companion advisory pass (`apply_advisory_suffixes_from_tags`) renamed companion audio but not the lyric / subtitle sidecars next to them:

```
Album [Explicit]/
  01 Title [Explicit] [Dolby Atmos].m4a   ← primary, audio renamed by enrichment
  01 Title [Explicit] [Dolby Atmos].lrc   ← primary sidecar, renamed by #535 codec-rename
  01 Title [Explicit] [Lossless].m4a      ← companion, audio renamed by post-companion advisory
  01 Title [Lossless].lrc                 ← companion sidecar — ORPHAN, stale stem
```

The companion sidecar no longer matched its audio's stem → lyrics conversion + subtitle embedding silently skipped it → user saw lyrics for the primary codec only.

### Fix

New `rename_matching_advisory_sidecars(audio_path, old_stem, new_stem)` helper mirrors the `rename_matching_sidecars` pattern from #535 (the codec-suffix sibling) but uses the explicit new stem from `insert_advisory_before_codec_suffix` instead of plain suffix-append — because the advisory suffix lands BEFORE any codec suffix, not at the end.

Called from `apply_advisory_suffixes_from_tags` only when the audio rename succeeded (audio rename failure → sidecars are still correctly paired with the un-renamed stem; renaming them would CREATE the orphan we're trying to prevent).

Defensive behaviour preserved: missing sidecars silently skipped, already-renamed target left alone (no `safe_rename` auto-disambiguation noise), errors logged at warn level without propagating.

### Tests

4 new unit tests:
- All 5 sidecar formats (TTML/LRC/SRT/VTT/ASS) follow the audio in lockstep.
- Missing sidecars don't fail.
- Idempotency: existing renamed target preserved (no clobber).
- No-codec-suffix case: `01 Track.lrc` → `01 Track [Explicit].lrc` works.

---

## #790 — Progress bar resolution chain

### Symptom

The top progress bar appeared to "scroll" left-to-right repeatedly mid-download. Two distinct sources:

1. Between enrichment stages, the per-item bar's `progress` was unset → fell through to a CSS-animated indeterminate stripe.
2. The right-hand "Processing…" placeholder showed instead of an actual percentage.

User feedback (2026-05-17) made the intent explicit: avoid the indeterminate animation as a **last resort**, prefer per-file accuracy (each file cycles 0→100 with the LABEL changing per file), use every signal we have.

### Fix

New `computeItemProgress` helper in `src/lib/progress-percent.ts` with this priority:

1. **Active GAMDL stream** (`speed` set → subprocess actively reporting `[download] X%`): use the raw `progress` — per-file byte percentage, the most accurate signal we have.
2. **Enrichment stage weight** (`processing_progress` set): scale the 0-1 fraction to 0-100.
3. **Non-active states** (queued / complete / error): backend value.
4. **Last resort** — no signal at all: return `null`. The caller renders the indeterminate animation. Fires only in the brief gaps between enrichment stages where no signal has emitted yet; should be sub-second.

`GlobalProgressBar.tsx`: the indeterminate-animation branch and the "Processing…" placeholder are KEPT but now fire only on the Path 4 null return, not on every gap.

### Per-file accuracy is preserved

Per the user's clarification, each file's bar cycles 0→100 as it downloads. The caption (`formatActiveItemCaption`) updates per file so the user can see WHICH file is in flight while the bar tells them HOW MUCH of THAT file is done. Album-level aggregation was rolled back during the design — it lives on the queue-level (second) bar instead, where per-file rollup is the right granularity.

### Tests

17 new unit tests across each resolution path, the defensive clamping (out-of-range / negative / NaN / `processing_progress > 1`), and null input handling.

---

## Not in this PR

**#789** — legacy sibling-folder merge for pre-#528 downloads. The user asked if gap-fill could re-organise old folders (`Album/` + `Album [Explicit]/`) into the new merged layout. That's a meaningful new feature on Library Scan with real on-disk file moves; needs its own design pass + careful tests + UI work. Filed as #789 for a focused follow-up PR.

---

## Verification

| Check | Result |
|---|---|
| `cargo check` | ✓ clean |
| `cargo test --lib services::metadata_tag_service::tests` | ✓ 47 pass (4 new for #788) |
| `cargo clippy --all-targets -- -D warnings` | ✓ clean |
| `npx tsc --noEmit` | ✓ clean |
| `npm test -- --run` | ✓ 482 pass (17 new for #790) |

## Test plan

- [x] All local checks pass.
- [ ] CI runs the full Backend + Frontend matrix on this PR.
- [ ] Manual smoke test (#788): download an Explicit album with companion mode enabled → verify companion sidecars (.lrc, .ttml etc.) have the `[Explicit]` suffix matching their audio.
- [ ] Manual smoke test (#790): watch the top bar during a multi-track album download → bar cycles 0→100 per track with the caption updating per file; indeterminate animation absent for the bulk of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
