### PR TITLE
feat: legacy folder merge + colour-coded activity log (closes #789, #793)

### DIFF
--- a/src-tauri/src/commands/gamdl.rs
+++ b/src-tauri/src/commands/gamdl.rs
@@ -1992,6 +1992,94 @@ fn parse_manifest_at_path(path: &std::path::Path) -> Option<ScannedManifest> {
     })
 }
 
+// ============================================================
+// Legacy sibling-folder merge (#789) — IPC surface
+// ============================================================
+//
+// Three commands wrap the `legacy_folder_merge` service's
+// detect → preview → execute pipeline so the frontend Library
+// Scan UI can offer pre-#528 users a one-shot cleanup.
+//
+// All three are opt-in (user clicks a button); none auto-run on
+// startup. Real on-disk file moves only happen inside
+// `execute_legacy_folder_merge` and only after the user has
+// reviewed the preview.
+
+/// Walk a user-selected folder for sibling pairs that should be
+/// merged (e.g. `Album/` + `Album [Explicit]/`). Defensive — the
+/// service verifies the un-suffixed sibling's `rtng` atom matches
+/// the other sibling's advisory suffix before accepting a pair.
+///
+/// Returns an empty Vec when no pairs are detected — the frontend
+/// shows "no legacy pairs found" rather than a banner.
+#[tauri::command]
+pub async fn detect_legacy_folder_pairs(
+    folder_path: String,
+) -> Result<Vec<crate::services::legacy_folder_merge::SiblingPair>, String> {
+    log::info!("Scanning for legacy sibling-folder pairs at: {folder_path}");
+    let path = std::path::Path::new(&folder_path);
+    if !path.is_dir() {
+        return Err(format!(
+            "Path is not a directory or does not exist: {folder_path}"
+        ));
+    }
+    let pairs = crate::services::legacy_folder_merge::detect_sibling_pairs(path);
+    log::info!("Detected {} legacy sibling-folder pair(s)", pairs.len());
+    Ok(pairs)
+}
+
+/// Dry-run a merge — returns file counts, potential collisions,
+/// and whether manifests will be merged, WITHOUT touching disk.
+/// Powers the confirmation UI before [`execute_legacy_folder_merge`].
+#[tauri::command]
+pub async fn preview_legacy_folder_merge(
+    pair: crate::services::legacy_folder_merge::SiblingPair,
+) -> Result<crate::services::legacy_folder_merge::MergePreview, String> {
+    crate::services::legacy_folder_merge::preview_merge(&pair)
+}
+
+/// Perform the merge. Renames source-folder audio + sidecars to
+/// add the advisory suffix, moves all files into the suffixed
+/// destination via `fs_safe::safe_rename` (auto-disambiguates
+/// collisions), merges `.meedyadl` manifests, and removes the
+/// source folder if empty after.
+///
+/// Returns a structured report the UI can surface ("moved N audio,
+/// M sidecars, K disambiguated, manifest merged"). Non-fatal
+/// warnings are in `report.warnings`.
+#[tauri::command]
+pub async fn execute_legacy_folder_merge(
+    app: AppHandle,
+    pair: crate::services::legacy_folder_merge::SiblingPair,
+) -> Result<crate::services::legacy_folder_merge::MergeReport, String> {
+    log::info!(
+        "Executing legacy folder merge: {} + {}",
+        pair.unsuffixed_path.display(),
+        pair.suffixed_path.display()
+    );
+    let report = crate::services::legacy_folder_merge::execute_merge(&pair)?;
+
+    // Surface a brief summary in the in-app activity log so the
+    // user has a paper trail outside the modal.
+    let summary = format!(
+        "Legacy folder merge: \"{}\" — moved {} audio + {} sidecars + {} other ({} disambiguated, manifest {}, source folder {})",
+        report.pair.album_basename,
+        report.audio_moved,
+        report.sidecars_moved,
+        report.other_moved,
+        report.collisions_disambiguated.len(),
+        if report.manifest_merged { "merged" } else { "skipped" },
+        if report.source_folder_removed { "removed" } else { "left in place" },
+    );
+    emit_app_log(&app, &summary);
+    for w in &report.warnings {
+        log::warn!("Legacy folder merge warning: {w}");
+        emit_app_log(&app, &format!("Legacy folder merge: {w}"));
+    }
+
+    Ok(report)
+}
+
 /// Checks whether a URL was previously downloaded and returns change
 /// Detect the codec of the first M4A file in an album directory (#380).
 ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1161,6 +1161,10 @@ pub fn run() {
             // Manifest import and folder scan
             commands::gamdl::import_manifest,
             commands::gamdl::scan_folder_for_manifests,
+            // Legacy sibling-folder merge for pre-#528 downloads (#789)
+            commands::gamdl::detect_legacy_folder_pairs,
+            commands::gamdl::preview_legacy_folder_merge,
+            commands::gamdl::execute_legacy_folder_merge,
             // Library Scan smart-retry diff per row (Phase 5b, #717)
             commands::gamdl::diff_library_scan_manifest,
             // Library Scan Apple Music lastModifiedDate freshness check (Phase 5c, #717)

--- a/src-tauri/src/models/manifest.rs
+++ b/src-tauri/src/models/manifest.rs
@@ -110,21 +110,186 @@ impl ManifestFile {
 
     /// Merge a new source into an existing manifest.
     ///
-    /// If a source with the same `platform` and `url` already exists,
-    /// it is replaced (re-download of the same content). Otherwise,
-    /// the new source is appended.
+    /// **Dedup key** (`platform`, `url`, `codec`) — promoted from
+    /// (`platform`, `url`) in #789 so a single album folder can carry
+    /// both the primary codec source (e.g. Atmos) AND a companion
+    /// codec source (e.g. ALAC) without one replacing the other. The
+    /// pre-#789 dedup treated both as the same "re-download" and lost
+    /// the companion's per-track metadata when the legacy-folder
+    /// merge appended its source.
+    ///
+    /// Behaviour:
+    ///   - Same (`platform`, `url`, `codec`) → replace (genuine
+    ///     re-download of the same content + codec; tracks may have
+    ///     been remastered / added).
+    ///   - Different `codec` for the same `url` → append (the
+    ///     companion-codec case that #789 surfaces).
+    ///   - Different `url` → append (existing multi-platform /
+    ///     multi-album behaviour).
     pub fn merge_source(&mut self, source: ManifestSource) {
         self.updated_at = chrono::Utc::now().to_rfc3339();
 
-        // Replace existing source for the same platform + URL, or append
-        if let Some(existing) = self
-            .sources
-            .iter_mut()
-            .find(|s| s.platform == source.platform && s.url == source.url)
-        {
+        // Replace existing source for the same platform + URL + codec,
+        // or append. `codec` is part of the key so primary + companion
+        // sources for the same album both survive the merge (#789).
+        if let Some(existing) = self.sources.iter_mut().find(|s| {
+            s.platform == source.platform
+                && s.url == source.url
+                && s.codec == source.codec
+        }) {
             *existing = source;
         } else {
             self.sources.push(source);
         }
+    }
+}
+
+// ============================================================
+// Unit tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_source(platform: &str, url: &str, codec: Option<&str>) -> ManifestSource {
+        ManifestSource {
+            platform: platform.to_string(),
+            url: url.to_string(),
+            storefront: None,
+            downloaded_at: "2026-05-17T12:00:00Z".to_string(),
+            codec: codec.map(String::from),
+            last_modified_date: None,
+            tracks: Vec::new(),
+        }
+    }
+
+    /// Genuine re-download: same (platform, url, codec) → replace.
+    /// Preserves the old behaviour for the most common case.
+    #[test]
+    fn merge_source_replaces_same_platform_url_codec() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        let mut second = make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        );
+        second.downloaded_at = "2026-05-17T13:00:00Z".to_string();
+        m.merge_source(second);
+        assert_eq!(m.sources.len(), 1, "same (platform, url, codec) → replace");
+        assert_eq!(m.sources[0].downloaded_at, "2026-05-17T13:00:00Z");
+    }
+
+    /// Companion-codec case (#789): same album URL but different codec
+    /// → append both, don't replace. This is the change the issue
+    /// surfaced: pre-fix the companion's source would overwrite the
+    /// primary's source and lose its tracks.
+    #[test]
+    fn merge_source_appends_when_codec_differs_on_same_url() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("atmos"),
+        ));
+        m.merge_source(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        assert_eq!(m.sources.len(), 2);
+        assert_eq!(m.sources[0].codec.as_deref(), Some("atmos"));
+        assert_eq!(m.sources[1].codec.as_deref(), Some("alac"));
+    }
+
+    /// Different URL still appends regardless of codec (existing
+    /// multi-album behaviour preserved).
+    #[test]
+    fn merge_source_appends_when_url_differs() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        m.merge_source(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/bar/456",
+            Some("alac"),
+        ));
+        assert_eq!(m.sources.len(), 2);
+    }
+
+    /// Different platform always appends (multi-service support).
+    #[test]
+    fn merge_source_appends_when_platform_differs() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        m.merge_source(make_source(
+            "spotify",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        assert_eq!(m.sources.len(), 2);
+    }
+
+    /// Both sources lack a codec field → they're still "the same"
+    /// source (the dedup key matches on `None == None`).
+    #[test]
+    fn merge_source_replaces_when_both_codecs_are_none() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            None,
+        ));
+        m.merge_source(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            None,
+        ));
+        assert_eq!(m.sources.len(), 1);
+    }
+
+    /// One source has a codec, the other doesn't → these are
+    /// distinct entries (a legacy manifest without codec metadata
+    /// next to a fresh one with codec).
+    #[test]
+    fn merge_source_treats_some_codec_and_none_as_distinct() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            None,
+        ));
+        m.merge_source(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        assert_eq!(m.sources.len(), 2);
+    }
+
+    /// `updated_at` bumps on every merge call (so consumers can
+    /// detect manifest staleness).
+    #[test]
+    fn merge_source_bumps_updated_at() {
+        let mut m = ManifestFile::new(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("alac"),
+        ));
+        let original_updated = m.updated_at.clone();
+        // Wait at least 1 ms so the new RFC3339 timestamp differs.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        m.merge_source(make_source(
+            "apple-music",
+            "https://music.apple.com/us/album/foo/123",
+            Some("atmos"),
+        ));
+        assert_ne!(m.updated_at, original_updated);
     }
 }

