### PR TITLE
fix(v1.8.1): macOS startup crash (#827) + {platform} KeyError on every download (#829)

### DIFF
--- a/src-tauri/src/services/config_service.rs
+++ b/src-tauri/src/services/config_service.rs
@@ -534,6 +534,39 @@ fn sanitize_ini_value(value: &str) -> String {
     value.replace(['\n', '\r'], "")
 }
 
+/// Substitute MeedyaDL-introduced template variables before handing the
+/// template off to GAMDL.
+///
+/// GAMDL's `CustomStringFormatter` only knows about its own metadata
+/// keys (`artist`, `album`, `title`, `track`, `disc`, etc.). Any
+/// MeedyaDL-introduced placeholder must be resolved here BEFORE the
+/// template is written into GAMDL's `config.ini` or passed via CLI,
+/// otherwise GAMDL's Python `str.format(**metadata)` raises
+/// `KeyError: '<our-var>'` and the download fails.
+///
+/// Currently:
+/// - `{platform}` → `"AppleMusic"` (only supported service today; will
+///   become per-queue-item once M8 / M9 / M10 land).
+///
+/// **Why this exists (#829):** `{platform}` was added to the frontend
+/// `TEMPLATE_VARIABLES` registry in #309 (April 2026) for multi-service
+/// preparedness, but the corresponding write-time substitution was
+/// never implemented. #800 (v1.6.0 bundle) then added the `[Platform]`
+/// chip to every `TemplateBuilder` instance by default, making the
+/// broken variable highly discoverable. Any user who clicked the chip
+/// got `Error processing "...": 'platform'` on every download until
+/// they manually removed the chip from their templates.
+pub(crate) fn resolve_meedyadl_template_vars(template: &str) -> String {
+    // Short-circuit the common case (no MeedyaDL vars in the template)
+    // to avoid an unnecessary allocation. The check is cheap — if the
+    // template doesn't contain `{platform}`, return the original slice
+    // unchanged via `to_string`.
+    if !template.contains("{platform}") {
+        return template.to_string();
+    }
+    template.replace("{platform}", "AppleMusic")
+}
+
 /// Validate a user-provided path for safety (#459).
 ///
 /// Rejects paths containing traversal sequences (`..`) that could
@@ -751,22 +784,35 @@ fn ini_template_section(lines: &mut Vec<String>, settings: &AppSettings) {
     // Output path templates use Python format strings with metadata placeholders.
     // Example: "{album_artist}/{album}" -> "Taylor Swift/1989 (Taylor's Version)"
     // Ref: https://github.com/glomatico/gamdl#output-path-template
+    // Every template field below is passed through
+    // `resolve_meedyadl_template_vars` BEFORE `sanitize_ini_value` so
+    // MeedyaDL-introduced placeholders (currently just `{platform}`,
+    // #829) are resolved to concrete values that GAMDL's metadata dict
+    // actually contains. Without this, GAMDL's
+    // `CustomStringFormatter.format(**metadata)` raises
+    // `KeyError: '<our-var>'` and every download fails.
     if !settings.album_folder_template.is_empty() {
         lines.push(format!(
             "album_folder_template = {}",
-            sanitize_ini_value(&settings.album_folder_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.album_folder_template
+            ))
         ));
     }
     if !settings.compilation_folder_template.is_empty() {
         lines.push(format!(
             "compilation_folder_template = {}",
-            sanitize_ini_value(&settings.compilation_folder_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.compilation_folder_template
+            ))
         ));
     }
     if !settings.no_album_folder_template.is_empty() {
         lines.push(format!(
             "no_album_folder_template = {}",
-            sanitize_ini_value(&settings.no_album_folder_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.no_album_folder_template
+            ))
         ));
     }
     // `playlist_folder_template` is GAMDL v3.0+ only (#618). On v2.9.x the
