### PR TITLE
ci(release): preserve release-please pr body across force-pushes

### DIFF
--- a/.github/release-drafts/README.md
+++ b/.github/release-drafts/README.md
@@ -1,0 +1,55 @@
+# Release notes drafts
+
+User-facing release-notes bodies, one Markdown file per planned release.
+
+## Why this exists
+
+Release-please force-pushes its release branch on every sync. Each force-push
+regenerates the PR body from raw commit subjects, wiping any manual rewrite.
+That means the GitHub Release body — which the in-app updater serves to users
+via [`release_body` in `update_checker.rs`](../../src-tauri/src/services/update_checker.rs) —
+ends up as a wall of 70-char dev shorthand instead of the four-section
+gold-standard format users actually want to read.
+
+The [`preserve-release-pr-body.yml`](../workflows/preserve-release-pr-body.yml)
+workflow runs after every "Release Please" sync and re-applies the matching
+draft file from this folder as the PR body. The draft survives every
+force-push for the lifetime of the release PR.
+
+## Convention
+
+- One file per release: `v<MAJOR>.<MINOR>.<PATCH>.md` (or `v<X.Y.Z>-<channel>.<N>.md`
+  for prereleases — e.g., `v1.7.0-rc.1.md`).
+- Filename must match the version that release-please picks up from the
+  conventional commits since the last tag.
+- Format: four-section gold-standard (What's new / What's fixed /
+  Performance / Notes). See [the v1.6.0 draft](v1.6.0.md) for the canonical
+  shape, and [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) > "MANDATORY:
+  rewrite the release-please PR body before it merges" for the writing rules.
+- The first line should be the release-please robot banner so the file is a
+  drop-in replacement for the auto-generated body:
+  ```
+  :robot: I have created a release *beep* *boop*
+  ---
+  ```
+
+## Workflow
+
+1. Write `.github/release-drafts/vX.Y.Z.md` while the release PR is open.
+2. Commit it to `main`. The next release-please sync (triggered by any push
+   to main) will force-push the release branch — and within seconds the
+   `Preserve Release-Please PR Body` workflow will re-apply your draft.
+3. Iterate on the file in the same way; each commit to main re-triggers the
+   apply step. To re-apply without waiting for release-please, dispatch the
+   `Preserve Release-Please PR Body` workflow manually.
+4. After the release ships, the draft file can be left in place (historical
+   record) or moved into a `_shipped/` subfolder — neither is required.
+
+## Manual re-apply
+
+```bash
+gh workflow run "Preserve Release-Please PR Body" --ref main
+# Optional: target a specific PR (e.g. an alpha release that doesn't follow
+# the standard `chore(main): release X.Y.Z` title pattern):
+gh workflow run "Preserve Release-Please PR Body" --ref main -f pr_number=810
+```

