### PR TITLE
ci(820): preserve workflow now also rewrites the published release body

### DIFF
--- a/.github/workflows/preserve-release-pr-body.yml
+++ b/.github/workflows/preserve-release-pr-body.yml
@@ -1,8 +1,8 @@
 # Copyright (c) 2026 MeedyaSuite
 # Licensed under the MIT License. See LICENSE file in the project root.
 #
-# Preserve Release-Please PR Body
-# ================================
+# Preserve Release-Please PR Body  (and the published Release body)
+# =================================================================
 #
 # Release-please force-pushes its release branch on every sync (any push to
 # main triggers a sync), which regenerates the PR body from raw commit
@@ -10,27 +10,33 @@
 # option to disable this — the body is part of release-please's source of
 # truth.
 #
-# This workflow restores the user-facing body after every force-push:
+# This workflow restores the user-facing body in two places:
 #
-#   1. Trigger when "Release Please" workflow completes.
-#   2. Find the open `chore(main): release X.Y.Z` PR.
-#   3. Extract the version X.Y.Z from the title.
-#   4. Read `.github/release-drafts/vX.Y.Z.md` from main.
-#   5. If the file exists, overwrite the PR body with its contents.
-#   6. If the file is missing, leave the PR alone (a maintainer hasn't
-#      written the notes yet — they'll commit it later and the next
-#      release-please sync will retrigger this workflow).
+#   1. `preserve_pr_body` (workflow_run trigger):
+#      Fires when the "Release Please" workflow completes. Finds the open
+#      `chore(main): release X.Y.Z` PR, extracts the version from the
+#      title, reads `.github/release-drafts/vX.Y.Z.md`, and overwrites
+#      the PR body. Idempotent — re-applies on every release-please sync.
+#
+#   2. `preserve_release_body` (release.released trigger, added in #820):
+#      Fires when a release publishes (or is flipped from prerelease to
+#      released). Reads `.github/release-drafts/v<tag>.md` from main and
+#      overwrites the live release body via `gh release edit`. This is
+#      the safety net for the race in (1): release-please's auto-merge
+#      can fire before the preserve workflow finds the PR, so the
+#      release object publishes with whatever body was in the PR at
+#      merge time (typically empty or the terse commit subjects). The
+#      post-publish job recovers from that automatically.
 #
 # To use:
 #   - Before a release ships, commit `.github/release-drafts/vX.Y.Z.md` to
 #     main using the four-section gold-standard format (What's new /
 #     What's fixed / Performance / Notes). See the README in that folder.
-#   - This workflow handles the rest. The PR body will be re-applied every
-#     time release-please force-pushes the branch.
+#   - This workflow handles the rest in both places automatically.
 #
-# Manual trigger via `workflow_dispatch` is also supported so the body can
-# be re-applied without waiting for the next release-please sync (useful
-# when iterating on the drafts file).
+# Manual trigger via `workflow_dispatch` is also supported so the PR body
+# can be re-applied without waiting for the next release-please sync
+# (useful when iterating on the drafts file).
 
 name: Preserve Release-Please PR Body
 
@@ -38,6 +44,8 @@ on:
   workflow_run:
     workflows: ["Release Please"]
     types: [completed]
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -46,15 +54,21 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # `contents: write` so the post-publish job can rewrite the live
+  # release body via `gh release edit` (release objects live under the
+  # contents scope). Read alone is enough for `actions/checkout`.
+  contents: write
   pull-requests: write
 
 jobs:
-  preserve:
+  preserve_pr_body:
+    # PR-body branch — only for workflow_run (after a Release Please run)
+    # and manual dispatch. Skipped on the `release.released` trigger,
+    # which is handled by the sister job below.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch')
+        || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
-    # Skip if the triggering Release Please run failed — no point patching
-    # a branch state that might not be valid.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout main (for drafts)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -110,3 +124,65 @@ jobs:
           echo "Applying ${DRAFT} (${BYTES} bytes) to PR #${PR_NUM}"
           gh pr edit "$PR_NUM" --body-file "$DRAFT"
           echo "::notice::Re-applied user-facing release notes to PR #${PR_NUM} (v${VERSION})"