@@ -781,31 +827,41 @@ fn ini_template_section(lines: &mut Vec<String>, settings: &AppSettings) {
     {
         lines.push(format!(
             "playlist_folder_template = {}",
-            sanitize_ini_value(&settings.playlist_folder_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.playlist_folder_template
+            ))
         ));
     }
     if !settings.single_disc_file_template.is_empty() {
         lines.push(format!(
             "single_disc_file_template = {}",
-            sanitize_ini_value(&settings.single_disc_file_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.single_disc_file_template
+            ))
         ));
     }
     if !settings.multi_disc_file_template.is_empty() {
         lines.push(format!(
             "multi_disc_file_template = {}",
-            sanitize_ini_value(&settings.multi_disc_file_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.multi_disc_file_template
+            ))
         ));
     }
     if !settings.no_album_file_template.is_empty() {
         lines.push(format!(
             "no_album_file_template = {}",
-            sanitize_ini_value(&settings.no_album_file_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.no_album_file_template
+            ))
         ));
     }
     if !settings.playlist_file_template.is_empty() {
         lines.push(format!(
             "playlist_file_template = {}",
-            sanitize_ini_value(&settings.playlist_file_template)
+            sanitize_ini_value(&resolve_meedyadl_template_vars(
+                &settings.playlist_file_template
+            ))
         ));
     }
 }
@@ -942,6 +998,56 @@ mod tests {
         fn drop(&mut self) {
             gamdl_capabilities::set_detected_version(self.previous.take());
         }
+    }
+
+    // ----------------------------------------------------------
+    // resolve_meedyadl_template_vars (#829)
+    // ----------------------------------------------------------
+
+    #[test]
+    fn platform_var_is_substituted_to_apple_music() {
+        assert_eq!(
+            resolve_meedyadl_template_vars("{platform}/{album_artist}/{album}"),
+            "AppleMusic/{album_artist}/{album}"
+        );
+    }
+
+    #[test]
+    fn platform_var_substitutes_every_occurrence() {
+        // Defensive: a user could put `{platform}` in both folder AND
+        // file templates and the result must substitute consistently.
+        assert_eq!(
+            resolve_meedyadl_template_vars("[{platform}]/{artist}/{platform}-cover"),
+            "[AppleMusic]/{artist}/AppleMusic-cover"
+        );
+    }
+
+    #[test]
+    fn templates_without_platform_pass_through_unchanged() {
+        // The short-circuit branch must not corrupt templates that
+        // don't mention `{platform}`. GAMDL's own placeholders
+        // (`{album_artist}`, `{album}`, `{track}`) survive verbatim.
+        let template = "{album_artist}/{album}/{track:02d} {title}";
+        assert_eq!(resolve_meedyadl_template_vars(template), template);
+    }
+
+    #[test]
+    fn ini_template_section_resolves_platform_var() {
+        // End-to-end: settings with `{platform}` in a folder template
+        // must produce an INI line that already has it substituted.
+        // Pre-#829, GAMDL would read the unresolved `{platform}` and
+        // crash on `KeyError: 'platform'` at first download.
+        let mut settings = default_settings();
+        settings.album_folder_template = "{platform}/{album_artist}/{album}".to_string();
+        let ini = settings_to_ini(&settings);
+        assert!(
+            ini.contains("album_folder_template = AppleMusic/{album_artist}/{album}"),
+            "expected substituted template in INI, got:\n{ini}"
+        );
+        assert!(
+            !ini.contains("album_folder_template = {platform}"),
+            "unresolved {{platform}} leaked into INI:\n{ini}"
+        );
     }
 
     // ----------------------------------------------------------

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -3059,16 +3059,33 @@ fn merge_options(overrides: Option<&GamdlOptions>, settings: &AppSettings) -> Ga
     options.cover_size = Some(settings.cover_size);
     options.overwrite = Some(settings.overwrite);
     options.language = Some(settings.language.clone());
-    options.album_folder_template = Some(settings.album_folder_template.clone());
-    options.compilation_folder_template = Some(settings.compilation_folder_template.clone());
-    options.no_album_folder_template = Some(settings.no_album_folder_template.clone());
+    // Every template field is passed through
+    // `config_service::resolve_meedyadl_template_vars` BEFORE assignment
+    // so MeedyaDL-introduced placeholders (currently `{platform}`, #829)
+    // are resolved to concrete values. Without this, GAMDL's Python
+    // `str.format(**metadata)` raises `KeyError: 'platform'` and every
+    // download fails — same path as the INI-write equivalent in
+    // `config_service::ini_template_section`. CLI-arg path matters
+    // because options can also be passed via `--album-folder-template`
+    // etc. when overriding INI defaults.
+    options.album_folder_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.album_folder_template,
+    ));
+    options.compilation_folder_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.compilation_folder_template,
+    ));
+    options.no_album_folder_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.no_album_folder_template,
+    ));
     // `playlist_folder_template` is a GAMDL v3.0+ CLI flag (#618). We can
     // safely set the field on `options` unconditionally — the CLI-emission
     // path in `GamdlOptions::to_cli_args` gates the actual `--playlist-
     // folder-template` arg behind `GamdlFeature::PlaylistFolderTemplate`,
     // so v2.9.x still gets a crash-free invocation. Setting the field on
     // every version keeps `GamdlOptions` the canonical debug dump.