--- a/.github/release-drafts/v1.6.0.md
+++ b/.github/release-drafts/v1.6.0.md
@@ -1,0 +1,45 @@
+:robot: I have created a release *beep* *boop*
+---
+
+# v1.6.0 — companion-track captions, MV cover embed, MusicBrainz canonical match, licence compliance, vendor rename
+
+A consolidated bundle that closes 30+ issues across UX, observability, music-video handling, MusicBrainz matching, third-party licence compliance, and CI hygiene. Bundled with the npm-minor-patch group (12 deps, all minor/patch) merged in via #811.
+
+## What's new
+
+- **Companion progress now names the track being downloaded.** The top progress bar caption was previously stuck on `Companion: ALAC` for entire 28-track downloads — it now updates to the artist + album + track as each one starts so you can see what's happening at a glance.
+- **Live wall-clock chip + cross-day banner in the Activity Log.** The Activity Log header shows a 1Hz local clock so long-running downloads have a wall-clock reference, and a dated banner row appears between entries when the date rolls over at midnight.
+- **`{platform}` is now a first-class template chip.** The dropdowns under Settings > Download > Templates show `{platform}` (resolves to `AppleMusic`, `Spotify`, `YouTube`, …) alongside `{album}`, `{artist}`, etc., so you can sort downloads by service without hand-typing the token.
+- **Apple Music album spotlight video** is downloaded and saved as `AlbumSpotlightCover.mp4` alongside the existing `FrontCover.mp4` / `ArtistSpotlightCover.mp4`, completing the per-album / per-artist hero-video set.
+- **Music videos now embed their cover art into the MP4 and drop the sidecar** instead of leaving a stray PNG/JPEG next to the file. Embedding is verify-before-delete so the sidecar is only removed once the artwork atom is confirmed present in the container.
+- **Library Scan page is live as a sidebar nav** between Queue and History — folder-pick a download root, scan it for `manifest.meedyadl` files, get a table of artist / album / track count / on-disk file count / codec / last-download date.
+- **MeedyaDL Log Level is now exposed in the Developer Tools panel** (Konami-gated). Switching GAMDL from `INFO` to `DEBUG` no longer requires editing a config file by hand.
+- **Keyboard shortcuts help dialog** (Cmd+Shift+?) lists every shortcut with platform-aware key glyphs (⌘ on macOS, Ctrl elsewhere). New page-nav shortcuts: Cmd+L (Library), Cmd+H (History), Cmd+K (Activity).
+
+## What's fixed
+
+- **Top progress bar no longer pegs at 95% during companion downloads.** A regression earlier in the v1.6 cycle held the bar at the final-stage progress weight while updating the caption — fixed by routing per-track caption updates through a new helper that doesn't touch the progress fraction.
+- **MusicBrainz now matches Apple Music URLs by storefront-independent canonical form.** Previously a GB Apple Music URL failed to match the corresponding MusicBrainz release because MB stored the US-geographic URL. Lookup now strips the storefront and slug before searching, so any region's URL finds the right MB record.
+- **Classical-movement collision diagnostic** logs when a Classical movement title could be mistaken for the album title because of how Apple Music returns the data, making troubleshooting `classical.apple.com` filename oddities much faster.
+- **GAMDL library-URL `KeyError: 'webplayback'` errors are now classified and surfaced with actionable guidance** instead of bubbling up as opaque Python tracebacks. The error message now tells you the library URL needs `--no-wrapper` or wrapper authentication.
+- **`audioTraits` filter decisions are traced at debug level** so when a download skips a tier (e.g., no Atmos available for a particular album) you can see why in `--verbose` mode without re-running GAMDL.
+- **Defensive filename classification** rejects degenerate output paths (empty stems like `.mp4`, punctuation-only like `-.mp4`, `[Unknown]` markers, `Unknown Artist/Album/Title` sentinels) at the music-video post-download step with a clear warning instead of writing files that are hard to find later.
+- **Vendor / copyright references across the repo now read `MeedyaSuite`** instead of `MeedyaDL` for the publisher / author / copyright-holder fields. The product name (window title, installer name, `meedyadl://` URL scheme, doc body text) is unchanged — this only renames the parent-organisation references in 291 source-file copyright headers, `package.json::author`, `Cargo.toml::authors`, the `LICENSE` file, the brand kit footer, and the year-rollover script's pattern.
+
+## Performance
+
+- **In-process AppSettings cache eliminates queue-path disk reads.** A new `SettingsCache` Tauri-managed state lazy-loads `settings.json` once and serves it from an `Arc<RwLock<…>>` on every queue iteration. Removes hundreds of `read_to_string("settings.json")` calls during multi-item queue runs.
+- **Incremental Activity Log filter.** Branch A re-filters on predicate change, Branch B1 trims dropped front entries, Branch B2 only filters new tail entries. Previously the whole entry list was re-scanned on every store update; now it's O(new tail) instead of O(all).
+- **Heartbeat ticker** emits a `[System]` "still working — N min elapsed" line every 2 minutes during long-running stages (Atmos→ALAC→AC3 companions, ReplayGain analysis, large-album enrichment). Long silent gaps in the activity log are now impossible.
+
+## Notes
+
+- **New `Licences` GitHub Action runs on every PR to `main`.** Three checks: (1) every direct dep in `Cargo.toml` / `package.json` is named in `ACKNOWLEDGEMENTS.md`; (2) each direct dep's actual upstream licence string matches what `ACKNOWLEDGEMENTS.md` claims (catches upstream re-licensings between MeedyaDL releases); (3) `cargo-deny check licenses` on the full transitive tree. Run locally via `npm run check:legal`.
+- **New `THIRD_PARTY_LICENSES.md` at repo root** ships verbatim upstream MIT / BSD / Unlicense / PSF notices for every bundled external engine (GAMDL, votify, N\_m3u8DL-RE, mp4decrypt, yt-dlp, MediaInfo, FFmpeg, MP4Box, get\_iplayer, Python). Includes "Source Offers" section with the three-year written-offer policy for LGPL components (FFmpeg, MP4Box) and GPL components (planned: get\_iplayer for the BBC iPlayer milestone).
+- **GAMDL support window admits up to v3.5.2** (audited 2026-05-13). Pure music-video bug-fix release; zero MeedyaDL-facing surface change at default log level.
+- **npm dependency bumps shipped silently** in the v1.6.0 cut via #811: `@sentry/browser` 10.52.0 → 10.53.1, `i18next` 26.1.0 → 26.2.0, `lucide-react` 1.14.0 → 1.16.0, `react-i18next` 17.0.7 → 17.0.8, `@tauri-apps/cli` 2.11.1 → 2.11.2, `@typescript-eslint/{eslint-plugin,parser}` 8.59.2 → 8.59.3, `@vitejs/plugin-react` 6.0.1 → 6.0.2, `eslint` 10.3.0 → 10.4.0, `puppeteer` 24.43.0 → 24.43.1, `vite` 8.0.12 → 8.0.13, `vitest` 4.1.5 → 4.1.6. All minor/patch; full upstream-licence drift check (`npm run check:legal`) passes.
+- **Audit closed 4 issues that turned out to already be shipped** (#581, #575, #588, #766) after a thorough codebase check against the bug-report symptoms.
+
+---
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).