--- a/src-tauri/src/services/activity_log_writer.rs
+++ b/src-tauri/src/services/activity_log_writer.rs
@@ -293,6 +293,7 @@ mod tests {
         let event = ActivityLogEvent {
             download_id: "abc12345".to_string(),
             stream: "internal",
+            severity: crate::utils::activity_log::LogSeverity::Info,
             line: "hello world".to_string(),
             timestamp: "2026-04-22T14:03:21.482Z".to_string(),
         };
@@ -321,12 +322,14 @@ mod tests {
         let first = ActivityLogEvent {
             download_id: "system".to_string(),
             stream: "internal",
+            severity: crate::utils::activity_log::LogSeverity::Info,
             line: "day one".to_string(),
             timestamp: "2026-04-22T23:59:59.999Z".to_string(),
         };
         let second = ActivityLogEvent {
             download_id: "system".to_string(),
             stream: "internal",
+            severity: crate::utils::activity_log::LogSeverity::Info,
             line: "day two".to_string(),
             timestamp: "2026-04-23T00:00:00.001Z".to_string(),
         };

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -112,7 +112,10 @@ use crate::utils::process;
 // `app.emit("activity-log", &event)` site through the new
 // `emit_subprocess_line` helper, so download_queue.rs no longer needs
 // to construct events directly.
-use crate::utils::activity_log::{emit_app_log, emit_download_log, emit_verbose_download_log};
+use crate::utils::activity_log::{
+    emit_app_log, emit_download_error, emit_download_log, emit_download_warn,
+    emit_verbose_download_log,
+};
 
 // ============================================================
 // Graceful shutdown signal
@@ -3748,7 +3751,7 @@ async fn spawn_music_video_companion_inner(
         }
         Err(e) => {
             log::debug!("Music video companion token resolution failed for {dl_id}: {e}");
-            emit_download_log(app, dl_id, &format!("Music video lookup failed: {e}"));
+            emit_download_warn(app, dl_id, &format!("Music video lookup failed: {e}"));
             return;
         }
     };
@@ -3763,7 +3766,7 @@ async fn spawn_music_video_companion_inner(
             Ok(r) => r,
             Err(e) => {
                 log::debug!("Music video relation lookup failed for {dl_id}: {e}");
-                emit_download_log(app, dl_id, &format!("Music video lookup failed: {e}"));
+                emit_download_warn(app, dl_id, &format!("Music video lookup failed: {e}"));
                 return;
             }
         };
@@ -6604,7 +6607,7 @@ pub fn process_queue(
                                 q.set_error(&dl_id, &error_msg);
                                 q.on_task_finished();
                                 drop(q);
-                                emit_download_log(
+                                emit_download_error(
                                     &app_clone,
                                     &dl_id,
                                     &format!("Download failed: {error_msg}"),
@@ -9011,7 +9014,7 @@ pub fn process_queue(
                             q.set_error(&dl_id, &error_msg);
                             q.on_task_finished();
                             drop(q);
-                            emit_download_log(
+                            emit_download_error(
                                 &app_clone,
                                 &dl_id,
                                 &format!(
@@ -9028,7 +9031,7 @@ pub fn process_queue(
                             q.set_error(&dl_id, &error_msg);
                             q.on_task_finished();
                             drop(q);
-                            emit_download_log(
+                            emit_download_error(
                                 &app_clone,
                                 &dl_id,
                                 &format!("Download failed ({error_category}): {error_msg}"),

--- a/src-tauri/src/services/legacy_folder_merge.rs
+++ b/src-tauri/src/services/legacy_folder_merge.rs
@@ -1,0 +1,897 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+//! Legacy sibling-folder merge for pre-#528 downloads (#789).
+//!
+//! Albums downloaded before v1.4.4 with companion codecs enabled
+//! and `content_advisory_in_filenames = true` produced two
+//! sibling folders on disk:
+//!
+//! ```text
+//! Anne-Marie/
+//!   UNHEALTHY (Deluxe)            ← companion-codec files
+//!   UNHEALTHY (Deluxe) [Explicit] ← primary-codec files, post-rename
+//! ```
+//!
+//! #528 (v1.4.4) prevents the split for new downloads by
+//! injecting the advisory suffix into the companion's GAMDL
+//! folder template before spawn. This module handles the
+//! historical cleanup — detect existing sibling pairs, offer the
+//! user a preview, then merge.
+//!
+//! ## Three-phase API
+//!
+//! 1. [`detect_sibling_pairs`] — walks the user's library root
+//!    looking for `Foo` + `Foo [Explicit]` (or `[Clean]`) pairs
+//!    under the same parent. Defensive: reads one audio file's
+//!    `rtng` atom from the un-suffixed sibling and refuses the
+//!    pair if the rating doesn't match the suffix on the other
+//!    sibling.
+//!
+//! 2. [`preview_merge`] — describes WHAT the merge would do
+//!    (file counts, potential collisions, manifest merge plan)
+//!    without touching disk. Powers the dry-run UI.
+//!
+//! 3. [`execute_merge`] — performs the merge:
+//!    - Calls `apply_advisory_suffixes_from_tags` on the
+//!      un-suffixed source folder so its audio + sidecars get
+//!      the `[Explicit]`/`[Clean]` suffix in lockstep (reuses the
+//!      #788-extended pathway, so each audio rename brings its
+//!      `.lrc`/`.ttml`/etc. along automatically).
+//!    - Merges `.meedyadl` manifests if both folders have one
+//!      (the v1.4.6 `merge_source` dedup key — `(platform, url,
+//!      codec)` — keeps primary + companion sources both intact
+//!      rather than the companion overwriting the primary).
+//!    - Moves every remaining file via `fs_safe::safe_rename`
+//!      (auto-disambiguates `Cover.jpg` collisions to
+//!      `Cover.1.jpg` rather than overwriting).
+//!    - Deletes the source folder only if empty after moves.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::models::manifest::ManifestFile;
+use crate::utils::fs_safe;
+
+/// Recognised advisory suffixes, in the canonical form they appear
+/// in album-folder names. Order matters for [`detect_sibling_pairs`]
+/// — checked longest-first so `[Explicit]` matches before any future
+/// shorter variant.
+const RECOGNISED_SUFFIXES: &[&str] = &["[Explicit]", "[Clean]"];
+
+/// Audio file extensions checked when verifying that the un-suffixed
+/// sibling actually carries the matching advisory rating.
+const AUDIO_EXTENSIONS: &[&str] = &["m4a", "m4b", "m4p", "mp4"];
+
+/// A detected pair of sibling folders that share a base name and
+/// differ only by an advisory suffix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiblingPair {
+    /// The parent directory both siblings live in (typically an
+    /// artist folder).
+    pub parent: PathBuf,
+    /// Absolute path to the un-suffixed sibling (e.g.
+    /// `…/UNHEALTHY (Deluxe)`).
+    pub unsuffixed_path: PathBuf,
+    /// Absolute path to the suffixed sibling (e.g.
+    /// `…/UNHEALTHY (Deluxe) [Explicit]`).
+    pub suffixed_path: PathBuf,
+    /// Which advisory suffix the pair uses — `"[Explicit]"` or
+    /// `"[Clean]"`.
+    pub suffix: String,
+    /// The shared base album name (no suffix). Used purely for
+    /// human-facing display in the UI.
+    pub album_basename: String,
+}
+
+/// Dry-run summary of what [`execute_merge`] WOULD do for a pair,
+/// without touching disk. Powers the confirmation UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergePreview {
+    pub pair: SiblingPair,
+    /// Number of audio files in the un-suffixed folder.
+    pub audio_count: usize,
+    /// Number of lyric / subtitle sidecars in the un-suffixed folder.
+    pub sidecar_count: usize,
+    /// Number of other files (cover art, manifest, etc.) that would
+    /// also move across.
+    pub other_count: usize,
+    /// Filenames that already exist in the destination — these will
+    /// auto-disambiguate to `.1`, `.2`, etc. on move rather than
+    /// overwrite. Surfaces upfront so the user isn't surprised.
+    pub potential_collisions: Vec<String>,
+    /// Whether both folders carry a `.meedyadl` manifest (in which
+    /// case the merge consolidates them via
+    /// [`ManifestFile::merge_source`]).
+    pub will_merge_manifest: bool,
+}
+
+/// Result of [`execute_merge`] — counts + diagnostics for the UI to
+/// show after the action completes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeReport {
+    pub pair: SiblingPair,
+    /// Number of audio files that moved into the destination.
+    pub audio_moved: usize,
+    /// Number of sidecars that moved into the destination.
+    pub sidecars_moved: usize,
+    /// Number of other files (cover art, manifest, etc.) that moved.
+    pub other_moved: usize,
+    /// Filenames that were disambiguated by `safe_rename` (target
+    /// already existed).
+    pub collisions_disambiguated: Vec<String>,
+    /// Whether the manifest merge ran.
+    pub manifest_merged: bool,
+    /// Whether the source folder was empty after the moves and so
+    /// got removed. `false` if files were left behind for any
+    /// reason (e.g. permission errors).
+    pub source_folder_removed: bool,
+    /// Non-fatal errors that didn't halt the merge but the user
+    /// should know about.
+    pub warnings: Vec<String>,
+}
+
+// ============================================================
+// Detection
+// ============================================================
+
+/// Walk `root` at most two levels deep (typical music-library
+/// layout: `root/Artist/Album`) and return every detected sibling
+/// pair.
+///
+/// Verification — the un-suffixed sibling's `rtng` atom is checked
+/// against the other sibling's suffix. A mismatch (e.g. a folder
+/// literally named `[Explicit]` next to a folder that doesn't
+/// actually contain explicit tracks) is REJECTED, so we never merge
+/// unrelated folders that happen to have similar names.
+#[must_use]
+pub fn detect_sibling_pairs(root: &Path) -> Vec<SiblingPair> {
+    let mut pairs = Vec::new();
+    let Ok(level1) = std::fs::read_dir(root) else {
+        return pairs;
+    };
+    for artist_entry in level1.flatten() {
+        let artist_path = artist_entry.path();
+        if !artist_path.is_dir() {
+            continue;
+        }
+        pairs.extend(detect_pairs_in_parent(&artist_path));
+    }
+    // Also check `root` itself in case the user pointed the scan
+    // directly at an artist folder (album folders one level deep).
+    pairs.extend(detect_pairs_in_parent(root));
+    pairs
+}
+
+/// Find sibling pairs whose direct parent is `parent`. Pulled out
+/// of [`detect_sibling_pairs`] for clarity + so the unit tests can
+/// exercise a single parent directly.
+fn detect_pairs_in_parent(parent: &Path) -> Vec<SiblingPair> {
+    let mut pairs = Vec::new();
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return pairs;
+    };
+
+    // Index folder names so we can look up by stripped base.
+    let folders: Vec<(String, PathBuf)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let name = path.file_name()?.to_str()?.to_string();
+            Some((name, path))
+        })
+        .collect();
+
+    let folder_set: HashSet<&str> =
+        folders.iter().map(|(n, _)| n.as_str()).collect();
+
+    // Track which suffixed folders have already been claimed so the
+    // same `Album [Explicit]` isn't paired with two different
+    // un-suffixed candidates.
+    let mut seen_suffixed: HashSet<&str> = HashSet::new();
+
+    for (name, path) in &folders {
+        for &suffix in RECOGNISED_SUFFIXES {
+            let suffixed_name = format!("{name} {suffix}");
+            // Two checks:
+            //   1. The suffixed sibling exists.
+            //   2. We haven't already paired it.
+            //   3. The audio inside `path` actually carries the
+            //      matching advisory rating (defensive — refuses
+            //      false positives).
+            if !folder_set.contains(suffixed_name.as_str()) {
+                continue;
+            }
+            if seen_suffixed.contains(suffixed_name.as_str()) {
+                continue;
+            }
+            if !audio_rating_matches_suffix(path, suffix) {
+                continue;
+            }
+            let suffixed_path = parent.join(&suffixed_name);
+            pairs.push(SiblingPair {
+                parent: parent.to_path_buf(),
+                unsuffixed_path: path.clone(),
+                suffixed_path,
+                suffix: suffix.to_string(),
+                album_basename: name.clone(),
+            });
+            // Borrow-checker workaround: `seen_suffixed` keys are
+            // `&str` borrowed from `folders` — that's fine as long
+            // as the name is in the set. We use the *folders'*
+            // owned string by lookup.
+            if let Some(borrowed) =
+                folder_set.get(suffixed_name.as_str()).copied()
+            {
+                seen_suffixed.insert(borrowed);
+            }
+            break;
+        }
+    }
+
+    pairs
+}
+
+/// Read one audio file from `folder` and return `true` iff its
+/// `rtng` atom yields the same advisory suffix as `expected_suffix`.
+/// Returns `false` on any error (unreadable file, missing rtng,
+/// mismatch) so callers default to "skip this candidate pair".
+fn audio_rating_matches_suffix(folder: &Path, expected_suffix: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(folder) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if !AUDIO_EXTENSIONS
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(ext))
+        {
+            continue;
+        }
+        // Open the first audio file we find — they should all carry
+        // the same album-level rating.
+        let Ok(tag) = mp4ameta::Tag::read_from_path(&path) else {
+            continue;
+        };
+        let rating = match tag.advisory_rating() {
+            Some(mp4ameta::AdvisoryRating::Explicit) => "[Explicit]",
+            Some(mp4ameta::AdvisoryRating::Clean) => "[Clean]",
+            _ => return false,
+        };
+        return rating == expected_suffix;
+    }
+    false
+}
+
+// ============================================================
+// Preview
+// ============================================================
+
+const SIDECAR_EXTENSIONS: &[&str] = &["ttml", "lrc", "srt", "vtt", "ass"];
+
+/// Classify a file by extension into the three preview buckets.
+fn classify_file(path: &Path) -> FileBucket {
+    let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+        return FileBucket::Other;
+    };
+    let ext_lc = ext.to_ascii_lowercase();
+    if AUDIO_EXTENSIONS.iter().any(|a| a.eq_ignore_ascii_case(&ext_lc)) {
+        FileBucket::Audio
+    } else if SIDECAR_EXTENSIONS.contains(&ext_lc.as_str()) {
+        FileBucket::Sidecar
+    } else {
+        FileBucket::Other
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileBucket {
+    Audio,
+    Sidecar,
+    Other,
+}
+
+/// Build a [`MergePreview`] for a pair without touching disk.
+///
+/// `Err` only fires when the source folder is unreadable; everything
+/// else (collisions, missing manifests) is encoded in the preview
+/// fields as data rather than failure.
+pub fn preview_merge(pair: &SiblingPair) -> Result<MergePreview, String> {
+    let entries = std::fs::read_dir(&pair.unsuffixed_path).map_err(|e| {
+        format!(
+            "Failed to read source folder {}: {e}",
+            pair.unsuffixed_path.display()
+        )
+    })?;
+
+    // Snapshot destination filenames once so collision checks are
+    // O(1) per source file (and a missing dest folder is treated as
+    // empty rather than blocking the preview).
+    let dest_names: HashSet<String> =
+        std::fs::read_dir(&pair.suffixed_path)
+            .ok()
+            .map(|it| {
+                it.flatten()
+                    .filter_map(|e| {
+                        e.path()
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .map(String::from)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+    let mut audio = 0;
+    let mut sidecar = 0;
+    let mut other = 0;
+    let mut collisions = Vec::new();
+    let mut has_source_manifest = false;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if name == "manifest.meedyadl" {
+            has_source_manifest = true;
+            continue; // handled separately via manifest merge
+        }
+
+        match classify_file(&path) {
+            FileBucket::Audio => audio += 1,
+            FileBucket::Sidecar => sidecar += 1,
+            FileBucket::Other => other += 1,
+        }
+
+        if dest_names.contains(name) {
+            collisions.push(name.to_string());
+        }
+    }
+
+    let dest_has_manifest = pair.suffixed_path.join("manifest.meedyadl").exists();
+
+    Ok(MergePreview {
+        pair: pair.clone(),
+        audio_count: audio,
+        sidecar_count: sidecar,
+        other_count: other,
+        potential_collisions: collisions,
+        will_merge_manifest: has_source_manifest && dest_has_manifest,
+    })
+}
+
+// ============================================================
+// Execute
+// ============================================================
+
+/// Perform the merge.
+///
+/// Sequence:
+///   1. Apply the advisory rename to the source folder so its
+///      audio + sidecars carry the `[Explicit]` / `[Clean]` suffix
+///      before they cross folders.
+///   2. Merge `.meedyadl` manifests if both exist.
+///   3. Move every remaining file into the destination via
+///      `safe_rename` (auto-disambiguates collisions).
+///   4. Delete the source folder if empty.
+pub fn execute_merge(pair: &SiblingPair) -> Result<MergeReport, String> {
+    if !pair.unsuffixed_path.is_dir() {
+        return Err(format!(
+            "Source folder no longer exists: {}",
+            pair.unsuffixed_path.display()
+        ));
+    }
+    if !pair.suffixed_path.is_dir() {
+        return Err(format!(
+            "Destination folder no longer exists: {}",
+            pair.suffixed_path.display()
+        ));
+    }
+
+    let mut warnings = Vec::new();
+
+    // Step 1: in-place advisory rename. Reuses the public function
+    // from metadata_tag_service which also handles sidecar lockstep
+    // (#788). After this, source-folder filenames carry the
+    // `[Explicit]` / `[Clean]` suffix exactly as the merged
+    // destination expects.
+    crate::services::metadata_tag_service::apply_advisory_suffixes_from_tags(
+        pair.unsuffixed_path.to_string_lossy().as_ref(),
+    );
+
+    // Step 2: manifest merge. Both folders may carry a manifest;
+    // the v1.4.6 (platform, url, codec) dedup key keeps both
+    // sources intact.
+    let manifest_merged =
+        merge_manifests(&pair.unsuffixed_path, &pair.suffixed_path, &mut warnings);
+
+    // Step 3: walk source folder and move every remaining file.
+    let mut audio_moved = 0;
+    let mut sidecars_moved = 0;
+    let mut other_moved = 0;
+    let mut collisions = Vec::new();
+
+    let entries = std::fs::read_dir(&pair.unsuffixed_path).map_err(|e| {
+        format!(
+            "Failed to read source folder during merge: {} ({e})",
+            pair.unsuffixed_path.display()
+        )
+    })?;
+
+    for entry in entries.flatten() {
+        let src = entry.path();
+        if !src.is_file() {
+            continue;
+        }
+        let Some(name) = src.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        // Manifest was merged + removed by `merge_manifests`; skip.
+        if name == "manifest.meedyadl" {
+            continue;
+        }
+
+        let dest = pair.suffixed_path.join(name);
+        let bucket = classify_file(&src);
+
+        match fs_safe::safe_rename(&src, &dest) {
+            Ok(final_path) => {
+                let final_name = final_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(name);
+                if final_name != name {
+                    collisions.push(format!("{name} → {final_name}"));
+                }
+                match bucket {
+                    FileBucket::Audio => audio_moved += 1,
+                    FileBucket::Sidecar => sidecars_moved += 1,
+                    FileBucket::Other => other_moved += 1,
+                }
+            }
+            Err(e) => {
+                warnings.push(format!(
+                    "Failed to move {}: {e}",
+                    src.display()
+                ));
+            }
+        }
+    }
+
+    // Step 4: remove source folder if empty. If anything was left
+    // behind (warnings recorded above), leave the folder alone so
+    // the user can investigate.
+    let source_folder_removed = match std::fs::read_dir(&pair.unsuffixed_path) {
+        Ok(mut it) => {
+            if it.next().is_none() {
+                if let Err(e) = std::fs::remove_dir(&pair.unsuffixed_path) {
+                    warnings.push(format!(
+                        "Source folder is empty but removal failed: {e}"
+                    ));
+                    false
+                } else {
+                    true
+                }
+            } else {
+                warnings.push(format!(
+                    "Source folder not empty after merge — left in place: {}",
+                    pair.unsuffixed_path.display()
+                ));
+                false
+            }
+        }
+        Err(e) => {
+            warnings.push(format!(
+                "Failed to check source folder for removal: {e}"
+            ));
+            false
+        }
+    };
+
+    Ok(MergeReport {
+        pair: pair.clone(),
+        audio_moved,
+        sidecars_moved,
+        other_moved,
+        collisions_disambiguated: collisions,
+        manifest_merged,
+        source_folder_removed,
+        warnings,
+    })
+}
+
+/// Merge `source_folder/.meedyadl` into `dest_folder/.meedyadl`.
+///
+/// Behaviour matrix:
+///   - Both exist → load both, call `ManifestFile::merge_source` for
+///     each source in the source manifest, write dest back atomically,
+///     delete source.
+///   - Only source exists → move it to dest (becomes the dest
+///     manifest verbatim). Implemented via `safe_rename`.
+///   - Only dest exists → nothing to do; return false.
+///   - Neither exists → nothing to do; return false.
+///
+/// Returns `true` iff a merge actually happened (matrix row 1).
+fn merge_manifests(
+    source_folder: &Path,
+    dest_folder: &Path,
+    warnings: &mut Vec<String>,
+) -> bool {
+    let source_manifest = source_folder.join("manifest.meedyadl");
+    let dest_manifest = dest_folder.join("manifest.meedyadl");
+
+    if !source_manifest.exists() {
+        return false;
+    }
+
+    // Case: only source. Move it and we're done.
+    if !dest_manifest.exists() {
+        match fs_safe::safe_rename(&source_manifest, &dest_manifest) {
+            Ok(_) => return false, // moved, not "merged"
+            Err(e) => {
+                warnings.push(format!(
+                    "Failed to move source manifest: {e}"
+                ));
+                return false;
+            }
+        }
+    }
+
+    // Both exist — load + merge.
+    let source_data = match std::fs::read_to_string(&source_manifest) {
+        Ok(s) => s,
+        Err(e) => {
+            warnings.push(format!("Failed to read source manifest: {e}"));
+            return false;
+        }
+    };
+    let source: ManifestFile = match serde_json::from_str(&source_data) {
+        Ok(m) => m,
+        Err(e) => {
+            warnings.push(format!("Source manifest is not valid JSON: {e}"));
+            return false;
+        }
+    };
+    let dest_data = match std::fs::read_to_string(&dest_manifest) {
+        Ok(s) => s,
+        Err(e) => {
+            warnings.push(format!("Failed to read dest manifest: {e}"));
+            return false;
+        }
+    };
+    let mut dest: ManifestFile = match serde_json::from_str(&dest_data) {
+        Ok(m) => m,
+        Err(e) => {
+            warnings.push(format!("Dest manifest is not valid JSON: {e}"));
+            return false;
+        }
+    };
+
+    for src in source.sources {
+        dest.merge_source(src);
+    }
+
+    match crate::utils::atomic_write::atomic_write_json(
+        &dest_manifest,
+        &dest,
+        "merge legacy folder manifest",
+    ) {
+        Ok(()) => {
+            // Best-effort delete of source manifest now that its
+            // contents live in dest.
+            if let Err(e) = std::fs::remove_file(&source_manifest) {
+                warnings.push(format!(
+                    "Merged manifest but failed to remove source manifest: {e}"
+                ));
+            }
+            true
+        }
+        Err(e) => {
+            warnings.push(format!("Failed to write merged manifest: {e}"));
+            false
+        }
+    }
+}
+
+// ============================================================
+// Unit tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::manifest::{ManifestFile, ManifestSource};
+    use tempfile::TempDir;
+
+    /// Create a directory layout for testing without touching real
+    /// audio files. `pair_basename` becomes the album base; the test
+    /// creates both `Foo` and `Foo {suffix}` under the parent.
+    fn setup_pair(
+        parent: &Path,
+        pair_basename: &str,
+        suffix: &str,
+    ) -> (PathBuf, PathBuf) {
+        let unsuffixed = parent.join(pair_basename);
+        let suffixed = parent.join(format!("{pair_basename} {suffix}"));
+        std::fs::create_dir_all(&unsuffixed).unwrap();
+        std::fs::create_dir_all(&suffixed).unwrap();
+        (unsuffixed, suffixed)
+    }
+
+    /// Write a minimal M4A with the given advisory rating into
+    /// `folder/name`. Uses `mp4ameta` to construct a tag-only file
+    /// (no actual audio data — sufficient for the rtng-check).
+    fn write_audio_with_rating(
+        folder: &Path,
+        name: &str,
+        rating: mp4ameta::AdvisoryRating,
+    ) {
+        let path = folder.join(name);
+        // mp4ameta needs an existing MP4 container to write tags
+        // into. Build a minimal one with the `mp4` crate would be
+        // overkill — instead, write a stub file and skip the tag
+        // write; the detector reads via `Tag::read_from_path` which
+        // will fail and the helper returns false. For tests that
+        // need actual rtng reads, we'd need fixtures; here we rely
+        // on the detection unit tests using folders whose audio
+        // we explicitly mock.
+        //
+        // Alternative: use a pre-built fixture file shipped under
+        // `src-tauri/test-fixtures/`. Out of scope for the initial
+        // suite — covered indirectly by integration tests.
+        let _ = rating;
+        std::fs::write(&path, b"stub").unwrap();
+    }
+
+    #[test]
+    fn detect_finds_no_pairs_in_empty_directory() {
+        let dir = TempDir::new().unwrap();
+        let pairs = detect_sibling_pairs(dir.path());
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn detect_finds_no_pairs_when_only_unsuffixed_exists() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("Artist/Album")).unwrap();
+        let pairs = detect_sibling_pairs(dir.path());
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn detect_finds_no_pairs_when_only_suffixed_exists() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("Artist/Album [Explicit]")).unwrap();
+        let pairs = detect_sibling_pairs(dir.path());
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn detect_rejects_pair_without_matching_rtng_atom() {
+        // Two folders look like a pair by name, but the un-suffixed
+        // sibling has no readable audio with the matching advisory.
+        // The defensive `audio_rating_matches_suffix` should refuse.
+        let dir = TempDir::new().unwrap();
+        let artist = dir.path().join("Artist");
+        let (unsuffixed, _) = setup_pair(&artist, "Album", "[Explicit]");
+        // Stub file is not a valid M4A → rtng read fails → reject.
+        write_audio_with_rating(
+            &unsuffixed,
+            "01 Track.m4a",
+            mp4ameta::AdvisoryRating::Explicit,
+        );
+        let pairs = detect_sibling_pairs(dir.path());
+        assert!(
+            pairs.is_empty(),
+            "rtng mismatch / unreadable audio must REJECT the pair"
+        );
+    }
+
+    /// Even with no `rtng` data, the audio_rating_matches_suffix
+    /// helper should never panic — verifies defensive behaviour.
+    #[test]
+    fn audio_rating_matches_suffix_handles_unreadable_audio() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("01 Track.m4a"), b"not really an mp4")
+            .unwrap();
+        assert!(!audio_rating_matches_suffix(dir.path(), "[Explicit]"));
+    }
+
+    #[test]
+    fn audio_rating_matches_suffix_handles_empty_folder() {
+        let dir = TempDir::new().unwrap();
+        assert!(!audio_rating_matches_suffix(dir.path(), "[Explicit]"));
+    }
+
+    /// Preview correctly tallies file counts and surfaces collisions.
+    #[test]
+    fn preview_classifies_files_and_detects_collisions() {
+        let dir = TempDir::new().unwrap();
+        let (unsuffixed, suffixed) =
+            setup_pair(dir.path(), "Album", "[Explicit]");
+
+        std::fs::write(unsuffixed.join("01 Track [Lossless].m4a"), b"a").unwrap();
+        std::fs::write(unsuffixed.join("01 Track [Lossless].lrc"), b"b").unwrap();
+        std::fs::write(unsuffixed.join("Cover.jpg"), b"c").unwrap();
+        std::fs::write(suffixed.join("Cover.jpg"), b"already-here").unwrap();
+
+        let pair = SiblingPair {
+            parent: dir.path().to_path_buf(),
+            unsuffixed_path: unsuffixed,
+            suffixed_path: suffixed,
+            suffix: "[Explicit]".to_string(),
+            album_basename: "Album".to_string(),
+        };
+
+        let preview = preview_merge(&pair).unwrap();
+        assert_eq!(preview.audio_count, 1);
+        assert_eq!(preview.sidecar_count, 1);
+        assert_eq!(preview.other_count, 1);
+        assert_eq!(preview.potential_collisions, vec!["Cover.jpg".to_string()]);
+        assert!(!preview.will_merge_manifest);
+    }
+
+    /// Preview reports manifest merge intent when both folders have one.
+    #[test]
+    fn preview_reports_manifest_merge_when_both_present() {
+        let dir = TempDir::new().unwrap();
+        let (unsuffixed, suffixed) =
+            setup_pair(dir.path(), "Album", "[Explicit]");
+        std::fs::write(unsuffixed.join("manifest.meedyadl"), b"{}").unwrap();
+        std::fs::write(suffixed.join("manifest.meedyadl"), b"{}").unwrap();
+
+        let pair = SiblingPair {
+            parent: dir.path().to_path_buf(),
+            unsuffixed_path: unsuffixed,
+            suffixed_path: suffixed,
+            suffix: "[Explicit]".to_string(),
+            album_basename: "Album".to_string(),
+        };
+
+        let preview = preview_merge(&pair).unwrap();
+        assert!(preview.will_merge_manifest);
+    }
+
+    /// Manifest merge concatenates sources from both folders rather
+    /// than the companion replacing the primary. Stress-tests the
+    /// (platform, url, codec) dedup key from the v1.4.6 manifest
+    /// change.
+    #[test]
+    fn merge_manifests_preserves_both_codec_sources() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+
+        let primary_manifest = ManifestFile::new(ManifestSource {
+            platform: "apple-music".to_string(),
+            url: "https://music.apple.com/us/album/foo/123".to_string(),
+            storefront: None,
+            downloaded_at: "2026-01-01T00:00:00Z".to_string(),
+            codec: Some("atmos".to_string()),
+            last_modified_date: None,
+            tracks: Vec::new(),
+        });
+        let companion_manifest = ManifestFile::new(ManifestSource {
+            platform: "apple-music".to_string(),
+            url: "https://music.apple.com/us/album/foo/123".to_string(),
+            storefront: None,
+            downloaded_at: "2026-01-01T00:30:00Z".to_string(),
+            codec: Some("alac".to_string()),
+            last_modified_date: None,
+            tracks: Vec::new(),
+        });
+
+        std::fs::write(
+            src.join("manifest.meedyadl"),
+            serde_json::to_string(&companion_manifest).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dst.join("manifest.meedyadl"),
+            serde_json::to_string(&primary_manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let merged = merge_manifests(&src, &dst, &mut warnings);
+        assert!(merged, "both manifests present → merge runs");
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+
+        let merged_data: ManifestFile = serde_json::from_str(
+            &std::fs::read_to_string(dst.join("manifest.meedyadl")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            merged_data.sources.len(),
+            2,
+            "primary + companion sources both kept"
+        );
+        let codecs: HashSet<Option<String>> =
+            merged_data.sources.iter().map(|s| s.codec.clone()).collect();
+        assert!(codecs.contains(&Some("atmos".to_string())));
+        assert!(codecs.contains(&Some("alac".to_string())));
+        assert!(
+            !src.join("manifest.meedyadl").exists(),
+            "source manifest deleted after merge"
+        );
+    }
+
+    /// Source-only manifest gets MOVED to dest verbatim — no merge,
+    /// no warning.
+    #[test]
+    fn merge_manifests_moves_source_when_dest_absent() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(src.join("manifest.meedyadl"), b"{}").unwrap();
+
+        let mut warnings = Vec::new();
+        let merged = merge_manifests(&src, &dst, &mut warnings);
+        assert!(!merged, "only-source case is a move, not a merge");
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+        assert!(dst.join("manifest.meedyadl").exists());
+        assert!(!src.join("manifest.meedyadl").exists());
+    }
+
+    /// Execute correctly moves non-audio files (cover art) via
+    /// `safe_rename` collision handling — the dest's Cover.jpg
+    /// stays, the source's becomes Cover.1.jpg.
+    #[test]
+    fn execute_safe_renames_colliding_cover_art() {
+        let dir = TempDir::new().unwrap();
+        let (unsuffixed, suffixed) =
+            setup_pair(dir.path(), "Album", "[Explicit]");
+        std::fs::write(unsuffixed.join("Cover.jpg"), b"src-cover").unwrap();
+        std::fs::write(suffixed.join("Cover.jpg"), b"dst-cover").unwrap();
+
+        let pair = SiblingPair {
+            parent: dir.path().to_path_buf(),
+            unsuffixed_path: unsuffixed.clone(),
+            suffixed_path: suffixed.clone(),
+            suffix: "[Explicit]".to_string(),
+            album_basename: "Album".to_string(),
+        };
+
+        let report = execute_merge(&pair).unwrap();
+        assert_eq!(report.other_moved, 1);
+        assert_eq!(report.collisions_disambiguated.len(), 1);
+        assert!(report.source_folder_removed, "src empty after move");
+        // Original dest cover untouched.
+        assert_eq!(
+            std::fs::read(suffixed.join("Cover.jpg")).unwrap(),
+            b"dst-cover"
+        );
+        // Source's cover landed under a disambiguated name.
+        let disambiguated = std::fs::read_dir(&suffixed)
+            .unwrap()
+            .flatten()
+            .find(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("Cover")
+                    && e.file_name().to_string_lossy() != "Cover.jpg"
+            });
+        assert!(
+            disambiguated.is_some(),
+            "src Cover.jpg should have been disambiguated"
+        );
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -446,6 +446,13 @@ pub mod filename_safety;
 /// task is active.
 pub mod progress_stages;
 
+/// Legacy sibling-folder merge for pre-#528 downloads (#789).
+/// Detects `Album/` + `Album [Explicit]/` pairs left over from
+/// older versions and offers a three-phase (detect → preview →
+/// execute) merge to consolidate them into the single
+/// post-#528 layout.
+pub mod legacy_folder_merge;
+
 /// Only compiled in test mode (`cargo test`).
 #[cfg(test)]
 mod integration_tests;

--- a/src-tauri/src/utils/activity_log.rs
+++ b/src-tauri/src/utils/activity_log.rs
@@ -132,18 +132,62 @@ fn append_label(message: &str, label: Option<String>) -> String {
     }
 }
 
+/// Severity classification for activity-log entries (#793).
+///
+/// Drives the frontend's colour-coded rendering — red for `Error`,
+/// amber for `Warning`, default colour for `Info`. The serde
+/// representation is lowercase (`"info"` / `"warning"` / `"error"`)
+/// so it round-trips through JSON without ceremony.
+///
+/// `Info` is the default — existing emit sites get this implicitly
+/// via `default_severity()`, so the entire migration to severity-
+/// tagged emits is incremental: only sites that genuinely represent
+/// a warning or error need to opt in via the dedicated helpers.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum LogSeverity {
+    #[default]
+    Info,
+    Warning,
+    Error,
+}
+
+/// Helper for `#[serde(default = "default_severity")]` on
+/// [`ActivityLogEvent`] so older persisted records / older
+/// frontends that don't know about severity default cleanly to
+/// `Info`.
+fn default_severity() -> LogSeverity {
+    LogSeverity::Info
+}
+
 /// Payload for the `"activity-log"` Tauri event.
 ///
 /// Stream values:
 ///   - `"stdout"` — GAMDL subprocess stdout
 ///   - `"stderr"` — GAMDL subprocess stderr
 ///   - `"internal"` — MeedyaDL internal actions (enrichment, companions, system events)
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ActivityLogEvent {
     pub download_id: String,
     pub stream: &'static str,
     pub line: String,
     pub timestamp: String,
+    /// Severity classification (#793). `Info` by default; the
+    /// `warn` / `error` emit helpers set this explicitly. The
+    /// frontend uses it to pick the right design-token text class
+    /// (red / amber / default), staying theme-aware across light /
+    /// dark / high-contrast / colour-blind palettes.
+    #[serde(default = "default_severity")]
+    pub severity: LogSeverity,
 }
 
 /// Single-source-of-truth implementation for all four public emit
@@ -173,6 +217,7 @@ fn emit_inner(
     download_id: Option<&str>,
     message: &str,
     verbose: bool,
+    severity: LogSeverity,
 ) {
     let id = download_id.unwrap_or(SYSTEM_LOG_ID);
 
@@ -189,13 +234,18 @@ fn emit_inner(
     // Tracing-log line — `[id] msg` or `[System] msg`, with `[VERBOSE]`
     // prefix in the verbose case. Always emitted regardless of the
     // VERBOSE_LOGGING flag (the flag gates the activity-log UI, not
-    // the on-disk tracing log).
+    // the on-disk tracing log). Severity drives the tracing level
+    // so the file log groups Error/Warning/Info correctly too
+    // (#793 — same source of truth on disk as in the UI).
+    let id_prefix = if download_id.is_some() { id } else { "System" };
     if verbose {
-        log::debug!("[{id}] [VERBOSE] {enriched}");
-    } else if download_id.is_some() {
-        log::info!("[{id}] {enriched}");
+        log::debug!("[{id_prefix}] [VERBOSE] {enriched}");
     } else {
-        log::info!("[System] {enriched}");
+        match severity {
+            LogSeverity::Error => log::error!("[{id_prefix}] {enriched}"),
+            LogSeverity::Warning => log::warn!("[{id_prefix}] {enriched}"),
+            LogSeverity::Info => log::info!("[{id_prefix}] {enriched}"),
+        }
     }
 
     // Build the activity-log event payload. Verbose messages get the
@@ -211,6 +261,7 @@ fn emit_inner(
         stream: "internal",
         line,
         timestamp: chrono::Utc::now().to_rfc3339(),
+        severity,
     };
 
     // Always fan out to disk — bug-hunting sessions need the full
@@ -229,16 +280,45 @@ fn emit_inner(
 /// Used for enrichment progress, companion downloads, fallback decisions,
 /// and other per-download diagnostic messages. Also writes to the tracing
 /// file log so enrichment progress is captured on disk.
+///
+/// Defaults to `LogSeverity::Info` — use [`emit_download_warn`] /
+/// [`emit_download_error`] when the message represents an actual
+/// warning or error so the UI can colour-code it (#793).
 pub fn emit_download_log(app: &tauri::AppHandle, download_id: &str, message: &str) {
-    emit_inner(app, Some(download_id), message, false);
+    emit_inner(app, Some(download_id), message, false, LogSeverity::Info);
+}
+
+/// Emits an internal activity-log event with [`LogSeverity::Warning`]
+/// (#793). Frontend renders the line in `text-status-warning` (amber)
+/// across all themes.
+pub fn emit_download_warn(app: &tauri::AppHandle, download_id: &str, message: &str) {
+    emit_inner(app, Some(download_id), message, false, LogSeverity::Warning);
+}
+
+/// Emits an internal activity-log event with [`LogSeverity::Error`]
+/// (#793). Frontend renders the line in `text-status-error` (red)
+/// across all themes.
+pub fn emit_download_error(app: &tauri::AppHandle, download_id: &str, message: &str) {
+    emit_inner(app, Some(download_id), message, false, LogSeverity::Error);
 }
 
 /// Emits a system-level activity log event (not tied to any download).
 ///
 /// Used for queue operations, update checks, dependency installs, cookie
-/// imports, settings changes, and app lifecycle events.
+/// imports, settings changes, and app lifecycle events. See
+/// [`emit_app_warn`] / [`emit_app_error`] for severity-tagged variants.
 pub fn emit_app_log(app: &tauri::AppHandle, message: &str) {
-    emit_inner(app, None, message, false);
+    emit_inner(app, None, message, false, LogSeverity::Info);
+}
+
+/// Emits a system-level activity-log event with [`LogSeverity::Warning`].
+pub fn emit_app_warn(app: &tauri::AppHandle, message: &str) {
+    emit_inner(app, None, message, false, LogSeverity::Warning);
+}
+
+/// Emits a system-level activity-log event with [`LogSeverity::Error`].
+pub fn emit_app_error(app: &tauri::AppHandle, message: &str) {
+    emit_inner(app, None, message, false, LogSeverity::Error);
 }
 
 /// Emits a verbose download-specific activity log event.
@@ -254,7 +334,7 @@ pub fn emit_app_log(app: &tauri::AppHandle, message: &str) {
 /// The message is prefixed with `[VERBOSE]` in the activity log to
 /// distinguish it from normal messages.
 pub fn emit_verbose_download_log(app: &tauri::AppHandle, download_id: &str, message: &str) {
-    emit_inner(app, Some(download_id), message, true);
+    emit_inner(app, Some(download_id), message, true, LogSeverity::Info);
 }
 
 /// Emits a verbose system-level activity log event.
@@ -263,7 +343,7 @@ pub fn emit_verbose_download_log(app: &tauri::AppHandle, download_id: &str, mess
 /// enabled in settings. Always written to the tracing file log as
 /// `debug` AND to the on-disk activity log file.
 pub fn emit_verbose_app_log(app: &tauri::AppHandle, message: &str) {
-    emit_inner(app, None, message, true);
+    emit_inner(app, None, message, true, LogSeverity::Info);
 }
 
 /// Emits a raw subprocess-stream activity log event (Phase 3.5e).
@@ -294,11 +374,18 @@ pub fn emit_subprocess_line(
     line: String,
     show_in_ui: bool,
 ) {
+    // Severity inferred from GAMDL's structlog level prefix (#793).
+    // GAMDL 3.0+ emits lines like `[WARNING  12:10:05] [Track 2/4]
+    // Skipping…` so we can colour-code without changing the
+    // subprocess output itself. Pre-v3.0 GAMDL had no level prefix
+    // → defaults to Info.
+    let severity = infer_severity_from_subprocess_line(&line, stream);
     let event = ActivityLogEvent {
         download_id: download_id.to_string(),
         stream,
         line,
         timestamp: chrono::Utc::now().to_rfc3339(),
+        severity,
     };
     if show_in_ui {
         let _ = app.emit("activity-log", &event);
@@ -306,4 +393,160 @@ pub fn emit_subprocess_line(
     // Disk fan-out is unconditional — the on-disk activity log file
     // is the forensic record, kept regardless of UI filtering.
     write_to_disk(&event);
+}
+
+/// Infer the severity of a raw subprocess output line for the
+/// frontend's colour-coded rendering (#793).
+///
+/// Three heuristics, applied in order:
+///
+///   1. **GAMDL structlog level prefix** (`[LEVEL    HH:MM:SS]`
+///      shape) — most reliable signal on GAMDL v3.0+. Maps
+///      `ERROR` / `CRITICAL` → Error and `WARNING` → Warning.
+///      Other levels (INFO / DEBUG) fall through.
+///
+///   2. **Stream tag** — anything on `stderr` defaults to Warning
+///      (most Python tooling sends genuine warnings + errors
+///      there). Avoids over-classifying because GAMDL's own
+///      `ERROR` lines also land on stderr and the level prefix
+///      already promoted them to `Error`.
+///
+///   3. **Default** — Info.
+///
+/// Deliberately conservative: we'd rather under-colour than
+/// mis-colour a line (e.g. a sentence containing "error" inside
+/// an otherwise informational message shouldn't go red).
+#[must_use]
+fn infer_severity_from_subprocess_line(line: &str, stream: &str) -> LogSeverity {
+    // Trim a leading `\r` overwrite that the GAMDL reader may have
+    // coalesced past; structlog prefix is always after that.
+    let trimmed = line.trim_start_matches('\r').trim_start();
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        // Take everything up to the first ']' — should be
+        // `LEVEL    HH:MM:SS` — then split on whitespace and
+        // check the first token.
+        if let Some(end_idx) = rest.find(']') {
+            let inside = &rest[..end_idx];
+            let level = inside.split_whitespace().next().unwrap_or("");
+            match level {
+                "ERROR" | "CRITICAL" | "FATAL" => return LogSeverity::Error,
+                "WARNING" | "WARN" => return LogSeverity::Warning,
+                _ => {}
+            }
+        }
+    }
+
+    if stream == "stderr" {
+        return LogSeverity::Warning;
+    }
+
+    LogSeverity::Info
+}
+
+// ============================================================
+// Unit tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_default_is_info() {
+        assert_eq!(LogSeverity::default(), LogSeverity::Info);
+    }
+
+    #[test]
+    fn severity_serialises_as_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&LogSeverity::Info).unwrap(),
+            "\"info\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LogSeverity::Warning).unwrap(),
+            "\"warning\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LogSeverity::Error).unwrap(),
+            "\"error\""
+        );
+    }
+
+    #[test]
+    fn infer_severity_recognises_gamdl_error_prefix() {
+        let line = "[ERROR    12:10:05] [Track 2/4] Failed to download";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stderr"),
+            LogSeverity::Error
+        );
+    }
+
+    #[test]
+    fn infer_severity_recognises_gamdl_warning_prefix() {
+        let line = "[WARNING  12:10:05] [Track 2/4] Skipping format";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stderr"),
+            LogSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn infer_severity_info_prefix_falls_through_to_stream_default() {
+        // INFO on stderr → still Warning by stream-default rule
+        // (some tools route everything through stderr including
+        // genuine INFO; we prefer the conservative Warning over
+        // misleading Info).
+        let line = "[INFO     12:10:05] Starting download";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stderr"),
+            LogSeverity::Warning
+        );
+        // INFO on stdout → Info default.
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stdout"),
+            LogSeverity::Info
+        );
+    }
+
+    #[test]
+    fn infer_severity_unprefixed_stdout_is_info() {
+        let line = "Saved to: /Users/me/Music/Album/01 Track.m4a";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stdout"),
+            LogSeverity::Info
+        );
+    }
+
+    #[test]
+    fn infer_severity_unprefixed_stderr_is_warning() {
+        let line = "Some unexpected output";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stderr"),
+            LogSeverity::Warning
+        );
+    }
+
+    /// Conservative: a sentence MENTIONING "error" inside otherwise
+    /// informational text should NOT be promoted to Error — only
+    /// the explicit bracketed level prefix triggers a promotion.
+    #[test]
+    fn infer_severity_does_not_overreact_to_keyword_mentions() {
+        let line = "Skipping cover error retry as a no-op (#774)";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stdout"),
+            LogSeverity::Info
+        );
+    }
+
+    /// A leading `\r` overwrite (common in GAMDL progress output)
+    /// shouldn't confuse the prefix matcher.
+    #[test]
+    fn infer_severity_handles_leading_cr_overwrite() {
+        let line = "\r[ERROR    12:10:05] [Track 2/4] Boom";
+        assert_eq!(
+            infer_severity_from_subprocess_line(line, "stderr"),
+            LogSeverity::Error
+        );
+    }
 }

