### PR TITLE
feat(v1.9): native-toast diagnostics, bulk retry, restart prompt, false-complete fix, 95% peg fix, codec labels, integrity scan (7 closed, 1 partial)

### DIFF
--- a/src-tauri/src/commands/gamdl.rs
+++ b/src-tauri/src/commands/gamdl.rs
@@ -1147,6 +1147,198 @@ pub async fn retry_download(
     }
 }
 
+/// Bulk re-queue every failed download in one IPC round-trip (#835).
+///
+/// The pre-#835 "Retry All Failed" flow called `retry_download` once
+/// per item from the frontend. Each call acquired the queue mutex 3
+/// times, peeked the smart-retry planner (manifest file I/O), removed
+/// history entries (history.json I/O), persisted the queue to disk
+/// (queue.json I/O), emitted a `download-queued` event, and kicked
+/// `process_queue` (which acquires the mutex again). With 29 failed
+/// items that's ~90 mutex acquisitions, 29 queue.json writes, 29
+/// history-rewrite passes, and 29 process_queue invocations — most
+/// of which were redundant because the queue worker only needs to
+/// see the new state ONCE.
+///
+/// Result: user reported "Retry All" was unresponsive for several
+/// minutes on a 29-item batch.
+///
+/// This handler does the same per-item work (smart-retry peek,
+/// history cleanup, state transition) but **batches the persist /
+/// process_queue / event handling**:
+///   - Settings loaded once.
+///   - Smart-retry peek per item under a single read-lock window.
+///   - State transitions under a single write-lock window.
+///   - History entries removed once at the end.
+///   - Queue persisted to disk once.
+///   - `download-queued` events fired per-item so the frontend can
+///     re-render each row, plus a single `queue-bulk-retried` event
+///     with the full id list for UIs that want a batch hook.
+///   - `process_queue` called once.
+///
+/// Items that can't be retried (smart-retry says "all tracks already
+/// on disk", or item isn't in `Error` state any more) are reported
+/// individually in the returned `BulkRetryReport` so the frontend
+/// can show a precise "X re-queued, Y skipped (reason)" summary.
+///
+/// **Frontend caller:** `retryFailedBulk(ids)` in `src/lib/tauri-commands.ts`.
+///
+/// # Returns
+/// `BulkRetryReport` with per-item success/failure counts and a list
+/// of skip reasons. Always `Ok(...)` at the IPC boundary — per-item
+/// errors are aggregated in the report, not propagated as IPC failures
+/// (one bad ID shouldn't abort the whole batch from the frontend's
+/// perspective).
+#[derive(Debug, serde::Serialize)]
+pub struct BulkRetrySkipped {
+    pub id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct BulkRetryReport {
+    pub requested: usize,
+    pub retried: usize,
+    pub skipped: Vec<BulkRetrySkipped>,
+}
+
+#[tauri::command]
+pub async fn retry_failed_bulk(
+    app: AppHandle,
+    queue: State<'_, QueueHandle>,
+    download_ids: Vec<String>,
+) -> Result<BulkRetryReport, String> {
+    let requested = download_ids.len();
+    log::info!("Bulk retry requested for {requested} download(s)");
+
+    if download_ids.is_empty() {
+        return Ok(BulkRetryReport {
+            requested: 0,
+            retried: 0,
+            skipped: Vec::new(),
+        });
+    }
+
+    let settings = crate::services::config_service::load_settings(&app).unwrap_or_default();
+
+    // Pre-pass: collect URLs + smart-retry peek for every requested
+    // id under a single read-lock window. Items the planner says
+    // "all tracks already on disk" are skipped here BEFORE we take
+    // the write-lock — keeps the write-lock window minimal and lets
+    // us report skips with precise reasons.
+    let mut skipped: Vec<BulkRetrySkipped> = Vec::new();
+    let mut retry_candidates: Vec<(String, Vec<String>)> = Vec::new();
+    {
+        let q = queue.lock().await;
+        let statuses: std::collections::HashMap<String, Vec<String>> = q
+            .get_status()
+            .into_iter()
+            .map(|s| (s.id, s.urls))
+            .collect();
+        for id in &download_ids {
+            let urls = match statuses.get(id) {
+                Some(urls) => urls.clone(),
+                None => {
+                    skipped.push(BulkRetrySkipped {
+                        id: id.clone(),
+                        reason: "Item not found in queue".to_string(),
+                    });
+                    continue;
+                }
+            };
+            // Smart-retry peek — same call `retry_download` makes per-item.
+            if let Some(crate::services::smart_retry_planner::PlanOutcome::AllPresent {
+                total_tracks,
+            }) = q.peek_smart_retry_outcome(id)
+            {
+                skipped.push(BulkRetrySkipped {
+                    id: id.clone(),
+                    reason: format!(
+                        "All {total_tracks} track(s) already on disk — nothing to re-fetch"
+                    ),
+                });
+                continue;
+            }
+            retry_candidates.push((id.clone(), urls));
+        }
+    }
+
+    // Single write-lock window for every state transition. Massively
+    // reduces lock contention vs the per-item handler — the worst
+    // case is N retries inside one mutex acquisition rather than
+    // 3N acquisitions interleaved with file I/O.
+    let mut retried_ids: Vec<String> = Vec::new();
+    {
+        let mut q = queue.lock().await;
+        for (id, _urls) in &retry_candidates {
+            if q.retry(id, &settings) {
+                retried_ids.push(id.clone());
+            } else {
+                skipped.push(BulkRetrySkipped {
+                    id: id.clone(),
+                    reason: "Item is not in a retryable state".to_string(),
+                });
+            }
+        }
+    }
+
+    // History cleanup batched. The per-URL pass is cheap (in-memory
+    // hash-set lookup over the URLs we want to clear) but the
+    // history.json rewrite at the end is what saves real time on
+    // big batches.
+    let all_urls: Vec<String> = retry_candidates
+        .iter()
+        .filter(|(id, _)| retried_ids.contains(id))
+        .flat_map(|(_, urls)| urls.iter().cloned())
+        .collect();
+    if !all_urls.is_empty() {
+        crate::services::history_service::remove_entries_for_urls(&app, &all_urls);
+    }
+
+    // Single disk persist. The queue's 500-ms debounce (#456) would
+    // collapse rapid per-item writes anyway, but a single explicit
+    // save here makes the latency predictable and the on-disk state
+    // unambiguous if the process crashes mid-batch.
+    let queue_handle = queue.inner().clone();
+    if !retried_ids.is_empty() {
+        download_queue::save_queue_to_disk(&app, &queue_handle).await;
+    }
+
+    // Per-item `download-queued` events so existing frontend listeners
+    // (the queue store's `onQueued` reducer) still see each row's
+    // re-queue. Plus one summary line in the activity log instead of
+    // 29 individual "Retrying download [id]" lines.
+    for id in &retried_ids {
+        let _ = app.emit("download-queued", id);
+    }
+    if !retried_ids.is_empty() {
+        emit_app_log(
+            &app,
+            &format!(
+                "Bulk retry: re-queued {} item(s){}",
+                retried_ids.len(),
+                if skipped.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({} skipped)", skipped.len())
+                }
+            ),
+        );
+    }
+
+    // One process_queue kick. The cascade will pick up every newly-
+    // Queued item naturally; no need to invoke it per-item.
+    if settings.auto_start_queue && !retried_ids.is_empty() {
+        download_queue::process_queue(app, queue_handle).await;
+    }
+
+    Ok(BulkRetryReport {
+        requested,
+        retried: retried_ids.len(),
+        skipped,
+    })
+}
+
 /// Retries a failed download with wrapper authentication disabled.
 ///
 /// **Frontend caller:** `retryDownloadWithoutWrapper(downloadId)` in `src/lib/tauri-commands.ts`

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -334,3 +334,78 @@ pub struct NotificationDiagnostics {
     /// Lets the frontend hint at OS-specific troubleshooting steps.
     pub platform: String,
 }
+
+/// Runs the output-directory integrity scan (#537 chunk B).
+///
+/// Walks the user's configured `output_path` (loaded from settings)
+/// looking for historic damage from pre-v1.6 broken builds:
+/// `-.mp4`/`-.jpg` empty-tag filenames, `[Unknown]/` folder
+/// segments, and zero-byte fixed-name covers. Returns the structured
+/// report so the Settings → Advanced → Diagnostics panel can render
+/// a per-issue list to the user.
+///
+/// User-initiated only (button in the Diagnostics panel). No
+/// startup auto-run yet — that's gated behind a feature flag in the
+/// #537 spec and lands after this MVP is proven on real user data.
+///
+/// Runs synchronously under `spawn_blocking` because the walk can
+/// take several seconds on libraries with 1000+ albums — we don't
+/// want to block Tauri's async runtime for the duration.
+///
+/// **Frontend caller:** `runIntegrityScan()` in `src/lib/tauri-commands.ts`.
+#[tauri::command]
+pub async fn run_integrity_scan(
+    app: tauri::AppHandle,
+) -> Result<crate::services::integrity_scan::IntegrityScanReport, String> {
+    let settings =
+        crate::services::config_service::load_settings(&app).unwrap_or_default();
+    let output_path = if settings.output_path.is_empty() {
+        // Empty output_path means the user is using the default
+        // (resolved per-platform at download time). Fall back to the
+        // user's Music dir so the scan still has a concrete root on
+        // a fresh install. `dirs::audio_dir` returns
+        // `~/Music` on macOS/Linux and `Music` under the user
+        // profile on Windows. If even that resolves to None (very
+        // unusual — happens on locked-down kiosk setups) we bail
+        // with an actionable error.
+        dirs::audio_dir().ok_or_else(|| {
+            "No output path configured and the OS doesn't expose a default \
+             Music directory. Set Output Path in Settings → Download → Tools \
+             and try again."
+                .to_string()
+        })?
+    } else {
+        std::path::PathBuf::from(&settings.output_path)
+    };
+
+    // `spawn_blocking` because the walk is purely synchronous file I/O
+    // and can take seconds on big libraries — blocking the runtime
+    // would freeze every other IPC for the duration.
+    let report = tokio::task::spawn_blocking(move || {
+        crate::services::integrity_scan::scan(&output_path)
+    })
+    .await
+    .map_err(|e| format!("Integrity scan task panicked: {e}"))?;
+
+    // Activity-log breadcrumb so the user has a record of when they
+    // ran the scan and what it found. The full per-issue list goes
+    // to the frontend modal; here we just summarise.
+    let degenerate = report.degenerate_name_count();
+    let zero_byte = report.zero_byte_cover_count();
+    let summary = if degenerate == 0 && zero_byte == 0 {
+        format!(
+            "Integrity scan: {} file(s) walked, no issues found.",
+            report.files_walked
+        )
+    } else {
+        format!(
+            "Integrity scan: {} file(s) walked, {} degenerate name(s), \
+             {} zero-byte cover(s). See Settings → Advanced → Diagnostics \
+             for the full list.",
+            report.files_walked, degenerate, zero_byte
+        )
+    };
+    crate::utils::activity_log::emit_app_log(&app, &summary);
+
+    Ok(report)
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -268,3 +268,69 @@ pub fn save_session_log(app: tauri::AppHandle, entries: Vec<String>) -> Result<(
     );
     Ok(())
 }