--- a/.github/workflows/preserve-release-pr-body.yml
+++ b/.github/workflows/preserve-release-pr-body.yml
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Preserve Release-Please PR Body
+# ================================
+#
+# Release-please force-pushes its release branch on every sync (any push to
+# main triggers a sync), which regenerates the PR body from raw commit
+# subjects and overwrites any manual rewrites. There is no upstream config
+# option to disable this — the body is part of release-please's source of
+# truth.
+#
+# This workflow restores the user-facing body after every force-push:
+#
+#   1. Trigger when "Release Please" workflow completes.
+#   2. Find the open `chore(main): release X.Y.Z` PR.
+#   3. Extract the version X.Y.Z from the title.
+#   4. Read `.github/release-drafts/vX.Y.Z.md` from main.
+#   5. If the file exists, overwrite the PR body with its contents.
+#   6. If the file is missing, leave the PR alone (a maintainer hasn't
+#      written the notes yet — they'll commit it later and the next
+#      release-please sync will retrigger this workflow).
+#
+# To use:
+#   - Before a release ships, commit `.github/release-drafts/vX.Y.Z.md` to
+#     main using the four-section gold-standard format (What's new /
+#     What's fixed / Performance / Notes). See the README in that folder.
+#   - This workflow handles the rest. The PR body will be re-applied every
+#     time release-please force-pushes the branch.
+#
+# Manual trigger via `workflow_dispatch` is also supported so the body can
+# be re-applied without waiting for the next release-please sync (useful
+# when iterating on the drafts file).
+
+name: Preserve Release-Please PR Body
+
+on:
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Override: PR number to re-apply (auto-detected if blank)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preserve:
+    runs-on: ubuntu-latest
+    # Skip if the triggering Release Please run failed — no point patching
+    # a branch state that might not be valid.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout main (for drafts)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+
+      - name: Find release-please PR + apply drafts file
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OVERRIDE_PR: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          # --- Locate the release-please PR ---
+          if [ -n "${OVERRIDE_PR:-}" ]; then
+            PR_NUM="$OVERRIDE_PR"
+            echo "Using overridden PR #${PR_NUM}"
+          else
+            PR_JSON=$(gh pr list \
+              --state open \
+              --search 'in:title "chore(main): release"' \
+              --json number,title \
+              --limit 1)
+            PR_NUM=$(echo "$PR_JSON" | jq -r '.[0].number // empty')
+            if [ -z "$PR_NUM" ]; then
+              echo "::notice::No open release-please PR found — nothing to do."
+              exit 0
+            fi
+            echo "Found release-please PR #${PR_NUM}"
+          fi
+
+          # --- Extract version from PR title ---
+          # Title shape: "chore(main): release 1.6.0" (no `v` prefix in
+          # release-please's default template).
+          TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
+          VERSION=$(echo "$TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::warning::Could not parse version from PR title: ${TITLE}"
+            exit 0
+          fi
+          echo "Detected version: v${VERSION}"
+
+          # --- Look for the drafts file (we're on main, so it must already exist here) ---
+          DRAFT=".github/release-drafts/v${VERSION}.md"
+          if [ ! -f "$DRAFT" ]; then
+            echo "::notice::${DRAFT} not found on main — leaving PR body alone."
+            echo "::notice::Write the user-facing notes there and commit to main."
+            exit 0
+          fi
+
+          # --- Apply ---
+          BYTES=$(wc -c < "$DRAFT" | tr -d ' ')
+          echo "Applying ${DRAFT} (${BYTES} bytes) to PR #${PR_NUM}"
+          gh pr edit "$PR_NUM" --body-file "$DRAFT"
+          echo "::notice::Re-applied user-facing release notes to PR #${PR_NUM} (v${VERSION})"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/preserve-release-pr-body.yml` that re-applies the user-facing PR body to release-please's open release PR after every force-push (release-please regenerates the body from raw commit subjects on every sync, wiping manual rewrites).
- Adds `.github/release-drafts/` folder with a README documenting the `vX.Y.Z.md` filename convention and the four-section gold-standard format.
- Ships `v1.6.0.md` as the first draft so v1.6.0 (currently in flight on #810) is the first release to benefit.
- Closes the recurring failure mode that caused v1.5.0 to ship with the generic `(closes #789, #793)` one-liner (see `.claude/CLAUDE.md` > **MANDATORY: rewrite the release-please PR body before it merges**).

## How it works

1. Maintainer writes `.github/release-drafts/v<version>.md` while the release PR is open.
2. Commits to main. The next release-please sync force-pushes #810, then `Preserve Release-Please PR Body` triggers on `workflow_run` completion.
3. The workflow extracts the version from the open PR title, looks for the matching drafts file on main, and `gh pr edit`s the body. Missing draft = silent no-op (maintainer hasn't written it yet).
4. Manual `workflow_dispatch` is also wired for iterating without waiting for release-please.

## Why this approach

Considered three alternatives:
- **Disable release-please body overwrite** — no upstream config option exists.
- **Post-sync workflow without a drafts file** — body lives in workflow logic, harder to iterate.
- **Manual re-apply via `gh pr edit`** — the status quo, ~30s of toil per force-push.

The drafts-file approach makes the user-facing notes a first-class repo artifact that survives infra changes.

## Test plan

- [ ] PR merges to main; `Preserve Release-Please PR Body` workflow becomes visible in Actions.
- [ ] Next time release-please force-pushes #810, the workflow triggers and re-applies `.github/release-drafts/v1.6.0.md` (verify by editing #810 body manually first, then push any commit to main, then confirm body restores).
- [ ] Manually dispatch `Preserve Release-Please PR Body` with `pr_number=810` and confirm it edits the body.
- [ ] Confirm a missing drafts file leaves the PR body alone (no failure, just a notice in the run log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)