-    options.playlist_folder_template = Some(settings.playlist_folder_template.clone());
+    options.playlist_folder_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.playlist_folder_template,
+    ));
     // Apply user-configurable zero-padding (#587). Padding widths are
     // derived from the user's settings; `resolve_width(None)` passes
     // `None` because `track_total` / `disc_total` aren't known at merge
@@ -3076,18 +3093,34 @@ fn merge_options(overrides: Option<&GamdlOptions>, settings: &AppSettings) -> Ga
     // pipeline. `Auto` mode falls back to pre-#587 defaults in that
     // case; fixed widths take effect immediately. See
     // `apply_padding_to_template` for the substitution rules.
+    //
+    // {platform} resolution runs FIRST, then padding rewrites
+    // `{track}` / `{disc}`. Order matters only insofar as one helper
+    // produces literal characters the other might touch — neither
+    // currently does (padding only matches `{track}` / `{disc}`;
+    // platform substitution only matches `{platform}`), so the order
+    // is purely cosmetic, but we keep `{platform}` first so the
+    // post-resolution debug dump shows the user-visible service name.
     options.single_disc_file_template = Some(apply_padding_to_template(
-        &settings.single_disc_file_template,
+        &super::config_service::resolve_meedyadl_template_vars(
+            &settings.single_disc_file_template,
+        ),
         settings.track_number_padding.resolve_width(None),
         settings.disc_number_padding.resolve_width(None),
     ));
     options.multi_disc_file_template = Some(apply_padding_to_template(
-        &settings.multi_disc_file_template,
+        &super::config_service::resolve_meedyadl_template_vars(
+            &settings.multi_disc_file_template,
+        ),
         settings.track_number_padding.resolve_width(None),
         settings.disc_number_padding.resolve_width(None),
     ));
-    options.no_album_file_template = Some(settings.no_album_file_template.clone());
-    options.playlist_file_template = Some(settings.playlist_file_template.clone());
+    options.no_album_file_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.no_album_file_template,
+    ));
+    options.playlist_file_template = Some(super::config_service::resolve_meedyadl_template_vars(
+        &settings.playlist_file_template,
+    ));
     options.use_wrapper = Some(settings.use_wrapper);
     options.wrapper_account_url = Some(settings.wrapper_account_url.clone());
     // `wrapper_m3u8_ip` is a GAMDL v3.1+ CLI flag; only emit it when the

