### PR TITLE
chore(ci): suppress DEP0040 punycode deprecation in CI logs (closes #797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,16 @@ jobs:
   backend:
     name: Backend (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Suppress Node's DEP0040 punycode deprecation warning emitted by
+    # `@actions/cache`'s bundled dependencies, which the Swatinem/rust-cache
+    # post step invokes. The warning is cosmetic — neither MeedyaDL nor the
+    # action's hot path call `require('punycode')` — but it clutters CI logs
+    # on every cache save. Job-level env propagates to both the main and post
+    # steps of every action in this job. Targeted (`--disable-warning=DEP0040`
+    # rather than `--no-deprecation`) so other deprecations remain visible.
+    # @see https://github.com/MWBMPartners/MeedyaDL/issues — punycode audit 2026-05-17
+    env:
+      NODE_OPTIONS: --disable-warning=DEP0040
     strategy:
       fail-fast: false
       matrix:
@@ -337,7 +347,7 @@ jobs:
       # This can save 5-15 minutes on subsequent runs by reusing compiled dependencies.
       # @see https://github.com/Swatinem/rust-cache
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: src-tauri
 

--- a/.github/workflows/dependency-report.yml
+++ b/.github/workflows/dependency-report.yml
@@ -32,6 +32,13 @@ jobs:
     name: Outdated Dependencies
     runs-on: ubuntu-latest
 
+    # Suppress Node's DEP0040 punycode deprecation warning emitted by
+    # `@actions/cache`'s bundled dependencies via the Swatinem/rust-cache
+    # post step. Targeted (`--disable-warning=DEP0040`) so other deprecations
+    # remain visible.
+    env:
+      NODE_OPTIONS: --disable-warning=DEP0040
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -88,7 +95,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: src-tauri
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,15 @@ jobs:
 
     runs-on: ${{ matrix.settings.os }}
 
+    # Suppress Node's DEP0040 punycode deprecation warning emitted by
+    # `@actions/cache`'s bundled dependencies, which the Swatinem/rust-cache
+    # post step invokes. Cosmetic only — neither MeedyaDL nor the action's
+    # hot path call `require('punycode')` — but it clutters every Build job's
+    # log. Job-level env propagates to main + post steps. Targeted
+    # (`--disable-warning=DEP0040`) so other deprecations remain visible.
+    env:
+      NODE_OPTIONS: --disable-warning=DEP0040
+
     # Linux ARM builds are experimental — allow them to fail without
     # blocking the overall release. All Tier 1 builds must succeed.
     continue-on-error: ${{ matrix.settings.cross_arch != '' }}
@@ -267,7 +276,7 @@ jobs:
       # Release builds compile all dependencies from scratch with optimizations,
       # which takes 15-30 minutes without caching. The cache saves most of this time.
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: src-tauri
 


### PR DESCRIPTION
## Summary

Every CI run currently emits a `[DEP0040] DeprecationWarning: The 'punycode' module is deprecated.` line during the "Post Cache Rust" step. The warning is cosmetic — neither MeedyaDL nor the action's hot path call `require('punycode')` — but it clutters every Build job's log and was flagged from a v1.5.0 build screenshot.

Verified our own builds emit zero deprecation warnings (`tsc`, `vite build`, `vitest run` all run cleanly under `node --trace-deprecation`).

## Fix

1. **Bump `Swatinem/rust-cache` SHA pin** from `c19371144` (v2.9.0) to `42dc69e1a` (v2.9.1) across all three workflows. v2.9.1 is a small hash-calculation bugfix; tracks the latest patched SHA per the project's commit-pin policy.

2. **Add `env: NODE_OPTIONS: --disable-warning=DEP0040`** at the job level for every job containing a `Swatinem/rust-cache` step:
   - `.github/workflows/ci.yml` — `backend` job (frontend job doesn't use rust-cache)
   - `.github/workflows/release.yml` — `publish` job (matrix builder)
   - `.github/workflows/dependency-report.yml` — `report` job

Job-level env propagates to both the action's main and post steps. Targeted (`--disable-warning=DEP0040`) rather than `--no-deprecation`, so other Node deprecations remain visible.

`--disable-warning=DEP0040` exists in Node 22.5+; GitHub-hosted runners ship Node 22+ in their action runtime since mid-2024.

## Test plan

- [x] YAML lint clean on all three workflows (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] `--disable-warning=DEP0040` flag silences `require('punycode')` warning on local Node 25.6
- [ ] CI run on this PR: verify the `(node:XXXXX) [DEP0040]` line is absent from `Post Cache Rust` step output

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)