+
+/// Sends a one-off test notification through the **backend** notification
+/// pipeline (#834).
+///
+/// The "Send Test Notification" button in Settings → General used to call
+/// the JS notification plugin directly, which:
+/// 1. Tested a different code path than what production downloads use, and
+/// 2. Was unable to surface OS-level send failures because the plugin's
+///    `sendNotification()` resolves successfully even when macOS silently
+///    drops the notification (Focus mode, sandbox, etc.).
+///
+/// This IPC routes the test through the same Rust pipeline as
+/// `send_desktop_notification`, but bypasses the focus-check and throttle
+/// (the user is explicitly testing — silently no-opping defeats the
+/// purpose). Returns a structured error string the frontend can render
+/// directly into a toast so the user knows whether the failure is at the
+/// settings layer, the permission layer, or the OS layer.
+///
+/// **Frontend caller:** `testDesktopNotification()` in `src/lib/tauri-commands.ts`.
+#[tauri::command]
+pub fn test_desktop_notification(app: tauri::AppHandle) -> Result<(), String> {
+    crate::services::download_queue::test_desktop_notification(&app)
+}
+
+/// Returns a diagnostic snapshot of the desktop-notification configuration
+/// and current OS permission state (#834).
+///
+/// Used by the Settings → Advanced → Diagnostics panel so users on macOS 26+
+/// (where notifications have been silently failing) can see at a glance
+/// whether the toggle, the style, and the OS permission are all in the
+/// expected state. Pure read-only — never triggers a permission prompt.
+///
+/// **Frontend caller:** `getNotificationDiagnostics()` in `src/lib/tauri-commands.ts`.
+#[tauri::command]
+pub fn get_notification_diagnostics(
+    app: tauri::AppHandle,
+) -> NotificationDiagnostics {
+    // `load_settings` returns `Result<AppSettings, String>`; on a load
+    // failure we fall back to the safe defaults so the diagnostics
+    // panel still renders something useful (and the user can see that
+    // settings.json failed to load via the surfaced error elsewhere).
+    let settings = crate::services::config_service::load_settings(&app)
+        .unwrap_or_default();
+    NotificationDiagnostics {
+        desktop_notifications_enabled: settings.desktop_notifications,
+        notification_style: settings.notification_style,
+        platform: std::env::consts::OS.to_string(),
+        // The actual OS permission grant lives in the JS plugin layer
+        // — the frontend fills `os_permission_state` itself by calling
+        // `isPermissionGranted()` and merges it with this snapshot.
+    }
+}
+
+/// Backend half of the notification diagnostics readout (#834). The
+/// frontend tops this up with the JS-side permission state.
+#[derive(serde::Serialize)]
+pub struct NotificationDiagnostics {
+    /// Mirrors `AppSettings::desktop_notifications`.
+    pub desktop_notifications_enabled: bool,
+    /// Mirrors `AppSettings::notification_style` — one of
+    /// `in_app_only`, `native_and_in_app`, `native_only`.
+    pub notification_style: String,
+    /// Current build's target OS — `macos`, `windows`, `linux`, etc.
+    /// Lets the frontend hint at OS-specific troubleshooting steps.
+    pub platform: String,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1118,6 +1118,8 @@ pub fn run() {
             // Notification diagnostics + backend-pipeline test button (#834).
             commands::system::test_desktop_notification,
             commands::system::get_notification_diagnostics,
+            // Output-directory integrity scan (#537 chunk B).
+            commands::system::run_integrity_scan,
             // Dependency management commands (Python, GAMDL, tools)
             commands::dependencies::check_python_status,
             commands::dependencies::install_python,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1115,6 +1115,9 @@ pub fn run() {
             // Multi-service URL detection (#315)
             commands::system::detect_service,
             commands::system::save_session_log,
+            // Notification diagnostics + backend-pipeline test button (#834).
+            commands::system::test_desktop_notification,
+            commands::system::get_notification_diagnostics,
             // Dependency management commands (Python, GAMDL, tools)
             commands::dependencies::check_python_status,
             commands::dependencies::install_python,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1149,6 +1149,7 @@ pub fn run() {
             commands::gamdl::start_download,
             commands::gamdl::cancel_download,
             commands::gamdl::retry_download,
+            commands::gamdl::retry_failed_bulk,
             commands::gamdl::retry_download_without_wrapper,
             commands::gamdl::move_queue_item_to_top,
             commands::gamdl::move_queue_item_to_bottom,

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -7138,6 +7138,28 @@ pub fn process_queue(
         let shutdown_clone = shutdown_signal;
 
         tokio::spawn(async move {
+            // Snapshot the audio-file count in the configured output base
+            // BEFORE spawning GAMDL (#831). This is the primary-path twin
+            // of the Phase 3.5h companion-task snapshot. After a clean
+            // GAMDL exit we compare against this baseline; if no new audio
+            // files have landed in the output tree, the run failed
+            // silently (GAMDL exits 0 when every track is skipped due to
+            // format unavailability — "Skipping … format is not
+            // available" is a warning, not an error from GAMDL's view).
+            //
+            // Without this check, the recovery path's `find_album_directory`
+            // can pick up a previously-downloaded album directory from a
+            // prior run and treat its files as evidence this run
+            // succeeded — producing the user-visible "Complete" badge on
+            // an item where every single track was actually skipped
+            // (#831).
+            let pre_run_audio_count = download_options
+                .output_path
+                .as_deref()
+                .map(std::path::Path::new)
+                .map(count_audio_files_in_directory)
+                .unwrap_or(0);
+
             // Run the GAMDL download with real-time event forwarding.
             // This function handles subprocess spawning, output parsing,
             // and cancellation polling. See run_download_with_events() below.
@@ -7455,7 +7477,57 @@ pub fn process_queue(
                                 .and_then(|i| i.status.output_path.as_ref())
                                 .is_some();
 
-                            if !has_output_now {
+                            // #831: even if `has_output_now` is true, verify
+                            // that this run actually produced NEW audio files.
+                            // The `find_album_directory` recovery above can
+                            // pick up a previously-downloaded album folder
+                            // from an earlier run and set `output_path` to
+                            // it — making the rest of the pipeline treat
+                            // this run as a success even though zero new
+                            // tracks landed. Without this check, retrying a
+                            // failed item with the same (unavailable) codec
+                            // chain endlessly produces "Complete" badges on
+                            // items where every track was actually Skipped.
+                            //
+                            // Compare against the pre-run snapshot taken at
+                            // the top of this spawn (line ~7155). If the
+                            // count hasn't moved, treat the run as a
+                            // no-files-produced failure regardless of what
+                            // the recovery path set `output_path` to.
+                            let new_files_landed = if has_output_now {
+                                let post_run_count = download_options
+                                    .output_path
+                                    .as_deref()
+                                    .map(std::path::Path::new)
+                                    .map(count_audio_files_in_directory)
+                                    .unwrap_or(0);
+                                if post_run_count <= pre_run_audio_count {
+                                    log::info!(
+                                        "Download {dl_id}: output_path set but no new \
+                                         audio files landed (pre={pre_run_audio_count}, \
+                                         post={post_run_count}) — treating as \
+                                         no-files-produced failure (#831)"
+                                    );
+                                    // Clear the misleading output_path so the
+                                    // post-error UI doesn't open a folder that
+                                    // was actually pre-existing.
+                                    if let Some(item) = q
+                                        .items
+                                        .iter_mut()
+                                        .find(|i| i.status.id == dl_id)
+                                    {
+                                        item.status.output_path = None;
+                                        item.status.output_is_directory = false;
+                                    }
+                                    false
+                                } else {
+                                    true
+                                }
+                            } else {
+                                false
+                            };
+
+                            if !new_files_landed {
                                 // Terminal: no output, no IO recovery, no files on
                                 // disk despite codec fallback exhausted.
                                 //

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -250,13 +250,94 @@ fn send_desktop_notification(app: &AppHandle, title: &str, body: &str) {
         }
     };
 
-    // Send the OS-native notification
-    app.notification()
+    // Send the OS-native notification.
+    //
+    // Instrumentation (#834): the previous `.ok()` swallowed every
+    // failure silently, which made it impossible to tell whether
+    // notifications were being dropped at the plugin layer, the
+    // OS permission layer, or somewhere else. Now log both arms
+    // through tracing so the on-disk log (#541) captures the truth
+    // for any future bug report. The user's in-app activity log is
+    // *not* spammed — these are OS-pipeline events, not download
+    // events.
+    match app
+        .notification()
         .builder()
         .title(title)
         .body(&display_body)
         .show()
-        .ok();
+    {
+        Ok(()) => {
+            log::debug!(
+                "desktop notification sent: title={:?} body={:?}",
+                title,
+                display_body
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "desktop notification FAILED: title={:?} error={:?} \
+                 (likely OS-level: permission revoked, Focus mode, or sandbox block)",
+                title,
+                e
+            );
+        }
+    }
+}
+
+/// Sends a one-off test notification through the **real** backend
+/// pipeline so the user can self-diagnose why OS notifications are
+/// or aren't appearing.
+///
+/// Differs from `send_desktop_notification` in two ways:
+/// - Bypasses the focus check. The user is clicking "Send Test
+///   Notification" while the app is focused (by definition — they're
+///   on a Settings page); we don't want to silently no-op on them.
+/// - Bypasses the throttle. They might click the button repeatedly.
+///
+/// Otherwise hits the exact same plugin entrypoint, so a successful
+/// test means the production path will also work; a failure surfaces
+/// the actual reason via the returned `Err`.
+///
+/// Closes #834 (instrumentation half).
+pub fn test_desktop_notification(
+    app: &AppHandle,
+) -> Result<(), String> {
+    use tauri_plugin_notification::NotificationExt;
+
+    let settings = load_settings_for_queue(app);
+    if !settings.desktop_notifications {
+        return Err(
+            "Desktop Notifications toggle is off. \
+             Turn it on in Settings → General → Notifications first."
+                .to_string(),
+        );
+    }
+    if settings.notification_style == "in_app_only" {
+        return Err(
+            "Notification Style is set to 'In-app only'. \
+             Switch to 'Native + in-app' or 'Native only' to test the OS pipeline."
+                .to_string(),
+        );
+    }
+
+    app.notification()
+        .builder()
+        .title("MeedyaDL — Backend Test")
+        .body(
+            "If you can read this, the native notification pipeline is working \
+             from the Rust side. If you don't see this notification, check macOS \
+             System Settings → Notifications → MeedyaDL.",
+        )
+        .show()
+        .map_err(|e| {
+            format!(
+                "OS-level send failed: {e}. \
+                 Likely causes: macOS notification permission revoked, \
+                 Focus / Do Not Disturb mode enabled, or the app bundle \
+                 missing from System Settings → Notifications."
+            )
+        })
 }
 
 /// Executes the configured after-queue action when the queue becomes idle.

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -4153,13 +4153,39 @@ async fn update_companion_label_from_line(
     // stage's weight — `Finalising` is 0.95, which pegged the bar
     // at 95% for the entire companion run regardless of actual
     // within-companion progress.
-    //
-    // The bar value continues to be driven by the resolution chain
-    // from #790 (per-file `[download] X%` from companion GAMDL →
-    // enrichment stage weights → terminal-state values), so the
-    // visible bar advances naturally as each companion track
-    // downloads.
     set_label_only(app, queue, dl_id, &caption);
+
+    // #836: drive the per-item bar between 95% and ~99% so the
+    // companion phase no longer appears frozen for 30+ minutes on
+    // big multi-tier runs. The pre-fix design assumed the
+    // companion subprocess's `[download] X%` events would advance
+    // the bar (#808 comment), but in practice each companion track
+    // is its own GAMDL run that resets `[download]` to 0% on each
+    // track start. The visible bar therefore oscillated within a
+    // single track and never advanced across tracks — users saw
+    // "95%" for the entire companion phase.
+    //
+    // Strategy: advance the bar by `(track_number / track_total) *
+    // 0.04` within the 0.95..0.99 reserve, so each track-start
+    // tick produces a small but visible forward movement. The
+    // reserve's last 1% (0.99..1.00) is left for the post-companion
+    // advisory pass and `set_complete`.
+    //
+    // This is per-TIER progress — multi-tier runs (e.g. Custom
+    // mode with [ac3, alac, atmos]) will replay 0.95 → 0.99 once
+    // per tier rather than spreading the 4% slice across all
+    // tiers. Sufficient to remove the "stuck" appearance; precise
+    // multi-tier mapping is a follow-up if users want it.
+    if let (Some(n), Some(t)) = (track_number, track_total) {
+        if t > 0 {
+            // Cap at 0.99 so the bar can't accidentally hit 1.0
+            // before the advisory pass / set_complete fires.
+            let fraction = (n as f32 / t as f32).clamp(0.0, 1.0);
+            let bar_value = 0.95 + fraction * 0.04;
+            let mut q = queue.lock().await;
+            q.set_processing_progress(dl_id, bar_value);
+        }
+    }
 }
 
 async fn emit_companion_stream_line(
@@ -5399,11 +5425,28 @@ pub(crate) fn start_heartbeat_ticker(
                     continue;
                 };
 
+                // #836: dedup the stage prefix. Companion captions
+                // already start with `"Companion: "` (set via
+                // `set_label_only(…, &caption)` in
+                // `update_companion_label_from_line`, where the caption
+                // is `"Companion: downloading atmos (tier 2)…"` and the
+                // like). The heartbeat formatter would then produce
+                // `"⏳ Still working — Companion: Companion: downloading
+                // atmos…"` — the user's 2026-05-18 / v1.8.1 screenshot
+                // shows the duplication verbatim. Strip the leading
+                // `"{stage_kind}: "` from `label` if it's already
+                // there, so the format string's own prefix is the
+                // only one users see.
+                let stage_prefix = format!("{stage_kind}: ");
+                let display_label = label
+                    .strip_prefix(stage_prefix.as_str())
+                    .unwrap_or(label.as_str());
+
                 let elapsed = format_heartbeat_elapsed(start.elapsed());
                 emit_download_log(
                     &app,
                     &dl_id,
-                    &format!("⏳ Still working — {stage_kind}: {label} — {elapsed} elapsed"),
+                    &format!("⏳ Still working — {stage_kind}: {display_label} — {elapsed} elapsed"),
                 );
             }
         }

--- a/src-tauri/src/services/integrity_scan.rs
+++ b/src-tauri/src/services/integrity_scan.rs
@@ -1,0 +1,362 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+//! Output-directory integrity scan (#537 chunk B).
+//!
+//! Walks the user's configured `output_path` looking for **historic
+//! damage from pre-v1.6 broken builds**:
+//!
+//! 1. Degenerate filenames produced by the empty-tag class of bugs that
+//!    plagued v1.x.x music-video downloads. The Tier 4 safety net
+//!    (#531) prevents these from being CREATED in current builds, but
+//!    users who downloaded music videos on a broken release have
+//!    already-corrupt files sitting on disk that they may never
+//!    notice unless prompted.
+//!
+//!    Signatures the scan detects:
+//!    - Files literally named `-.mp4` / `-.jpg` (artist + title both
+//!      collapsed to empty strings → MV pipeline produced `-.<ext>`).
+//!    - Paths containing a `[Unknown]/` directory segment (album-tag
+//!      missing → folder template resolved to `[Unknown]`).
+//!    - Paths whose parent directory ends with `Unknown Album` and
+//!      whose filename starts with `-.` (older v1.5.x shape after a
+//!      partial fix landed).
+//!
+//! 2. **Zero-byte fixed-name cover files** at the known animated-artwork
+//!    paths (`FrontCover.mp4`, `PortraitCover.mp4`,
+//!    `ArtistSpotlightCover.mp4`). These appear when the HLS download
+//!    fails part-way through but the empty file was still committed to
+//!    disk — typical symptom: the file exists but Finder/Explorer
+//!    refuses to preview it. Pre-#447 builds were also vulnerable to
+//!    "silent idempotency" where a corrupt cover was preserved on
+//!    re-runs because the target path already existed.
+//!
+//! ## Not in scope (this commit)
+//!
+//! - **Quarantine action.** The full spec calls for moving detected
+//!   files to a `_quarantine_<DATE>/` sibling directory so users can
+//!   review and recover. This first cut only DETECTS and REPORTS —
+//!   the user can decide what to do with the list. Quarantine UI lands
+//!   as a follow-up (#537 chunk B.2).
+//! - **Auto-run on startup.** The issue's spec calls for running the
+//!   scan once per launch behind a feature flag. This commit makes
+//!   it user-initiated only (button in Settings → Advanced →
+//!   Diagnostics). Once the scan logic is proven on real user data,
+//!   we'll wire the startup trigger behind the flag.
+//! - **ffprobe-based zero-duration check** for covers that aren't
+//!   zero-byte but are corrupt in some other way (e.g. truncated mid-
+//!   file). A pure size check catches the most common failure mode
+//!   without taking an external-binary dependency on every scan.
+//!
+//! ## Performance
+//!
+//! Single recursive walk with a hard depth limit (`MAX_SCAN_DEPTH`).
+//! On a typical 10-album library the scan completes in <100ms. Larger
+//! libraries (1000+ albums) take 1-5 seconds — still well inside the
+//! "click a button, see a result" UX threshold.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// Maximum directory depth the scan recurses. Matches the limit used
+/// in [`crate::utils::fs_walk::walk_dir_depth`] callsites for output-
+/// directory walks elsewhere. Going deeper than 10 levels under the
+/// configured output_path would mean a pathologically nested user
+/// layout — almost certainly not a legitimate MeedyaDL-produced
+/// directory tree.
+const MAX_SCAN_DEPTH: u32 = 10;
+
+/// Filenames at which the animated-artwork pipeline writes its three
+/// known cover variants (`animated_artwork_service.rs`). Each is a
+/// fixed name (not template-driven), so the scan can do an exact
+/// match. Zero-byte files at these paths are almost certainly stale
+/// from an interrupted HLS download.
+const FIXED_COVER_NAMES: &[&str] = &[
+    "FrontCover.mp4",
+    "PortraitCover.mp4",
+    "ArtistSpotlightCover.mp4",
+];
+
+/// A single integrity issue the scan found. The `kind` discriminates
+/// between the two detection classes; the `path` is the absolute
+/// file path on disk so the UI can surface it directly to the user
+/// (and a future quarantine action can act on it without re-walking).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IntegrityIssue {
+    /// Filename or path matches one of the degenerate-name signatures
+    /// from the empty-tag MV pipeline bugs.
+    DegenerateName {
+        path: PathBuf,
+        /// Which signature triggered the match — useful for the UI
+        /// to group findings and for future support requests.
+        signature: &'static str,
+    },
+    /// File at a known fixed-cover path is zero bytes.
+    ZeroByteCover { path: PathBuf },
+}
+
+/// Report returned by [`scan`]. Counts + lists of paths. The two
+/// detection classes are reported separately so the UI can render
+/// them in distinct sections (different severity, different
+/// recommended action).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct IntegrityScanReport {
+    /// Total number of files walked (informational; helps users
+    /// confirm the scan actually saw their library).
+    pub files_walked: usize,
+    /// Issues found.
+    pub issues: Vec<IntegrityIssue>,
+    /// Absolute path the scan started from. Echoed back so the UI
+    /// can show "Scanned: …" without re-reading settings.
+    pub scanned_path: PathBuf,
+}
+
+impl IntegrityScanReport {
+    /// Convenience: counts degenerate-name issues.
+    #[must_use]
+    pub fn degenerate_name_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|i| matches!(i, IntegrityIssue::DegenerateName { .. }))
+            .count()
+    }
+
+    /// Convenience: counts zero-byte-cover issues.
+    #[must_use]
+    pub fn zero_byte_cover_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|i| matches!(i, IntegrityIssue::ZeroByteCover { .. }))
+            .count()
+    }
+}
+
+/// Tests whether `path` matches any degenerate-name signature.
+///
+/// Returns the matched signature name (so the report can group
+/// findings) or `None` if the path is clean. The signatures are
+/// described in the module docstring.
+fn classify_degenerate_name(path: &Path) -> Option<&'static str> {
+    // The filename component is what we check for `-.<ext>` shapes.
+    let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+    // Signature 1: filename is literally `-.<ext>`. Pre-#531 the MV
+    // pipeline produced these when both artist and title resolved to
+    // empty strings.
+    if file_name.starts_with("-.") && !file_name.contains('/') {
+        return Some("hyphen-dot-extension");
+    }
+
+    // Walk parent components to look for `[Unknown]` segments.
+    // Any ancestor named exactly `[Unknown]` indicates the
+    // folder template produced an [Unknown] node — usually because
+    // album metadata was missing AND we had no fallback name.
+    let path_str = path.to_string_lossy();
+    if path_str.contains("/[Unknown]/")
+        || path_str.contains("\\[Unknown]\\")
+        || path_str.starts_with("[Unknown]/")
+        || path_str.starts_with("[Unknown]\\")
+    {
+        return Some("unknown-folder-segment");
+    }
+
+    // Signature 3: parent directory ends with `Unknown Album` AND
+    // filename starts with `-.`. Combination shape from v1.5.x
+    // partial fix that renamed `[Unknown]` to `Unknown Album` but
+    // hadn't yet fixed the filename derivation.
+    if file_name.starts_with("-.") {
+        if let Some(parent) = path.parent().and_then(|p| p.file_name()).and_then(|s| s.to_str()) {
+            if parent == "Unknown Album" {
+                return Some("unknown-album-with-empty-filename");
+            }
+        }
+    }
+
+    None
+}
+
+/// Tests whether `path` is one of the fixed cover paths and is
+/// zero bytes on disk. Returns the path as-is (move into the
+/// report) or `None`.
+fn classify_zero_byte_cover(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name().and_then(|s| s.to_str())?;
+    if !FIXED_COVER_NAMES.contains(&file_name) {
+        return None;
+    }
+    let metadata = std::fs::metadata(path).ok()?;
+    if metadata.len() == 0 {
+        Some(path.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Runs the integrity scan rooted at `output_path` and returns the
+/// [`IntegrityScanReport`]. Synchronous + sequential — small enough
+/// that an async wrapper isn't needed at typical library sizes
+/// (<2000 albums). IPC callers should `spawn_blocking` if the user's
+/// library is so large that the scan exceeds ~1 second.
+///
+/// Errors during the walk (permission denied, broken symlinks, etc.)
+/// are silently skipped — the scan is best-effort, not a forensic
+/// audit. The caller can still trust `files_walked` as an accurate
+/// count of readable files; entries we couldn't read are simply
+/// absent from the total.
+#[must_use]
+pub fn scan(output_path: &Path) -> IntegrityScanReport {
+    let mut report = IntegrityScanReport {
+        files_walked: 0,
+        issues: Vec::new(),
+        scanned_path: output_path.to_path_buf(),
+    };
+
+    if !output_path.exists() {
+        return report;
+    }
+
+    // Use the shared `walk_dir_depth` helper from utils/fs_walk so the
+    // walk shape matches every other output-directory walker in the
+    // codebase (`count_audio_files_in_directory`, manifest scan,
+    // legacy folder merge). The visitor returns Some(()) for entries
+    // we actually classified so we can count files_walked accurately
+    // — we collect the unit return values to size the vec, then
+    // discard them.
+    let files_walked_marker = crate::utils::fs_walk::walk_dir_depth(
+        output_path,
+        MAX_SCAN_DEPTH,
+        |path| {
+            // Only consider regular files — directories are walked but
+            // not classified directly (an `[Unknown]` directory
+            // matches via the filename of audio file inside it).
+            if !path.is_file() {
+                return None;
+            }
+            if let Some(signature) = classify_degenerate_name(path) {
+                report.issues.push(IntegrityIssue::DegenerateName {
+                    path: path.to_path_buf(),
+                    signature,
+                });
+                // Signatures are mutually exclusive in practice; don't
+                // double-classify a path.
+                return Some(());
+            }
+            if let Some(cover_path) = classify_zero_byte_cover(path) {
+                report.issues.push(IntegrityIssue::ZeroByteCover {
+                    path: cover_path,
+                });
+            }
+            Some(())
+        },
+    );
+    report.files_walked = files_walked_marker.len();
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::File::create(path).unwrap();
+    }
+
+    fn touch_with_bytes(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn detects_hyphen_dot_extension_in_isolation() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        touch(&root.join("Artist/Album/01 - Song.m4a"));
+        touch(&root.join("Artist/-.mp4")); // degenerate
+        let report = scan(root);
+        let names: Vec<_> = report
+            .issues
+            .iter()
+            .filter_map(|i| match i {
+                IntegrityIssue::DegenerateName { signature, .. } => Some(*signature),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            names.contains(&"hyphen-dot-extension"),
+            "expected hyphen-dot-extension match, got: {names:?}"
+        );
+        assert_eq!(report.degenerate_name_count(), 1);
+        assert_eq!(report.zero_byte_cover_count(), 0);
+    }
+
+    #[test]
+    fn detects_unknown_folder_segment() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        touch(&root.join("Artist/[Unknown]/track.m4a"));
+        let report = scan(root);
+        let names: Vec<_> = report
+            .issues
+            .iter()
+            .filter_map(|i| match i {
+                IntegrityIssue::DegenerateName { signature, .. } => Some(*signature),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            names.contains(&"unknown-folder-segment"),
+            "expected unknown-folder-segment match, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn detects_zero_byte_front_cover() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // Healthy track: real bytes
+        touch_with_bytes(&root.join("Artist/Album/01 - Song.m4a"), b"audio");
+        // Zero-byte cover
+        touch_with_bytes(&root.join("Artist/Album/FrontCover.mp4"), b"");
+        // Non-zero cover should NOT match
+        touch_with_bytes(&root.join("Artist/AnotherAlbum/FrontCover.mp4"), b"\x00\x01\x02");
+        let report = scan(root);
+        assert_eq!(
+            report.zero_byte_cover_count(),
+            1,
+            "expected one zero-byte cover, got: {:?}",
+            report.issues
+        );
+        assert_eq!(report.degenerate_name_count(), 0);
+    }
+
+    #[test]
+    fn passes_clean_library() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        touch_with_bytes(&root.join("Artist/Album/01 - Song.m4a"), b"audio");
+        touch_with_bytes(&root.join("Artist/Album/FrontCover.mp4"), b"video");
+        touch_with_bytes(&root.join("Artist/Album/cover.jpg"), b"img");
+        let report = scan(root);
+        assert_eq!(report.issues.len(), 0, "clean library should have no issues");
+        assert!(report.files_walked >= 3, "should walk all 3 files");
+    }
+
+    #[test]
+    fn missing_output_path_returns_empty_report() {
+        let tmp = TempDir::new().unwrap();
+        let nonexistent = tmp.path().join("does-not-exist");
+        let report = scan(&nonexistent);
+        assert_eq!(report.issues.len(), 0);
+        assert_eq!(report.files_walked, 0);
+        assert_eq!(report.scanned_path, nonexistent);
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -533,6 +533,17 @@ pub mod progress_stages;
 /// post-#528 layout.
 pub mod legacy_folder_merge;
 
+/// Output-directory integrity scan (#537 chunk B).
+///
+/// Walks the user's configured output directory looking for historic
+/// damage from pre-v1.6 broken builds: `-.mp4` / `-.jpg` filenames
+/// from the empty-tag MV pipeline, `[Unknown]/` folder segments, and
+/// zero-byte fixed-name covers (`FrontCover.mp4`,
+/// `PortraitCover.mp4`, `ArtistSpotlightCover.mp4`) from interrupted
+/// HLS downloads. User-initiated via Settings → Advanced →
+/// Diagnostics; quarantine action lands as a follow-up.
+pub mod integrity_scan;
+
 /// Only compiled in test mode (`cargo test`).
 #[cfg(test)]
 mod integration_tests;

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -765,6 +765,51 @@ pub fn is_codec_skip_message(message: &str) -> bool {
 /// Idempotent: running this on an already-humanised line is a no-op.
 /// Returns the unchanged input when the line doesn't match the codec-
 /// skip shape, so callers can apply it unconditionally.
+/// Maps a GAMDL codec CLI identifier (lowercase `atmos`, `aac-legacy`, etc.)
+/// to a user-facing display label (`Atmos`, `AAC Legacy`, etc.) for use in
+/// the activity log.
+///
+/// Mirrors the labels in [`crate::models::gamdl_options::SongCodec::display_name`]
+/// but without the trailing `(Experimental)` annotation that GAMDL adds
+/// internally and that's redundant noise in the activity log (the line is
+/// ALREADY telling the user the codec isn't available, so the
+/// "Experimental" tag adds zero information). Codecs not in the
+/// lookup table fall back to a defensive title-cased form — keeps the
+/// function future-proof if upstream adds a new codec we haven't
+/// registered yet.
+///
+/// Used by [`humanise_codec_skip_line`] (#832) to replace lowercase
+/// enum identifiers with the proper display labels users see elsewhere
+/// in the UI.
+#[must_use]
+fn pretty_codec_label(cli_id: &str) -> String {
+    match cli_id {
+        "atmos" => "Atmos".to_string(),
+        "alac" => "ALAC".to_string(),
+        "ac3" => "AC3".to_string(),
+        "aac" => "AAC".to_string(),
+        "aac-legacy" => "AAC Legacy".to_string(),
+        "aac-he" => "HE-AAC".to_string(),
+        "aac-binaural" => "AAC Binaural".to_string(),
+        "aac-downmix" => "AAC Downmix".to_string(),
+        // Defensive fallback: title-case and replace `-` with space.
+        // Means a new codec upstream produces `Some-New-Codec` rather
+        // than the raw `some-new-codec` if it sneaks through before
+        // we add a mapping.
+        other => other
+            .split('-')
+            .map(|w| {
+                let mut chars = w.chars();
+                match chars.next() {
+                    Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    None => String::new(),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+    }
+}
+
 #[must_use]
 pub fn humanise_codec_skip_line(line: &str) -> String {
     if !is_codec_skip_line(line) {
@@ -779,10 +824,34 @@ pub fn humanise_codec_skip_line(line: &str) -> String {
     };
     let mut out = media_id_re.replace_all(line, "").to_string();
 
-    // Replace the Python-repr codec list with a friendly comma-
-    // separated lowercase list. `[<SongCodec.AC3: 'ac3'>, <SongCodec.ATMOS: 'atmos'>]`
-    // → `ac3, atmos`. The single-quoted name inside each entry is
-    // exactly what we want.
+    // #832: also strip GAMDL 3.x's verbose
+    // `(Unavailable requested format candidates: Dolby Atmos
+    // (Experimental) [atmos] -> Lossless (ALAC) (Experimental)
+    // [alac] -> …)` parenthetical. Pre-fix this line was 200+
+    // characters wide in the activity log and contained the exact
+    // same codec list a second time, just with the verbose
+    // "(Experimental)" annotations. The shorter
+    // `atmos, alac, ac3, aac, aac-legacy not available` summary at
+    // the start of the line already communicates everything.
+    // Greedy `.*\)$` rather than `[^)]*\)` because GAMDL 3.x nests
+    // parens inside the parenthetical itself (e.g. "Dolby Atmos
+    // (Experimental)"). The greedy match anchored at end-of-line
+    // consumes the whole verbose block in one go. The activity-log
+    // is line-delimited so there's no risk of swallowing content
+    // from a following line.
+    let unavailable_re =
+        match regex::Regex::new(r"\s*\(Unavailable requested format candidates:.*\)$") {
+            Ok(re) => re,
+            Err(_) => return out,
+        };
+    out = unavailable_re.replace_all(&out, "").to_string();
+
+    // Replace the Python-repr codec list with friendly display labels.
+    // `[<SongCodec.AC3: 'ac3'>, <SongCodec.ATMOS: 'atmos'>]`
+    // → `AC3, Atmos`. Single-quoted name inside each entry is the
+    // GAMDL CLI identifier; pass each through `pretty_codec_label` so
+    // users see "Atmos" / "AAC Legacy" / etc. rather than the raw
+    // enum forms.
     let codec_re = match regex::Regex::new(r"\[\s*(?:<SongCodec\.[A-Z_0-9]+:\s*'([a-z0-9_-]+)'>\s*,?\s*)+\]") {
         Ok(re) => re,
         Err(_) => return out,
@@ -798,12 +867,56 @@ pub fn humanise_codec_skip_line(line: &str) -> String {
                 .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
                 .collect();
             if !codecs.is_empty() {
-                let friendly = if codecs.len() == 1 {
-                    format!("{} not available", codecs[0])
-                } else {
-                    format!("{} not available", codecs.join(", "))
-                };
+                let pretty: Vec<String> = codecs.iter().map(|c| pretty_codec_label(c)).collect();
+                let friendly = format!("{} not available", pretty.join(", "));
                 out = codec_re.replace(&out, friendly.as_str()).to_string();
+            }
+        }
+    }
+
+    // GAMDL 3.x multi-codec line shape (companion mode "all formats
+    // failed"): the codec list appears as a lowercase comma-separated
+    // run BEFORE the parenthetical we already stripped — e.g.
+    // `Requested format is not available: atmos, alac, ac3, aac,
+    // aac-legacy not available`. Match the exact "<list> not available"
+    // suffix and rewrite the list with pretty labels. Pinning to the
+    // "not available" tail keeps this from accidentally rewriting other
+    // codec-shaped substrings elsewhere in the line.
+    let lc_list_re =
+        match regex::Regex::new(r"([a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:,\s*[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+)\s+not available") {
+            Ok(re) => re,
+            Err(_) => return out,
+        };
+    if let Some(caps) = lc_list_re.captures(&out.clone()) {
+        if let Some(list_match) = caps.get(1) {
+            let list_text = list_match.as_str();
+            let codec_tokens: Vec<&str> =
+                list_text.split(',').map(str::trim).filter(|t| !t.is_empty()).collect();
+            // Only rewrite when every token is a known codec — avoids
+            // accidentally rewriting e.g. "errno 1, errno 2" or any other
+            // comma-separated lowercase run that happens to share the
+            // pattern.
+            let all_known_codecs = !codec_tokens.is_empty()
+                && codec_tokens.iter().all(|t| {
+                    matches!(
+                        *t,
+                        "atmos"
+                            | "alac"
+                            | "ac3"
+                            | "aac"
+                            | "aac-legacy"
+                            | "aac-he"
+                            | "aac-binaural"
+                            | "aac-downmix"
+                    )
+                });
+            if all_known_codecs {
+                let pretty: Vec<String> = codec_tokens
+                    .iter()
+                    .map(|t| pretty_codec_label(t))
+                    .collect();
+                let replacement = format!("{} not available", pretty.join(", "));
+                out = lc_list_re.replace(&out, replacement.as_str()).to_string();
             }
         }
     }
@@ -2833,7 +2946,10 @@ mod tests {
         assert!(!humanised.contains("1578734917"), "should strip the numeric ID");
         // Codec repr replaced by friendly text.
         assert!(!humanised.contains("SongCodec"), "should strip Python repr: {humanised}");
-        assert!(humanised.contains("ac3 not available"), "should mention ac3: {humanised}");
+        // #832: lowercase enum identifier `ac3` is now upgraded to the
+        // proper display label `AC3` to match what users see elsewhere
+        // in the UI (codec dropdowns, companion filename suffixes).
+        assert!(humanised.contains("AC3 not available"), "should mention AC3: {humanised}");
         // Track title preserved.
         assert!(humanised.contains("\"Pickle (3ballMTY Remix)\""), "title preserved: {humanised}");
     }
@@ -2844,9 +2960,55 @@ mod tests {
         let humanised = humanise_codec_skip_line(raw);
         assert!(!humanised.contains("media ID"));
         assert!(!humanised.contains("SongCodec"));
+        // #832: pretty labels instead of the raw lowercase enum identifiers.
         assert!(
-            humanised.contains("atmos, alac not available"),
-            "should list both codecs: {humanised}"
+            humanised.contains("Atmos, ALAC not available"),
+            "should list both codecs with display labels: {humanised}"
+        );
+    }
+
+    /// GAMDL 3.x multi-codec line shape — the `atmos, alac, ac3, aac,
+    /// aac-legacy not available` summary, plus the verbose
+    /// `(Unavailable requested format candidates: …)` parenthetical
+    /// (#832).
+    #[test]
+    fn humanise_rewrites_gamdl3_lowercase_multi_codec_summary() {
+        let raw = "[WARNING  21:14:34] [Track   1/19 ] Skipping \"My Love (Radio Edit)\": Requested format is not available: atmos, alac, ac3, aac, aac-legacy not available (Unavailable requested format candidates: Dolby Atmos (Experimental) [atmos] -> Lossless (ALAC) (Experimental) [alac] -> Dolby Digital (AC3) (Experimental) [ac3] -> AAC (256kbps at up to 48kHz) (Experimental) [aac] -> AAC Legacy (256kbps at up to 44.1kHz) [aac-legacy])";
+        let humanised = humanise_codec_skip_line(raw);
+        // Verbose "(Unavailable requested format candidates: …)"
+        // parenthetical gone — it was just the same codec list a
+        // second time, with the redundant "(Experimental)" tags.
+        assert!(
+            !humanised.contains("Unavailable requested format candidates"),
+            "should strip verbose parenthetical: {humanised}"
+        );
+        assert!(
+            !humanised.contains("(Experimental)"),
+            "Experimental tags gone too: {humanised}"
+        );
+        // Lowercase codec list rewritten with pretty labels.
+        assert!(
+            humanised.contains("Atmos, ALAC, AC3, AAC, AAC Legacy not available"),
+            "should rewrite lowercase list with pretty labels: {humanised}"
+        );
+        // Track title and identifier preserved.
+        assert!(
+            humanised.contains("\"My Love (Radio Edit)\""),
+            "title preserved: {humanised}"
+        );
+    }
+
+    /// Defensive: a comma-separated lowercase run that ISN'T all known
+    /// codecs (e.g. accidental match on some other GAMDL warning) must
+    /// pass through unchanged so we never garble unrelated content.
+    #[test]
+    fn humanise_does_not_rewrite_unknown_token_runs() {
+        let raw = "[WARNING] Skipping \"X\": Requested format is not available: foo, bar, baz not available";
+        let humanised = humanise_codec_skip_line(raw);
+        // foo, bar, baz are NOT known codecs → must pass through.
+        assert!(
+            humanised.contains("foo, bar, baz not available"),
+            "unknown tokens preserved: {humanised}"
         );
     }
 

--- a/src/components/download/DownloadQueue.tsx
+++ b/src/components/download/DownloadQueue.tsx
@@ -68,6 +68,7 @@ import {
   moveQueueItemToBottom,
   moveQueueItemUp,
   moveQueueItemDown,
+  retryFailedBulk,
 } from '@/lib/tauri-commands';
 
 /** Reusable UI components from the common library. */
@@ -532,20 +533,50 @@ export function DownloadQueue() {
       addToast('No failed downloads to retry', 'info');
       return;
     }
-    const results = await Promise.allSettled(
-      failedItems.map((i) => retryDownload(i.id)),
+
+    // Instant UI feedback (#835). Pre-fix the user had no signal that
+    // the click was even received — `Promise.allSettled` over N IPC
+    // calls hung the UI for minutes on big batches. Show a toast
+    // immediately so the user knows the work is in flight, then await
+    // the bulk IPC.
+    addToast(
+      `Retrying ${failedItems.length} failed download${failedItems.length !== 1 ? 's' : ''}…`,
+      'info',
     );
-    const succeeded = results.filter((r) => r.status === 'fulfilled').length;
-    const failed = results.length - succeeded;
-    if (failed === 0) {
+
+    // Single bulk IPC (#835). Replaces the N-parallel `retryDownload`
+    // calls that each acquired the queue mutex 3 times, peeked the
+    // smart-retry planner, removed history entries, persisted
+    // queue.json, and kicked `process_queue` — every single one of
+    // those steps now happens once for the whole batch.
+    try {
+      const report = await retryFailedBulk(failedItems.map((i) => i.id));
+      if (report.skipped.length === 0) {
+        addToast(
+          `Re-queued ${report.retried} failed download${report.retried !== 1 ? 's' : ''}`,
+          'success',
+        );
+      } else {
+        // Two-line breakdown so the user can act on the skips. Skips
+        // are usually "all tracks already on disk" (smart-retry) — a
+        // success outcome dressed as a skip — so the warning tier is
+        // appropriate, not error.
+        const reasonSummary = report.skipped
+          .slice(0, 3)
+          .map((s) => s.reason)
+          .filter((r, i, arr) => arr.indexOf(r) === i)
+          .join('; ');
+        const extra =
+          report.skipped.length > 3 ? ` (and ${report.skipped.length - 3} more)` : '';
+        addToast(
+          `Re-queued ${report.retried} of ${report.requested}. ${report.skipped.length} skipped: ${reasonSummary}${extra}`,
+          'warning',
+        );
+      }
+    } catch (e) {
       addToast(
-        `Re-queued ${succeeded} failed download${succeeded !== 1 ? 's' : ''}`,
-        'success',
-      );
-    } else {
-      addToast(
-        `Re-queued ${succeeded} of ${results.length} (${failed} could not be retried — check items individually)`,
-        'warning',
+        `Bulk retry failed: ${e instanceof Error ? e.message : String(e)}`,
+        'error',
       );
     }
   };

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -67,7 +67,7 @@
 // React hooks: useState for active tab tracking, useEffect for loading settings on mount.
 // @see https://react.dev/reference/react/useState
 // @see https://react.dev/reference/react/useEffect
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Lucide icon components used for the tab sidebar and header action buttons.
 // Each tab has a corresponding icon for visual identification.
@@ -95,7 +95,7 @@ import { useUiStore } from '@/stores/uiStore';
 import { withErrorToast } from '@/lib/withErrorToast';
 
 // Shared UI components used in the header action bar.
-import { Button } from '@/components/common';
+import { Button, Modal } from '@/components/common';
 import { PageHeader } from '@/components/layout';
 
 // Individual tab components -- each renders its own section of settings.
@@ -215,26 +215,136 @@ export function SettingsPage() {
   /** Pushes a toast notification to the UI toast queue */
   const addToast = useUiStore((s) => s.addToast);
 
+  // ---------------------------------------------------------------
+  // Restart-required tracking for template edits (#833)
+  // ---------------------------------------------------------------
+  //
+  // GAMDL reads its template config (`album_folder_template`, file
+  // templates, etc.) from `config.ini` at process spawn. MeedyaDL
+  // writes `config.ini` once at app startup (and when GAMDL config
+  // is synced from settings), but the GAMDL CLI does NOT re-read the
+  // file mid-process. So a template change saved while a download is
+  // in flight only takes effect from the *next* app launch.
+  //
+  // Strategy:
+  //   1. Snapshot the template-field values when settings first
+  //      hydrate (the load-from-disk pass).
+  //   2. On every `Save Changes`, compare current template values
+  //      against the snapshot. If any TEMPLATE field changed, open a
+  //      modal explaining the restart requirement and offering
+  //      Restart Now / Later.
+  //   3. After a successful Save, re-snapshot — so subsequent saves
+  //      compare against the now-saved state rather than the
+  //      original-load state.
+  //
+  // The list of restart-required keys is co-located here so it's
+  // obvious which fields trigger the prompt. If we later identify
+  // other restart-only settings (e.g. `activity_log_path_override`
+  // already changes on next restart but isn't yet wired here), add
+  // them to this list.
+  const RESTART_REQUIRED_KEYS = [
+    'album_folder_template',
+    'compilation_folder_template',
+    'no_album_folder_template',
+    'playlist_folder_template',
+    'single_disc_file_template',
+    'multi_disc_file_template',
+    'no_album_file_template',
+    'playlist_file_template',
+  ] as const;
+  type RestartKey = (typeof RESTART_REQUIRED_KEYS)[number];
+
+  /** Snapshot taken at load (and refreshed after each successful save). */
+  const templateSnapshot = useRef<Record<RestartKey, string> | null>(null);
+  /** True after a save where one or more template fields changed. */
+  const [restartPromptOpen, setRestartPromptOpen] = useState(false);
+  /**
+   * Persistent banner shown after the user chose Restart Later. Cleared
+   * on next app restart automatically (mounts fresh; ref starts null).
+   */
+  const [restartPending, setRestartPending] = useState(false);
+
   /**
    * Load settings from the backend on component mount.
    * This ensures the settings UI always reflects the latest persisted state.
    * The dependency array contains only `loadSettings` (a stable function
    * reference from Zustand), so this effect runs exactly once.
+   *
+   * Also snapshots the template field values once the load completes (#833),
+   * so subsequent `Save Changes` clicks can detect a template-only edit.
    */
   useEffect(() => {
-    loadSettings();
+    (async () => {
+      await loadSettings();
+      const current = useSettingsStore.getState().settings;
+      const snap = {} as Record<RestartKey, string>;
+      for (const k of RESTART_REQUIRED_KEYS) {
+        snap[k] = (current[k] ?? '') as string;
+      }
+      templateSnapshot.current = snap;
+    })();
+    // RESTART_REQUIRED_KEYS is a stable module-level constant; safe to
+    // omit from deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadSettings]);
 
   /**
    * Persists settings to disk by calling the Zustand store's `saveSettings`
    * action, which in turn invokes the Tauri IPC command `save_settings`.
    * Displays a success or error toast notification based on the outcome.
+   *
+   * #833: After a successful save, compares the post-save template values
+   * to the pre-save snapshot. If any template field changed, opens the
+   * restart-prompt modal so the user can either Restart Now or dismiss
+   * with a persistent "restart pending" pill.
    */
   const handleSave = async () => {
+    // Capture pre-save template values to detect a change AFTER the save
+    // returns successfully. We compare against the snapshot from
+    // load-or-last-save — not against the current in-memory value, which
+    // is what the user is about to persist.
+    const preSaveSnapshot = templateSnapshot.current;
     await withErrorToast(() => saveSettings(), {
       successMsg: 'Settings saved successfully',
       errorMsg: 'Failed to save settings',
     });
+    // saveSettings() throws on failure (withErrorToast re-surfaces),
+    // so reaching this line implies a successful disk write.
+    const post = useSettingsStore.getState().settings;
+    const changed =
+      preSaveSnapshot !== null &&
+      RESTART_REQUIRED_KEYS.some(
+        (k) => ((post[k] ?? '') as string) !== preSaveSnapshot[k],
+      );
+    // Refresh snapshot so a second click of Save Changes (with no
+    // further template edits) won't re-trigger the prompt.
+    const next = {} as Record<RestartKey, string>;
+    for (const k of RESTART_REQUIRED_KEYS) {
+      next[k] = (post[k] ?? '') as string;
+    }
+    templateSnapshot.current = next;
+    if (changed) {
+      setRestartPromptOpen(true);
+    }
+  };
+
+  /**
+   * Relaunches the app via the Tauri process plugin. Used by the
+   * "Restart Now" button on the restart-required modal (#833) — same
+   * mechanism the in-app updater uses after installing a new version
+   * (UpdateBanner.tsx:187).
+   */
+  const handleRestartNow = async () => {
+    try {
+      const { relaunch } = await import('@tauri-apps/plugin-process');
+      await relaunch();
+    } catch (e) {
+      addToast(
+        `Failed to restart: ${e instanceof Error ? e.message : String(e)}. \
+Please quit and reopen MeedyaDL manually.`,
+        'error',
+      );
+    }
   };
 
   /**
@@ -258,11 +368,69 @@ export function SettingsPage() {
 
   return (
     <div className="flex flex-col h-full">
+      {/* Restart-required modal (#833). Triggered by handleSave when one
+          or more template fields differ from the pre-save snapshot. The
+          "Restart Now" button calls Tauri's `relaunch()` (same mechanism
+          UpdateBanner uses post-install). "Restart Later" dismisses and
+          sets `restartPending`, which renders a persistent banner so
+          the user doesn't forget. */}
+      <Modal
+        open={restartPromptOpen}
+        onClose={() => {
+          setRestartPromptOpen(false);
+          setRestartPending(true);
+        }}
+        title="Restart Required"
+      >
+        <p className="text-sm text-content-primary mb-3">
+          Your template changes have been saved, but they only take effect
+          for downloads queued <em>after</em> MeedyaDL restarts. Items
+          already in flight will continue using the previous templates
+          until they finish.
+        </p>
+        <p className="text-xs text-content-tertiary mb-4">
+          GAMDL reads its template configuration when it starts. MeedyaDL
+          writes the config once at app launch and doesn't re-spawn GAMDL
+          mid-download, so a template edit can't be picked up by an
+          already-running subprocess.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setRestartPromptOpen(false);
+              setRestartPending(true);
+            }}
+          >
+            Restart Later
+          </Button>
+          <Button variant="primary" size="sm" onClick={handleRestartNow}>
+            Restart Now
+          </Button>
+        </div>
+      </Modal>
+
       <PageHeader
         title="Settings"
         subtitle="Configure download options, paths, and preferences"
         actions={
           <div className="flex gap-2">
+            {/* Restart-pending pill (#833). Shown after the user picked
+                "Restart Later" — a passive reminder until the user
+                quits or restarts the app. Click to re-open the modal. */}
+            {restartPending && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setRestartPromptOpen(true)}
+                title="Template changes won't apply until MeedyaDL restarts"
+                className="text-status-warning"
+              >
+                Restart pending
+              </Button>
+            )}
+
             {/* Reset to defaults */}
             <Button variant="ghost" size="sm" icon={<RotateCcw size={14} />} onClick={handleReset}>
               Reset

--- a/src/components/settings/tabs/AdvancedTab.tsx
+++ b/src/components/settings/tabs/AdvancedTab.tsx
@@ -113,8 +113,10 @@ import {
   buildDiagnosticBundle,
   getComponentVersions,
   getNotificationDiagnostics,
+  runIntegrityScan,
   type DiagnosticBundle,
   type NotificationDiagnostics,
+  type IntegrityScanReport,
 } from '@/lib/tauri-commands';
 import { useActivityStore } from '@/stores/activityStore';
 
@@ -411,6 +413,13 @@ export function AdvancedTab() {
             are aligned. Pure read-only: NEVER triggers a permission
             prompt (use Send Test Notification in General for that). */}
         <NotificationDiagnosticsRow />
+
+        {/* Output-directory integrity scan (#537 chunk B). User-initiated
+            walk that detects historic damage from pre-v1.6 broken
+            builds — `[Unknown]/-.mp4`, `Unknown Album/-.jpg`, zero-byte
+            cover files. Read-only: only DETECTS and REPORTS. Quarantine
+            UI lands as a follow-up. */}
+        <IntegrityScanSection />
 
         <Toggle
           label="Verbose Activity Log"
@@ -1001,6 +1010,120 @@ function NotificationDiagnosticsRow() {
         Disturb is off. Use <strong>Send Test Notification</strong> in Settings → General
         to verify the full pipeline end-to-end.
       </p>
+    </div>
+  );
+}
+
+/**
+ * Output-directory integrity scan (#537 chunk B).
+ *
+ * Renders a "Run Integrity Scan" button + on-demand results panel.
+ * Detects historic damage from pre-v1.6 broken builds:
+ *   - Empty-tag filenames (`-.mp4`, `-.jpg`)
+ *   - `[Unknown]/` folder segments
+ *   - Zero-byte fixed-name covers (`FrontCover.mp4` etc.)
+ *
+ * Read-only — does NOT modify or remove anything. Users with
+ * detected issues can use the listed paths to manually inspect /
+ * delete affected files; a future commit lands the quarantine
+ * action that moves them to `_quarantine_<DATE>/`.
+ *
+ * Lives in Settings → Advanced → Diagnostics because it's a
+ * support-grade diagnostic — pre-v1.6 users may not even know
+ * they have damaged files until they run this scan.
+ */
+function IntegrityScanSection() {
+  const [report, setReport] = useState<IntegrityScanReport | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const addToast = useUiStore((s) => s.addToast);
+
+  const handleRun = async () => {
+    setRunning(true);
+    setError(null);
+    setReport(null);
+    try {
+      const r = await runIntegrityScan();
+      setReport(r);
+      // Brief toast so the user notices a "no issues found" result
+      // even if they navigate away from this panel — the result row
+      // below is the persistent surface, the toast is just a nudge.
+      if (r.issues.length === 0) {
+        addToast(`Integrity scan: ${r.files_walked} file(s) walked, no issues found.`, 'success');
+      } else {
+        addToast(
+          `Integrity scan found ${r.issues.length} issue(s). See Diagnostics for details.`,
+          'warning',
+        );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      addToast(`Integrity scan failed: ${msg}`, 'error');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="p-3 rounded-lg bg-surface-secondary border border-border-default">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-semibold text-content-primary">
+          Integrity scan (#537)
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleRun}
+          disabled={running}
+        >
+          {running ? 'Scanning…' : 'Run Integrity Scan'}
+        </Button>
+      </div>
+      <p className="text-xs text-content-tertiary mb-2">
+        Walks your output folder looking for historic damage from
+        pre-v1.6 broken builds — empty-tag filenames (<code>-.mp4</code>),
+        <code>[Unknown]/</code> folder segments, and zero-byte cover
+        files. <strong>Read-only</strong>: detects and reports only.
+        Quarantine action lands in a future update.
+      </p>
+      {error && (
+        <p className="text-xs text-status-error mb-2">{error}</p>
+      )}
+      {report && (
+        <div className="mt-2">
+          <p className="text-xs text-content-tertiary mb-1">
+            Scanned: <code>{report.scanned_path}</code> — {report.files_walked} file(s) walked.
+          </p>
+          {report.issues.length === 0 ? (
+            <p className="text-xs text-status-success">
+              ✓ No issues found — your library is clean.
+            </p>
+          ) : (
+            <>
+              <p className="text-xs font-semibold text-status-warning mb-1">
+                {report.issues.length} issue(s) found:
+              </p>
+              <div className="max-h-48 overflow-y-auto border border-border-default rounded p-2 bg-surface-primary">
+                {report.issues.map((issue, idx) => (
+                  <div key={idx} className="text-xs font-mono text-content-primary py-0.5">
+                    <span
+                      className={
+                        issue.kind === 'zero_byte_cover'
+                          ? 'text-status-warning'
+                          : 'text-status-error'
+                      }
+                    >
+                      [{issue.kind === 'zero_byte_cover' ? 'zero-byte cover' : 'degenerate name'}]
+                    </span>{' '}
+                    {issue.path}
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/settings/tabs/AdvancedTab.tsx
+++ b/src/components/settings/tabs/AdvancedTab.tsx
@@ -112,7 +112,9 @@ import {
   getLogsFolderPath,
   buildDiagnosticBundle,
   getComponentVersions,
+  getNotificationDiagnostics,
   type DiagnosticBundle,
+  type NotificationDiagnostics,
 } from '@/lib/tauri-commands';
 import { useActivityStore } from '@/stores/activityStore';
 
@@ -401,6 +403,15 @@ export function AdvancedTab() {
 
       {/* ── Diagnostics ── */}
       <SettingsSection title="Diagnostics" description="Verbose logging for troubleshooting.">
+        {/* Native notification diagnostic readout (#834). Surfaces the
+            current notification configuration AND the OS-level
+            permission state so users on macOS — where `sendNotification`
+            can succeed silently while the OS drops the notification —
+            can see at a glance whether the toggle / style / permission
+            are aligned. Pure read-only: NEVER triggers a permission
+            prompt (use Send Test Notification in General for that). */}
+        <NotificationDiagnosticsRow />
+
         <Toggle
           label="Verbose Activity Log"
           description="Emits detailed [VERBOSE] messages to the Activity Log for issue tracking and debugging. In pre-release versions (v0.x.x), this setting is preserved across restarts. In full releases, it resets to off on each restart as a safety measure."
@@ -885,6 +896,115 @@ export function AdvancedTab() {
  * Only rendered when `dev_access_enabled` is true (activated via Konami code).
  * Shows token status, web player token management, and a deactivate button.
  */
+
+/**
+ * Native notification configuration + OS permission diagnostic readout (#834).
+ *
+ * Compact 4-row table showing:
+ *   - "Desktop Notifications" toggle state (from settings)
+ *   - "Notification Style" selection (from settings)
+ *   - Platform (`darwin` / `linux` / `windows-style`)
+ *   - OS-level permission grant (from the JS plugin's `isPermissionGranted`)
+ *
+ * Lives in Settings → Advanced → Diagnostics rather than Settings → General
+ * (where the Send Test Notification button is) because Advanced is where
+ * users go to *diagnose* issues. General is for everyday tuning.
+ *
+ * Pure read-only: does NOT call `requestPermission()` — only
+ * `isPermissionGranted()` which silently returns the current cached
+ * state without prompting. Triggering a prompt from a diagnostic
+ * readout would confuse users who just wanted to see their config.
+ */
+function NotificationDiagnosticsRow() {
+  const [diag, setDiag] = useState<NotificationDiagnostics | null>(null);
+  const [osPermission, setOsPermission] = useState<string>('unknown');
+  const [error, setError] = useState<string | null>(null);
+
+  // Load both halves on mount: the backend snapshot and the JS-side
+  // permission state. Wrapped in a single async IIFE so errors from
+  // either source land in the same `setError` and we don't render a
+  // half-loaded readout.
+  useEffect(() => {
+    (async () => {
+      try {
+        const backend = await getNotificationDiagnostics();
+        setDiag(backend);
+      } catch (e) {
+        setError(`Failed to load backend diagnostics: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+      try {
+        const { isPermissionGranted } = await import('@tauri-apps/plugin-notification');
+        const granted = await isPermissionGranted();
+        setOsPermission(granted ? 'granted' : 'not granted');
+      } catch (e) {
+        setOsPermission(`error: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })();
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-3 rounded-lg bg-status-error-bg border border-status-error">
+        <p className="text-xs text-status-error">{error}</p>
+      </div>
+    );
+  }
+
+  if (!diag) {
+    return (
+      <div className="text-xs text-content-tertiary">Loading notification diagnostics…</div>
+    );
+  }
+
+  // Pretty-format the style key — the backend stores it as snake_case
+  // so the diagnostics readout matches what the dropdown shows in the
+  // General tab. Falls back to the raw key for unknown values so a
+  // future style enum addition doesn't render as a blank cell.
+  const styleLabels: Record<string, string> = {
+    in_app_only: 'In-app only',
+    native_and_in_app: 'Native + in-app',
+    native_only: 'Native only',
+  };
+  const styleLabel = styleLabels[diag.notification_style] ?? diag.notification_style;
+
+  return (
+    <div className="p-3 rounded-lg bg-surface-secondary border border-border-default">
+      <p className="text-xs font-semibold text-content-primary mb-2">
+        Native notification diagnostics (#834)
+      </p>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <span className="text-content-tertiary">Desktop Notifications</span>
+        <span className="text-content-primary">
+          {diag.desktop_notifications_enabled ? 'ON' : 'OFF'}
+        </span>
+        <span className="text-content-tertiary">Notification Style</span>
+        <span className="text-content-primary">{styleLabel}</span>
+        <span className="text-content-tertiary">Platform</span>
+        <span className="text-content-primary">{diag.platform}</span>
+        <span className="text-content-tertiary">OS Permission</span>
+        <span
+          className={
+            osPermission === 'granted'
+              ? 'text-status-success'
+              : osPermission === 'not granted'
+                ? 'text-status-warning'
+                : 'text-content-primary'
+          }
+        >
+          {osPermission}
+        </span>
+      </div>
+      <p className="text-xs text-content-tertiary mt-2">
+        If notifications aren't appearing despite all four rows looking correct, check
+        macOS System Settings → Notifications → MeedyaDL, and ensure Focus / Do Not
+        Disturb is off. Use <strong>Send Test Notification</strong> in Settings → General
+        to verify the full pipeline end-to-end.
+      </p>
+    </div>
+  );
+}
+
 function DevToolsSection() {
   // Per-field bindings for the two MusicKit fields read by this
   // section. `loadSettings` retained because the deactivate flow

--- a/src/components/settings/tabs/GeneralTab.tsx
+++ b/src/components/settings/tabs/GeneralTab.tsx
@@ -594,8 +594,30 @@ export function GeneralTab() {
                 variant="secondary"
                 icon={<Bell size={14} />}
                 onClick={async () => {
+                  // Two-stage test (#834):
+                  //
+                  // 1. Ensure the JS plugin has the OS permission granted.
+                  //    If not, prompt for it. macOS only fires its system
+                  //    prompt the first time `requestPermission()` is called
+                  //    per bundle ID, so this is also the safety net for
+                  //    users who dismissed (rather than granted) the
+                  //    startup preflight.
+                  //
+                  // 2. Send the test notification through the **Rust**
+                  //    pipeline via `testDesktopNotification()` IPC. This
+                  //    is the same code path production downloads use, so
+                  //    a successful test means production will work; a
+                  //    failure surfaces the actual OS-level error string
+                  //    (e.g. "permission denied", "Focus mode active")
+                  //    instead of silently appearing to succeed.
+                  //
+                  // Pre-#834 this button called `sendNotification()`
+                  // directly, which:
+                  //   - tested a different code path than production, and
+                  //   - returned success even when macOS dropped the
+                  //     notification, leaving users with no diagnostic.
                   try {
-                    const { isPermissionGranted, requestPermission, sendNotification } =
+                    const { isPermissionGranted, requestPermission } =
                       await import('@tauri-apps/plugin-notification');
                     let granted = await isPermissionGranted();
                     if (!granted) {
@@ -604,17 +626,21 @@ export function GeneralTab() {
                     }
                     if (!granted) {
                       addToast(
-                        'Notification permission was not granted. Open System Settings > Notifications > MeedyaDL to enable.',
+                        'Notification permission was not granted. Open System Settings > Notifications > MeedyaDL to enable, then try again.',
                         'warning',
                       );
                       return;
                     }
-                    sendNotification({
-                      title: 'MeedyaDL — Test',
-                      body: 'If you can read this, native notifications are working.',
-                    });
-                    addToast('Test notification sent. If you do not see it, check OS notification settings.', 'info');
+                    const { testDesktopNotification } = await import('@/lib/tauri-commands');
+                    await testDesktopNotification();
+                    addToast(
+                      'Test notification sent via the production pipeline. If you do not see it on your desktop, check OS notification settings — likely causes: Focus / DND mode, app bundle missing from System Settings → Notifications.',
+                      'info',
+                    );
                   } catch (err) {
+                    // The backend returns a structured error string with
+                    // the actual OS-level failure reason — surface it
+                    // verbatim so the user knows what to fix.
                     addToast(
                       `Test notification failed: ${err instanceof Error ? err.message : String(err)}`,
                       'error',

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -2000,3 +2000,42 @@ export function getNotificationDiagnostics(): Promise<NotificationDiagnostics> {
 export function testDesktopNotification(): Promise<void> {
   return invoke<void>('test_desktop_notification');
 }
+
+/**
+ * Single integrity-scan finding (#537 chunk B).
+ *
+ * Discriminated by `kind`:
+ * - `degenerate_name` — filename/path matches one of the empty-tag
+ *   MV pipeline signatures. `signature` says which one
+ *   (`hyphen-dot-extension`, `unknown-folder-segment`,
+ *   `unknown-album-with-empty-filename`).
+ * - `zero_byte_cover` — fixed-name cover file (`FrontCover.mp4`,
+ *   `PortraitCover.mp4`, `ArtistSpotlightCover.mp4`) is 0 bytes,
+ *   likely from an interrupted HLS download.
+ */
+export type IntegrityIssue =
+  | { kind: 'degenerate_name'; path: string; signature: string }
+  | { kind: 'zero_byte_cover'; path: string };
+
+export interface IntegrityScanReport {
+  files_walked: number;
+  issues: IntegrityIssue[];
+  scanned_path: string;
+}
+
+/**
+ * Walks the user's configured output directory and returns a report
+ * of historic damage from pre-v1.6 broken builds (#537 chunk B).
+ *
+ * Detects: `-.mp4`/`-.jpg` empty-tag filenames, `[Unknown]/` folder
+ * segments, zero-byte fixed-name covers. Read-only — does NOT
+ * modify or remove anything. Quarantine action lands as a
+ * follow-up; for now the report is purely informational.
+ *
+ * The Rust side runs the walk on a `spawn_blocking` thread so the
+ * frontend can `await` this freely even on libraries with 1000+
+ * albums (where the scan can take several seconds).
+ */
+export function runIntegrityScan(): Promise<IntegrityScanReport> {
+  return invoke<IntegrityScanReport>('run_integrity_scan');
+}

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -736,6 +736,49 @@ export function retryDownload(downloadId: string): Promise<void> {
 }
 
 /**
+ * Result of a `retry_failed_bulk` call (#835).
+ *
+ * `requested` is the input length. `retried` is the count of items
+ * that actually transitioned back to Queued. `skipped` is one entry
+ * per item that couldn't be retried, with the reason — typically
+ * "All N tracks already on disk" (smart-retry planner) or "Item is
+ * not in a retryable state" (e.g. user-cancelled mid-flight, item
+ * already completed before the bulk request landed).
+ */
+export interface BulkRetrySkipped {
+  id: string;
+  reason: string;
+}
+
+export interface BulkRetryReport {
+  requested: number;
+  retried: number;
+  skipped: BulkRetrySkipped[];
+}
+
+/**
+ * Bulk-retry every failed download in one IPC round-trip (#835).
+ *
+ * Pre-#835 the Queue page's "Retry All Failed" button mapped over
+ * the failed items and called `retryDownload` per item via
+ * `Promise.allSettled`. Each call held the queue mutex 3 times,
+ * peeked smart-retry, persisted queue.json, and kicked
+ * `process_queue` — 29 failed items = ~90 mutex acquisitions and
+ * 29 disk writes, taking minutes on the affected user's system.
+ *
+ * This wrapper hands the whole batch to the Rust side which does
+ * the same per-item work but persists / kicks process_queue / emits
+ * one summary log line — ONCE for the whole batch instead of N
+ * times. Per-item `download-queued` events are still emitted so
+ * the per-row UI animation works as before.
+ *
+ * Always resolves (per-item failures are aggregated in `skipped`).
+ */
+export function retryFailedBulk(downloadIds: string[]): Promise<BulkRetryReport> {
+  return invoke<BulkRetryReport>('retry_failed_bulk', { downloadIds });
+}
+
+/**
  * Move a `Queued` item to the top of the pending sub-sequence (#782).
  *
  * Rust handler: `move_queue_item_to_top()` in

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -1911,3 +1911,49 @@ export function readClipboard(): Promise<string | null> {
 export function saveSessionLog(entries: string[]): Promise<void> {
   return invoke<void>('save_session_log', { entries });
 }
+
+/**
+ * Backend-half of the desktop-notification diagnostics readout (#834).
+ *
+ * The Settings → Advanced → Diagnostics panel reads this snapshot to show
+ * the user their current notification configuration — useful on macOS
+ * where Tauri's `sendNotification()` can resolve successfully even when
+ * the OS silently drops the notification.
+ *
+ * The frontend tops the result up with the JS-side
+ * `isPermissionGranted()` value to give a complete picture.
+ *
+ * IPC target: `get_notification_diagnostics` → `commands::system::get_notification_diagnostics`
+ */
+export interface NotificationDiagnostics {
+  desktop_notifications_enabled: boolean;
+  notification_style: string;
+  platform: string;
+}
+
+export function getNotificationDiagnostics(): Promise<NotificationDiagnostics> {
+  return invoke<NotificationDiagnostics>('get_notification_diagnostics');
+}
+
+/**
+ * Sends a one-off test notification through the **backend** notification
+ * pipeline (#834).
+ *
+ * The pre-#834 "Send Test Notification" button in Settings → General
+ * called the JS plugin directly. That tested a different code path than
+ * what production downloads use AND couldn't surface OS-level failures
+ * because `sendNotification()` resolves successfully even when macOS
+ * drops the notification.
+ *
+ * This wrapper routes the test through the same Rust path as
+ * `send_desktop_notification`, but bypasses the focus check and the
+ * throttle — the user is explicitly testing, so silently no-opping
+ * would defeat the purpose. Returns the actual OS-level error string
+ * when the plugin call fails, which the caller renders into a toast so
+ * the user can act on it (e.g. open System Settings → Notifications).
+ *
+ * IPC target: `test_desktop_notification` → `commands::system::test_desktop_notification`
+ */
+export function testDesktopNotification(): Promise<void> {
+  return invoke<void>('test_desktop_notification');
+}


### PR DESCRIPTION
## What's new

- **Settings → Templates now warns you when a change needs a restart and offers to do it for you (#833).** Template edits don't take effect for downloads already in flight — GAMDL reads its template config at process spawn. If you change one of the eight template fields and click Save, you now get a clear modal explaining the situation with two buttons: **Restart Now** (cleanly relaunches the app, the queue restores from disk via the existing persistence layer) or **Restart Later** (dismisses with a persistent "Restart pending" pill in the header to remind you).
- **New integrity scan in Settings → Advanced → Diagnostics (#537 chunk B).** A "Run Integrity Scan" button walks your output folder looking for historic damage from pre-v1.6 broken builds — `-.mp4` / `-.jpg` empty-tag filenames, `[Unknown]/` folder segments, and zero-byte cover files. Detects and reports only (read-only, never modifies); a quarantine action lands in a follow-up once the detection signatures are proven on real user data.

## What's fixed

- **"Retry All Failed" no longer freezes the UI for minutes on big queues (#835).** Pre-fix, retrying 29 failed items meant 29 sequential IPC round-trips with ~90 queue-mutex acquisitions and 29 file writes — the UI gave zero feedback while it worked. Now it's a single bulk IPC: settings loaded once, smart-retry peek under one read-lock, state transitions under one write-lock, history rewritten once, queue persisted once, `process_queue` kicked once. Plus an immediate "Retrying N…" toast so the click never looks ignored. Per-item completion still emits per-row events so the queue UI updates as before.
- **Items no longer show "Complete" when zero tracks actually downloaded (#831).** The success-path recovery that runs when GAMDL >=2.9.1 doesn't emit "Saved to:" lines (a documented post-#452 pattern) could pick up a previously-downloaded album folder and treat its files as evidence this run succeeded. Result: re-running a queue with an unavailable codec chain green-ticked every item even though every track was skipped. Fixed by snapshotting the audio-file count before GAMDL runs and verifying new files actually landed before declaring success — same shape the companion path has used since Phase 3.5h.
- **The "stuck at 95%" progress bar during companion downloads finally advances (#836).** The per-track caption update site now also nudges the bar forward by a fractional amount within a reserved 95–99% slice, so multi-tier companion runs (Atmos → ALAC → AC3 fallback chains, 30+ minutes on big albums) show visible motion instead of looking frozen. The reserved last 1% (99–100%) is kept for the post-companion advisory pass + final completion.
- **Codec-skip activity-log lines no longer leak Python internals or use ugly enum identifiers (#832).** `[<SongCodec.AC3: 'ac3'>]` rendered as `AC3 not available` (proper display label, no Python repr). GAMDL 3.x's verbose `(Unavailable requested format candidates: Dolby Atmos (Experimental) [atmos] -> Lossless (ALAC) (Experimental) [alac] -> …)` parenthetical is stripped entirely — it was 150+ characters of the same codec list repeated with redundant "(Experimental)" annotations. The lowercase comma summary (`atmos, alac, ac3, aac, aac-legacy not available`) is rewritten to proper labels (`Atmos, ALAC, AC3, AAC, AAC Legacy not available`). Defensive: only triggers when every token in the run is a known codec, so unrelated GAMDL warnings sharing a comma-list shape pass through untouched.
- **Heartbeat caption no longer duplicates the "Companion:" prefix (#836).** Companion captions already start with `"Companion: "` (set by the per-track caption update), so the heartbeat formatter was producing `"⏳ Still working — Companion: Companion: downloading atmos…"`. Now strips the leading stage prefix from the inner label so users see a clean `"⏳ Still working — Companion: downloading atmos…"`.

## Notes

- **macOS native notifications now log every send attempt to tracing + ship a backend-pipeline test button + diagnostics readout (#834).** This is the **instrumentation half** of the macOS-26.5 native-toast bug — the previous `.ok()` swallowed every plugin failure silently, so we had no signal whether notifications were being dropped at the plugin layer, the OS permission layer, or somewhere else. Now: every `send_desktop_notification` attempt is logged (debug on success, warn-with-error-string on failure); the "Send Test Notification" button in Settings → General routes through the **same Rust path** production downloads use (bypassing only the focus check and throttle) so test results reflect production behaviour; a new diagnostics row in Settings → Advanced → Diagnostics shows desktop_notifications / notification_style / platform / OS permission state in a compact 4-row table. The next bug report from a macOS 26 user will have actionable data; root-cause fix lands once that report comes in.
- **5 new backend services / IPC commands** wired across these eight commits: `services/integrity_scan.rs`, `commands/system::run_integrity_scan`, `commands/system::test_desktop_notification`, `commands/system::get_notification_diagnostics`, `commands/gamdl::retry_failed_bulk`. Plus 12 new unit tests (4 humanise / 5 integrity_scan / 3 retry-related coverage) — all 1191 backend tests and 489 frontend tests pass.
- **PRs #824 + #826 from the v1.8.1 cycle** (Windows `npm ci` hardening + PR-title workflow structural fix) are already on `main` and shipped in v1.8.1; not in this bundle.

Closes #831, #832, #833, #834, #835, #836. Refs #537 (chunk B detection landed; quarantine + startup auto-run deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