--- a/src/components/download/ActivityLog.tsx
+++ b/src/components/download/ActivityLog.tsx
@@ -31,6 +31,7 @@
 import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
+import type { ActivityLogEntry } from '@/types';
 import { useActivityStore } from '@/stores/activityStore';
 import { Button, Input } from '@/components/common';
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -60,6 +61,38 @@ function formatTime(iso: string): string {
  */
 function shortId(id: string): string {
   return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+/**
+ * Picks the Tailwind text-colour class for an activity-log entry.
+ *
+ * Severity wins (#793): an entry explicitly tagged
+ * `error` / `warning` always uses the matching status token —
+ * regardless of which stream produced it — so the user can scan
+ * the log for red/amber to find the actual problems.
+ *
+ * When severity is `info` or unset (the common case + the
+ * backwards-compat fallback for older Rust builds), fall through to
+ * the pre-#793 stream-based colour scheme so existing
+ * informational lines stay visually consistent:
+ *   - `internal`: accent (MeedyaDL-emitted messages)
+ *   - `stderr`: amber (subprocess stderr — most Python tooling
+ *     routes warnings there even without a level prefix)
+ *   - `stdout`: default content colour
+ *
+ * All four candidate classes (`text-status-error`,
+ * `text-status-warning`, `text-status-info`, `text-content-primary`)
+ * are defined in the project's design-token CSS and adapt across
+ * light / dark / high-contrast / colour-blind themes — so the
+ * coloured rendering stays readable in every accessibility mode
+ * without per-theme overrides here.
+ */
+function textColourForEntry(entry: ActivityLogEntry): string {
+  if (entry.severity === 'error') return 'text-status-error';
+  if (entry.severity === 'warning') return 'text-status-warning';
+  if (entry.stream === 'internal') return 'text-accent-primary';
+  if (entry.stream === 'stderr') return 'text-status-warning';
+  return 'text-content-primary';
 }
 
 /**
@@ -544,13 +577,7 @@ export function ActivityLog() {
                   }}
                   className={`group relative whitespace-pre-wrap break-words pr-6 py-0.5 px-1 font-mono text-xs leading-relaxed border-b border-border/20 ${
                     virtualRow.index % 2 === 0 ? '' : 'bg-surface-primary/30'
-                  } ${
-                    entry.stream === 'internal'
-                      ? 'text-accent-primary'
-                      : entry.stream === 'stderr'
-                        ? 'text-status-warning'
-                        : 'text-content-primary'
-                  }`}
+                  } ${textColourForEntry(entry)}`}
                 >
                   <span className="text-content-tertiary">{formatTime(entry.timestamp)} </span>
                   {entry.download_id === 'system' ? (

--- a/src/components/library/LegacyFolderMergeSection.tsx
+++ b/src/components/library/LegacyFolderMergeSection.tsx
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 MeedyaDL
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file Legacy sibling-folder merge UI (#789).
+ *
+ * Surfaces the three-phase backend pipeline (detect → preview →
+ * execute) for cleaning up pre-#528 downloads that left two
+ * sibling folders on disk (`Album/` + `Album [Explicit]/`).
+ *
+ * Lives alongside the existing Library Scan view rather than
+ * inside it so the manifest-scan path and the legacy-merge path
+ * stay independent — a user might want to run one without the
+ * other.
+ */
+
+import { useState } from 'react';
+import { FolderOpen, RefreshCw, AlertTriangle, CheckCircle2, FileWarning } from 'lucide-react';
+
+import { Button, Modal } from '@/components/common';
+import { useUiStore } from '@/stores/uiStore';
+import {
+  detectLegacyFolderPairs,
+  previewLegacyFolderMerge,
+  executeLegacyFolderMerge,
+  type SiblingPair,
+  type MergePreview,
+  type MergeReport,
+} from '@/lib/tauri-commands';
+
+/**
+ * Standalone section embedded on `LibraryScanPage`. Owns its own
+ * folder picker / scan state because the merge flow is independent
+ * of the manifest-scan flow (a user might want to clean up legacy
+ * pairs even on a library with no `.meedyadl` manifests).
+ */
+export function LegacyFolderMergeSection() {
+  const addToast = useUiStore((s) => s.addToast);
+
+  const [scanning, setScanning] = useState(false);
+  const [pairs, setPairs] = useState<SiblingPair[] | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [activePreview, setActivePreview] = useState<MergePreview | null>(null);
+  const [executing, setExecuting] = useState(false);
+  const [lastReport, setLastReport] = useState<MergeReport | null>(null);
+
+  /** Picks a folder, then asks the backend to detect sibling pairs in it. */
+  const handleScan = async () => {
+    setScanning(true);
+    setPairs(null);
+    try {
+      const { open } = await import('@tauri-apps/plugin-dialog');
+      const selected = await open({
+        multiple: false,
+        directory: true,
+        title: 'Choose your music root to scan for legacy sibling folders',
+      });
+      if (typeof selected !== 'string' || selected.length === 0) {
+        setScanning(false);
+        return; // user cancelled
+      }
+      const found = await detectLegacyFolderPairs(selected);
+      setPairs(found);
+      if (found.length === 0) {
+        addToast(
+          'No legacy sibling-folder pairs found. Your library is already in the post-#528 layout.',
+          'success'
+        );
+      } else {
+        addToast(
+          `Found ${found.length} legacy sibling-folder pair${found.length === 1 ? '' : 's'} that can be merged.`,
+          'info'
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.toLowerCase().includes('cancel')) {
+        addToast(`Scan failed: ${msg}`, 'error');
+      }
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  /** Loads the preview for a single pair and opens the confirmation modal. */
+  const handlePreview = async (pair: SiblingPair) => {
+    setPreviewing(true);
+    try {
+      const preview = await previewLegacyFolderMerge(pair);
+      setActivePreview(preview);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addToast(`Preview failed: ${msg}`, 'error');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  /** Runs the merge for the currently-previewed pair. */
+  const handleConfirmMerge = async () => {
+    if (!activePreview) return;
+    setExecuting(true);
+    try {
+      const report = await executeLegacyFolderMerge(activePreview.pair);
+      setLastReport(report);
+      // Drop the now-merged pair from the list so the user can
+      // see the remaining work without re-scanning.
+      setPairs(
+        (prev) =>
+          prev?.filter(
+            (p) =>
+              p.unsuffixed_path !== report.pair.unsuffixed_path
+          ) ?? null
+      );
+      setActivePreview(null);
+      addToast(
+        `Merged "${report.pair.album_basename}" — ${report.audio_moved} audio + ${report.sidecars_moved} sidecars moved${report.warnings.length > 0 ? ` (${report.warnings.length} warning${report.warnings.length === 1 ? '' : 's'})` : ''}`,
+        report.warnings.length > 0 ? 'warning' : 'success'
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addToast(`Merge failed: ${msg}`, 'error');
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  return (
+    <section className="mt-8 pt-6 border-t border-border-light">
+      <header className="mb-3">
+        <h2 className="text-lg font-semibold text-content-primary">
+          Legacy folder cleanup
+        </h2>
+        <p className="text-sm text-content-secondary max-w-3xl mt-1">
+          Albums downloaded before v1.4.4 with companion codecs enabled
+          (e.g. Atmos primary + ALAC companion) and the{' '}
+          <code className="font-mono text-xs">[Explicit]</code> /{' '}
+          <code className="font-mono text-xs">[Clean]</code> filename
+          suffix produced two sibling folders on disk. v1.4.4 prevents
+          this for new downloads; this tool merges any pairs left over
+          from older downloads into the single post-#528 layout.
+        </p>
+      </header>
+
+      <div className="mb-4 flex items-center gap-3">
+        <Button
+          variant="secondary"
+          onClick={handleScan}
+          disabled={scanning}
+          icon={scanning ? <RefreshCw size={16} className="animate-spin" /> : <FolderOpen size={16} />}
+        >
+          {scanning ? 'Scanning…' : 'Scan for legacy folder pairs'}
+        </Button>
+        {pairs !== null && (
+          <span className="text-sm text-content-secondary">
+            {pairs.length} pair{pairs.length === 1 ? '' : 's'} found
+          </span>
+        )}
+      </div>
+
+      {pairs !== null && pairs.length > 0 && (
+        <div className="border border-border-light rounded-md overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-surface-secondary text-content-secondary text-xs uppercase tracking-wider">
+              <tr>
+                <th className="text-left px-3 py-2">Album</th>
+                <th className="text-left px-3 py-2">Suffix</th>
+                <th className="text-left px-3 py-2">Parent folder</th>
+                <th className="text-right px-3 py-2">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pairs.map((pair) => (
+                <tr
+                  key={pair.unsuffixed_path}
+                  className="border-t border-border-light hover:bg-surface-secondary/50"
+                >
+                  <td className="px-3 py-2 font-medium text-content-primary">
+                    {pair.album_basename}
+                  </td>
+                  <td className="px-3 py-2 text-content-secondary font-mono text-xs">
+                    {pair.suffix}
+                  </td>
+                  <td className="px-3 py-2 text-content-tertiary font-mono text-xs truncate max-w-md" title={pair.parent}>
+                    {pair.parent}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handlePreview(pair)}
+                      disabled={previewing || executing}
+                    >
+                      {previewing ? 'Loading…' : 'Preview merge'}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {pairs !== null && pairs.length === 0 && lastReport === null && (
+        <p className="text-content-tertiary text-sm">
+          No legacy sibling-folder pairs found in the chosen folder.
+        </p>
+      )}
+
+      {/* Preview / confirmation modal */}
+      {activePreview && (
+        <Modal
+          open
+          onClose={() => setActivePreview(null)}
+          title={`Merge "${activePreview.pair.album_basename}"?`}
+        >
+          <div className="space-y-3 text-sm">
+            <p className="text-content-secondary">
+              Everything in{' '}
+              <span className="font-mono text-content-primary">
+                {activePreview.pair.unsuffixed_path}
+              </span>{' '}
+              will be renamed with the{' '}
+              <code className="font-mono">
+                {activePreview.pair.suffix}
+              </code>{' '}
+              advisory suffix (where appropriate), moved into{' '}
+              <span className="font-mono text-content-primary">
+                {activePreview.pair.suffixed_path}
+              </span>
+              , and the now-empty source folder removed.
+            </p>
+
+            <ul className="text-content-primary space-y-1 list-disc list-inside">
+              <li>{activePreview.audio_count} audio file{activePreview.audio_count === 1 ? '' : 's'}</li>
+              <li>{activePreview.sidecar_count} lyric / subtitle sidecar{activePreview.sidecar_count === 1 ? '' : 's'}</li>
+              <li>{activePreview.other_count} other file{activePreview.other_count === 1 ? '' : 's'} (cover art, etc.)</li>
+              {activePreview.will_merge_manifest && (
+                <li>
+                  <code className="font-mono text-xs">manifest.meedyadl</code> will be merged
+                </li>
+              )}
+            </ul>
+
+            {activePreview.potential_collisions.length > 0 && (
+              <div className="rounded-md border border-status-warning/30 bg-status-warning/10 p-3 text-status-warning text-xs">
+                <div className="flex items-center gap-2 font-medium mb-1">
+                  <FileWarning size={14} />
+                  Potential filename collisions
+                </div>
+                <p className="text-content-secondary mb-2">
+                  These files already exist in the destination. They
+                  won't be overwritten — colliders will be renamed{' '}
+                  <code className="font-mono">name.1.ext</code>,{' '}
+                  <code className="font-mono">name.2.ext</code>, etc.
+                  so nothing is lost.
+                </p>
+                <ul className="font-mono text-xs space-y-0.5">
+                  {activePreview.potential_collisions
+                    .slice(0, 5)
+                    .map((name) => (
+                      <li key={name}>{name}</li>
+                    ))}
+                  {activePreview.potential_collisions.length > 5 && (
+                    <li>
+                      …{' '}
+                      {activePreview.potential_collisions.length - 5}{' '}
+                      more
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                variant="secondary"
+                onClick={() => setActivePreview(null)}
+                disabled={executing}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleConfirmMerge}
+                disabled={executing}
+                icon={executing ? <RefreshCw size={14} className="animate-spin" /> : <CheckCircle2 size={14} />}
+              >
+                {executing ? 'Merging…' : 'Merge folders'}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+
+      {/* Post-merge report toast is already shown via addToast; we
+          surface non-fatal warnings inline so the user has a visible
+          paper trail of anything that didn't go perfectly. */}
+      {lastReport && lastReport.warnings.length > 0 && (
+        <div className="mt-4 rounded-md border border-status-warning/30 bg-status-warning/10 p-3 text-status-warning text-xs">
+          <div className="flex items-center gap-2 font-medium mb-2">
+            <AlertTriangle size={14} />
+            Merge of "{lastReport.pair.album_basename}" completed with warnings
+          </div>
+          <ul className="space-y-0.5 text-content-secondary">
+            {lastReport.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/library/LibraryScanPage.tsx
+++ b/src/components/library/LibraryScanPage.tsx
@@ -60,6 +60,7 @@ import {
 import { useUiStore } from '@/stores/uiStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { MvGapFillModal } from './MvGapFillModal';
+import { LegacyFolderMergeSection } from './LegacyFolderMergeSection';
 
 /**
  * Renders the per-row diff badge for a scanned manifest.
@@ -459,6 +460,12 @@ export function LibraryScanPage() {
         - 5e: Per-item music_video_companion override on QueueItem
         - 5f: "Re-download gaps" action button per row → enqueue with override
       */}
+
+      {/* #789: legacy sibling-folder merge for pre-#528 downloads.
+          Independent of the manifest scan above — owns its own
+          folder picker + state because the merge flow runs whether
+          or not the user has any .meedyadl manifests. */}
+      <LegacyFolderMergeSection />
     </div>
   );
 }

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -856,6 +856,83 @@ export function scanFolderForManifests(): Promise<ScannedManifest[]> {
   return invoke<ScannedManifest[]>('scan_folder_for_manifests');
 }
 
+// ============================================================
+// Legacy sibling-folder merge (#789)
+// ============================================================
+
+/** A `Foo` + `Foo [Explicit]` sibling pair detected on disk. */
+export interface SiblingPair {
+  parent: string;
+  unsuffixed_path: string;
+  suffixed_path: string;
+  suffix: string;
+  album_basename: string;
+}
+
+/** Dry-run summary returned by `previewLegacyFolderMerge`. */
+export interface MergePreview {
+  pair: SiblingPair;
+  audio_count: number;
+  sidecar_count: number;
+  other_count: number;
+  potential_collisions: string[];
+  will_merge_manifest: boolean;
+}
+
+/** Outcome of `executeLegacyFolderMerge`. */
+export interface MergeReport {
+  pair: SiblingPair;
+  audio_moved: number;
+  sidecars_moved: number;
+  other_moved: number;
+  collisions_disambiguated: string[];
+  manifest_merged: boolean;
+  source_folder_removed: boolean;
+  warnings: string[];
+}
+
+/**
+ * Walk a previously-scanned folder for sibling pairs left over
+ * from pre-#528 downloads. Defensive — only returns pairs whose
+ * un-suffixed sibling's audio carries the matching `rtng` advisory
+ * rating, so unrelated folders that happen to have similar names
+ * are never offered for merge.
+ *
+ * Rust handler: `detect_legacy_folder_pairs()` in `gamdl.rs`.
+ */
+export function detectLegacyFolderPairs(
+  folderPath: string
+): Promise<SiblingPair[]> {
+  return invoke<SiblingPair[]>('detect_legacy_folder_pairs', { folderPath });
+}
+
+/**
+ * Dry-run preview of what `executeLegacyFolderMerge` would do for
+ * `pair`. Returns file counts + potential collisions WITHOUT
+ * touching disk; powers the confirmation UI.
+ *
+ * Rust handler: `preview_legacy_folder_merge()` in `gamdl.rs`.
+ */
+export function previewLegacyFolderMerge(
+  pair: SiblingPair
+): Promise<MergePreview> {
+  return invoke<MergePreview>('preview_legacy_folder_merge', { pair });
+}
+
+/**
+ * Perform the merge. Renames audio + sidecars in the source folder
+ * to add the advisory suffix, moves all files into the suffixed
+ * sibling (auto-disambiguates collisions), merges `.meedyadl`
+ * manifests, and removes the source folder if empty.
+ *
+ * Rust handler: `execute_legacy_folder_merge()` in `gamdl.rs`.
+ */
+export function executeLegacyFolderMerge(
+  pair: SiblingPair
+): Promise<MergeReport> {
+  return invoke<MergeReport>('execute_legacy_folder_merge', { pair });
+}
+
 /** Result of scanning a folder for manifest files (#456). */
 export interface ScannedManifest {
   /** Path to the manifest file on disk */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1313,6 +1313,20 @@ export interface GamdlProgress {
  * @see ActivityLog component for the live log viewer
  * @see activityStore for the Zustand store that accumulates entries
  */
+/**
+ * Severity classification for an activity-log entry (#793).
+ *
+ * Drives the per-entry text colour in `ActivityLog.tsx`:
+ *   - `info` — default text colour (no override)
+ *   - `warning` — `text-status-warning` (amber/yellow), theme-aware
+ *   - `error` — `text-status-error` (red), theme-aware
+ *
+ * Optional in the wire format so older Rust builds / persisted
+ * records default cleanly to `info` (deserialised via
+ * `#[serde(default)]` on the Rust side).
+ */
+export type LogSeverity = 'info' | 'warning' | 'error';
+
 export interface ActivityLogEntry {
   /** Unique download ID this line belongs to, or `"system"` for app-wide events */
   download_id: string;
@@ -1323,6 +1337,13 @@ export interface ActivityLogEntry {
   line: string;
   /** ISO 8601 timestamp when the line was captured */
   timestamp: string;
+  /**
+   * Severity classification (#793). Defaults to `'info'` if the
+   * Rust backend didn't include the field (older builds /
+   * persisted records). The frontend coerces missing → `'info'`
+   * before rendering.
+   */
+  severity?: LogSeverity;
   /** Auto-incrementing ID assigned by the activity store for stable React keys.
    * Not present in the Rust-emitted payload — assigned on ingestion. */
   _id?: number;


### PR DESCRIPTION
## Summary

Two user-facing improvements bundled for **v1.4.6**:

### 1. Legacy sibling-folder merge (#789)
For users with pre-#528 downloads on disk, the **Library** page now has an opt-in **Merge Legacy Folders** tool that reconciles sibling album folders (e.g. `Album` + `Album [Explicit]`) into a single canonical folder, with collision-safe file moves and automatic `.meedyadl` manifest merging.

- Three-phase API (`detect` → `preview` → `execute`) — no destructive action without explicit confirmation.
- Defensive verification: each pair's `[Explicit]` / `[Clean]` suffix is cross-checked against the actual `rtng` atom in the audio files. Mismatches are rejected to avoid mis-merging unrelated folders that happen to share a name pattern.
- `.meedyadl` manifest merge dedup key bumped from `(platform, url)` to `(platform, url, codec)` so a folder that contains both ALAC and Atmos downloads of the same album records both source entries instead of clobbering one.
- Collision-safe file moves via `fs_safe::safe_rename` with auto-disambiguation (`Cover.jpg` + `Cover.jpg` → `Cover.jpg` + `Cover (1).jpg`).
- 11 unit tests covering detection, classification, manifest merge, advisory verification, and collision handling.

### 2. Colour-coded Activity Log (#793)
Activity Log entries now render in theme-aware colours that reflect their severity — **errors in red, warnings in amber**, info in the default content colour.

- Uses MeedyaDL's existing design tokens (`text-status-error` / `text-status-warning` / `text-content-primary`), so the colour mapping adapts to light, dark, high-contrast, and colour-blind themes without any per-theme overrides.
- New `LogSeverity` enum (`info` / `warning` / `error`) added to `ActivityLogEvent` as an optional field, serialised lowercase. Existing emit sites keep working unchanged (default: `Info`).
- Subprocess output gets severity inferred from GAMDL's structlog prefix (`[WARNING  HH:MM:SS]`, `[ERROR    HH:MM:SS]`, `[CRITICAL …]`). Stderr without a prefix defaults to Warning; stdout defaults to Info.
- Four new emit helpers (`emit_download_warn`, `emit_download_error`, `emit_app_warn`, `emit_app_error`) let high-impact failure sites opt in. Five sites migrated: filesystem errors, terminal download failures (both Err and success-path), and music-video lookup warnings.
- 9 new unit tests cover severity serialisation, default behaviour, GAMDL prefix detection (WARNING / ERROR / CRITICAL / INFO), and the conservative "no false positives from keyword mentions" guarantee.
- Exported activity logs remain plain text. A future HTML-with-CSS export is straightforward to add now that severity is on the event struct.

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --lib` — 201 download_queue tests, 9 activity_log severity tests, 11 legacy_folder_merge tests, 7 manifest tests, 3 activity_log_writer tests — all pass
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- --run` — 482 frontend tests pass
- [ ] Manual: open Library page → Merge Legacy Folders → pick a folder with mixed `[Explicit]` siblings → verify preview matches expectation → execute → confirm files moved and manifest merged
- [ ] Manual: trigger a download failure (e.g. invalid URL) → confirm Activity Log entry renders in red
- [ ] Manual: trigger a GAMDL warning (e.g. fallback codec) → confirm Activity Log entry renders in amber
- [ ] Manual: switch UI theme (light/dark/high-contrast/colour-blind) → confirm severity colours remain legible in each

Closes #789
Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)