+
+  preserve_release_body:
+    # Post-publish safety net (#820). Fires on `release.released` —
+    # which covers both first-time publish and prerelease → released
+    # flips. Reads the drafts file from main at the time the release
+    # publishes and overwrites the live release body so the user-facing
+    # notes always appear in the GitHub Releases UI and in the in-app
+    # update banner (which reads `release_body` straight from the API).
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (for drafts)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+
+      - name: Apply drafts file to published release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # Strip an optional leading `v` so v1.7.0 → 1.7.0 and 1.7.0 → 1.7.0.
+          VERSION="${TAG#v}"
+          DRAFT=".github/release-drafts/v${VERSION}.md"
+          echo "Release tag: ${TAG} (version ${VERSION})"
+          echo "Looking for: ${DRAFT}"
+
+          if [ ! -f "$DRAFT" ]; then
+            echo "::notice::${DRAFT} not found on main — leaving release body alone."
+            echo "::notice::This is expected for prereleases without a drafts file."
+            exit 0
+          fi
+
+          # Idempotency: if the live release body already starts with the
+          # drafts file's first non-empty line, treat it as already
+          # patched and skip. Stops a `prerelease → released` flip from
+          # clobbering a body that was manually rewritten in the meantime.
+          DRAFT_HEAD=$(awk 'NF{print; exit}' "$DRAFT")
+          LIVE_BODY=$(gh release view "$TAG" --json body --jq '.body' || echo "")
+          if printf '%s' "$LIVE_BODY" | grep -qF -- "$DRAFT_HEAD"; then
+            echo "::notice::Live release body already contains the drafts headline — skipping (idempotent)."
+            exit 0
+          fi
+
+          # Apply. Preserve the existing "Choose your download" footer
+          # if it's present in the live body (release.yml appends it
+          # after the per-platform builds finish).
+          FOOTER_START=$(printf '%s' "$LIVE_BODY" | awk '/^## Choose your download/{print NR; exit}')
+          {
+            cat "$DRAFT"
+            if [ -n "${FOOTER_START:-}" ]; then
+              printf '\n---\n\n'
+              printf '%s' "$LIVE_BODY" | tail -n +"$FOOTER_START"
+            fi
+          } > /tmp/rewritten-release-body.md
+
+          BYTES=$(wc -c < /tmp/rewritten-release-body.md | tr -d ' ')
+          echo "Applying rewritten body (${BYTES} bytes) to release ${TAG}"
+          gh release edit "$TAG" --notes-file /tmp/rewritten-release-body.md
+          echo "::notice::Re-applied user-facing release notes to ${TAG} from ${DRAFT}"


### PR DESCRIPTION
## Summary

v1.5.0, v1.6.0 and v1.7.0 all shipped with **blank release notes** on GitHub. Each had to be rescued post-publish via `gh release edit --notes-file`. Root cause: the existing `preserve-release-pr-body.yml` workflow (from #812) only rewrites the PR body — it doesn't patch the published release object — and it loses a timing race against release-please's auto-merge.

This PR adds a `release.released` trigger and a sister `preserve_release_body` job that re-applies `.github/release-drafts/v<tag>.md` to the live GitHub Release at publish time. Belt-and-braces: no matter who wins the PR-edit race, the published release body still gets the user-facing content.

## What changes

- New `release.released` workflow trigger on `preserve-release-pr-body.yml`.
- New `preserve_release_body` job that runs only on the `release` event.
- Existing PR-body job renamed `preserve_pr_body` and gated to skip on `release` so each event drives one job.
- `permissions.contents` bumped `read → write` (releases live under the contents scope).
- The new job:
  - Reads `.github/release-drafts/v<tag>.md` from main at publish time.
  - Skips cleanly if the drafts file is missing (expected for prereleases without a drafts file).
  - Skips idempotently if the live body already contains the drafts headline (so a `prerelease → released` flip doesn't clobber a body that was manually rewritten in the meantime).
  - Preserves the existing "Choose your download" footer that `release.yml` appends after the per-platform builds finish.
  - Applies the rewritten body via `gh release edit --notes-file`.

## Why now

v1.8.0 will publish from `feat/v1.8-bumper-bundle` (PR #819) some time after this lands. Without this patch, v1.8.0 would risk hitting the same race as the previous three releases. Shipping this as a small, focused, non-user-visible chore PR before v1.8 cuts means the v1.8.0 publish event will be covered by the new safety net.

## Verification

- ✅ YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Manual smoke-test plan after merge (no code path to unit-test):
  - [ ] Manually flip a recent prerelease to `released` via `gh release edit --prerelease=false`; verify the new job fires and re-applies the drafts file.
  - [ ] On the next real release publish, confirm the body contains the drafts headline + the "Choose your download" footer.

Closes #820
Related: #812 (the original preserve workflow), v1.5.0 / v1.6.0 / v1.7.0 (affected releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