--- a/src-tauri/src/services/queue_watchdog.rs
+++ b/src-tauri/src/services/queue_watchdog.rs
@@ -130,12 +130,25 @@ struct ItemState {
 /// Public entry point — spawn the watchdog task. Call once from the
 /// Tauri `.setup()` closure. The task runs until the shutdown signal
 /// fires.
+///
+/// **Important (#827):** must use `tauri::async_runtime::spawn`, NOT
+/// `tokio::spawn`. On macOS the Tauri setup closure runs from the
+/// AppKit main thread inside `applicationDidFinishLaunching:` BEFORE
+/// the Tauri-managed Tokio runtime is registered as the *current*
+/// runtime, so `tokio::spawn` → `Handle::current()` panics. The panic
+/// crosses the `extern "C"` FFI boundary that tao uses to bridge into
+/// AppKit, which Rust can't unwind across, so it aborts the entire
+/// process. `tauri::async_runtime::spawn` looks up Tauri's runtime
+/// handle directly and is safe to call from any thread.
+///
+/// Same convention as `setup_queue_recovery()` in lib.rs — see the
+/// CLAUDE.md "Queue persistence" section.
 pub fn spawn_queue_watchdog(
     app: AppHandle,
     queue: Arc<Mutex<DownloadQueue>>,
     shutdown: Arc<ShutdownSignal>,
 ) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         log::info!("queue watchdog started — polling every {:?}", POLL_INTERVAL);
         let mut tracked: HashMap<String, ItemState> = HashMap::new();
         let mut ticker = tokio::time::interval(POLL_INTERVAL);


### PR DESCRIPTION
## P0 hotfix bundle for v1.8.1

Two unrelated critical bugs surfaced within an hour of v1.8.0 publishing. Bundled into a single hotfix release so users only need one update.

Mitigation already in place: **v1.8.0 + v1.7.0 are now \`isPrerelease=true\`** (v1.7.0 ALSO has bug #829), \`Latest\` points at **v1.6.0**, both release bodies carry a **Known Issues** banner explaining the workaround. v1.6.0 left as Stable because it has the same #829 chip but is the most-recent build that auto-update users had a clean upgrade path TO before the breakage cascade started.

## Fix 1 — #827: macOS startup crash

\`services/queue_watchdog.rs:138\` (new in v1.8.0 via #818) called \`tokio::spawn\` from the Tauri setup closure. On macOS that closure runs on the AppKit main thread BEFORE the Tauri-managed Tokio runtime is registered as the *current* runtime, so \`tokio::spawn → Handle::current()\` panicked. Panic crossed the \`extern \"C\"\` FFI boundary tao uses for AppKit, couldn't unwind, aborted the process.

\`\`\`diff
- tokio::spawn(async move {
+ tauri::async_runtime::spawn(async move {
\`\`\`

CLAUDE.md \"Queue persistence\" section already documented this exact failure mode for \`setup_queue_recovery()\`. The new code in #818 didn't follow the convention. Added a doc-comment block so the next contributor sees it without having to re-derive it.

## Fix 2 — #829: \`{platform}\` template variable KeyError on every download

Commit \`eff38a4\` (#309, April 2026) added \`{platform}\` to the frontend \`TEMPLATE_VARIABLES\` registry. **It never added any backend substitution logic.** Commit \`bc537e2\` (#800, v1.6.0 bundle) added the \`[Platform]\` chip to every \`TemplateBuilder\` instance by default — making the broken variable mass-discoverable.

Templates with \`{platform}\` were written verbatim to GAMDL's \`config.ini\` and passed via \`--*-template\` CLI args. GAMDL's Python \`str.format(**metadata)\` raised \`KeyError: 'platform'\` because no \`platform\` key exists in its metadata dict.

User's traceback (v1.7.0, today):
\`\`\`
return kwargs[key]
              ~~~~~~^^^^^
KeyError: 'platform'
\`\`\`

**Fix:** new \`config_service::resolve_meedyadl_template_vars()\` helper substitutes \`{platform}\` → \`\"AppleMusic\"\` (only supported service today; becomes per-queue-item once M8/M9/M10 land). Wired into BOTH \`ini_template_section\` (config.ini path) and \`merge_options\` (CLI-arg path) so every handoff to GAMDL carries resolved values. Helper short-circuits on the common no-\`{platform}\` case for zero-cost on most templates.

## Verification

- ✅ \`cargo check --lib\` clean.
- ✅ \`cargo clippy --lib --no-deps -- -D warnings\` clean.
- ✅ \`cargo test --lib queue_watchdog\` — 4/4 pass (#827 fix doesn't break existing watchdog tests).
- ✅ \`cargo test --lib config_service::tests::platform_var\` — 2/2 pass (new tests).
- ✅ \`cargo test --lib config_service::tests::templates_without_platform_pass_through_unchanged\` — passes (short-circuit branch correctness).
- ✅ \`cargo test --lib config_service::tests::ini_template_section_resolves_platform_var\` — passes (end-to-end INI write).
- ⏳ Manual macOS release-build smoke test after merge — cold-launch v1.8.1 on macOS 26.5, verify watchdog logs \`queue watchdog started\` without crash; queue a URL with \`{platform}\` in templates, verify download succeeds.

## Release plan

1. Merge this PR.
2. release-please opens v1.8.1 PR; commit \`.github/release-drafts/v1.8.1.md\` to main + rewrite the PR body with user-facing notes (one bullet per fix).
3. Merge release-please PR → tag v1.8.1 → release.yml builds 6 platforms.
4. **Manual macOS test on the v1.8.1 build BEFORE flipping isPrerelease=false.** v1.8.0 burned the trust; v1.8.1 must be hand-verified on a real macOS install before promotion.

Closes #827
Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)