### PR TITLE
fix(ci): same-channel PREV_TAG + rebase-on-conflict retry for alpha/beta/RC release push steps

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -152,14 +152,52 @@ jobs:
           # job-level `if:` comment above for the full incident write-up.
           git commit -m "chore(alpha): ${{ steps.version.outputs.version }}"
 
-      - name: Push alpha branch and tag
+      - name: Push alpha branch and tag (with rebase-on-conflict retry)
         if: ${{ !inputs.dry_run }}
         run: |
           set -euo pipefail
           # Fast-forward push of the version-bump commit. The branch
           # ruleset blocks non-fast-forward pushes; we never overwrite
           # history here.
-          git push origin alpha
+          #
+          # Rebase-retry loop (added after the 2026-06-07 incident
+          # where two PRs merged 9 seconds apart and the second
+          # workflow run won the race for `alpha`; the first run's
+          # push was rejected as "failed to push some refs" against
+          # a tip that had moved). The concurrency group at the top
+          # of the file SHOULD queue same-group runs, but in practice
+          # GitHub Actions occasionally schedules both rather than
+          # serialising. The defence here is per-push: refetch alpha,
+          # rebase the bump commit onto its new tip, and retry the
+          # push. The tag annotation already encodes the version
+          # number from `steps.version`, so the tag itself doesn't
+          # move — only the commit it points at gets rebased.
+          MAX_RETRIES=5
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            if git push origin alpha; then
+              echo "::notice::Pushed alpha branch on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::git push origin alpha failed after $MAX_RETRIES attempts; another concurrent merge keeps winning the race"
+              exit 1
+            fi
+            # Random 0–4 second jitter so two contending runs don't
+            # both retry at the same instant.
+            JITTER=$((RANDOM % 5))
+            echo "::warning::git push origin alpha rejected on attempt $attempt; refetching + rebasing + retrying in ${JITTER}s"
+            sleep "$JITTER"
+            git fetch origin alpha
+            # The bump commit is the single commit we authored; rebase
+            # it onto the now-current tip. The rebase is autostash-safe
+            # because we have no uncommitted changes at this point.
+            git rebase --rebase-merges FETCH_HEAD
+          done
+          # Re-create the tag against the (possibly rebased) HEAD so
+          # it points at the actually-pushed commit, then push it.
+          # If a previous attempt created the tag locally against the
+          # old HEAD, drop it first.
+          git tag -d "${{ steps.version.outputs.tag }}" 2>/dev/null || true
           git tag -a "${{ steps.version.outputs.tag }}" -m "Alpha ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.tag }}"
 

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -132,11 +132,33 @@ jobs:
           # job-level `if:` comment above for the full incident write-up.
           git commit -m "chore(beta): ${{ steps.version.outputs.version }}"
 
-      - name: Push beta branch and tag
+      - name: Push beta branch and tag (with rebase-on-conflict retry)
         if: ${{ !inputs.dry_run }}
         run: |
           set -euo pipefail
-          git push origin beta
+          # Rebase-retry loop. See alpha-release.yml's matching step
+          # for the full incident write-up — two PRs merging seconds
+          # apart can occasionally win the same-channel push race even
+          # when the workflow's `concurrency` group is configured to
+          # queue. Same defence here: refetch beta, rebase the bump
+          # commit onto its new tip, retry the push.
+          MAX_RETRIES=5
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            if git push origin beta; then
+              echo "::notice::Pushed beta branch on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::git push origin beta failed after $MAX_RETRIES attempts; another concurrent merge keeps winning the race"
+              exit 1
+            fi
+            JITTER=$((RANDOM % 5))
+            echo "::warning::git push origin beta rejected on attempt $attempt; refetching + rebasing + retrying in ${JITTER}s"
+            sleep "$JITTER"
+            git fetch origin beta
+            git rebase --rebase-merges FETCH_HEAD
+          done
+          git tag -d "${{ steps.version.outputs.tag }}" 2>/dev/null || true
           git tag -a "${{ steps.version.outputs.tag }}" -m "Beta ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.tag }}"
 

--- a/.github/workflows/release-candidate-release.yml
+++ b/.github/workflows/release-candidate-release.yml
@@ -143,11 +143,33 @@ jobs:
           # the downstream-suppression side effect of the `[skip ci]` fix.
           git commit -m "chore(rc): ${{ steps.version.outputs.version }}"
 
-      - name: Push release-candidate branch and tag
+      - name: Push release-candidate branch and tag (with rebase-on-conflict retry)
         if: ${{ !inputs.dry_run }}
         run: |
           set -euo pipefail
-          git push origin release-candidate
+          # Rebase-retry loop. See alpha-release.yml's matching step
+          # for the full incident write-up — two PRs merging seconds
+          # apart can occasionally win the same-channel push race even
+          # when the workflow's `concurrency` group is configured to
+          # queue. Same defence here: refetch release-candidate,
+          # rebase the bump commit onto its new tip, retry the push.
+          MAX_RETRIES=5
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            if git push origin release-candidate; then
+              echo "::notice::Pushed release-candidate branch on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::git push origin release-candidate failed after $MAX_RETRIES attempts; another concurrent merge keeps winning the race"
+              exit 1
+            fi
+            JITTER=$((RANDOM % 5))
+            echo "::warning::git push origin release-candidate rejected on attempt $attempt; refetching + rebasing + retrying in ${JITTER}s"
+            sleep "$JITTER"
+            git fetch origin release-candidate
+            git rebase --rebase-merges FETCH_HEAD
+          done
+          git tag -d "${{ steps.version.outputs.tag }}" 2>/dev/null || true
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release Candidate ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.tag }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,17 +202,51 @@ jobs:
             echo "::notice::Using pre-staged release notes from $NOTES_FILE"
             NOTES_PATH="$NOTES_FILE"
           else
-            # Tier 2: git-cliff diff between this tag and the
-            # previous tag of the same channel.
+            # Tier 2: git-cliff diff between this tag and the previous
+            # tag of the same channel for the same base version.
             # Strip the trailing `.N` from prerelease suffixes
-            # (`v1.10.0-alpha.14` → `*-alpha.*`) so we can find
-            # the previous tag in the same channel.
+            # (`v1.11.0-alpha.19` → channel `alpha`, base `1.11.0`) so
+            # we can find the previous tag in the same channel on the
+            # same base version.
+            #
+            # The earlier implementation searched `v*-alpha.*` which
+            # would semver-rank historic abandoned alphas (e.g.
+            # `v2.0.0-alpha.8` from 2025) above current alphas (e.g.
+            # `v1.11.0-alpha.19`), producing a months-of-commits
+            # changelog that blew through GitHub's 125 000-char body
+            # limit and failed the create-release API call. Constraining
+            # to the same base version keeps the range bounded.
+            #
+            # Fallback (e.g. when this is the FIRST alpha on a new base
+            # like `v1.11.0-alpha.18` after the `v1.10.0` → `v1.11.0`
+            # bump): use the matching channel on any LOWER base version
+            # whose tag sorts immediately below this one.
             STRIPPED="${TAG#v}"
             if [[ "$STRIPPED" == *-* ]]; then
               CHANNEL_SUFFIX=$(echo "$STRIPPED" | sed -E 's/.*-([a-z]+)\..*/\1/')
-              PREV_TAG=$(git tag --sort=-version:refname --list "v*-${CHANNEL_SUFFIX}.*" | grep -v "^$TAG$" | head -1 || true)
+              BASE_VERSION=$(echo "$STRIPPED" | sed -E 's/-.*//')
+              PREV_TAG=$(git tag --sort=-version:refname --list "v${BASE_VERSION}-${CHANNEL_SUFFIX}.*" | grep -v "^$TAG$" | head -1 || true)
+              if [ -z "$PREV_TAG" ]; then
+                # First channel tag on this base. Use the previous
+                # base version's last channel tag — or, failing that,
+                # the previous stable. Skip semver-higher historic
+                # leftovers by selecting only tags lexicographically
+                # below this one in the version-aware sort.
+                PREV_TAG=$(git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*-${CHANNEL_SUFFIX}.*" \
+                  | awk -v cur="$TAG" '$0 < cur { print; exit }' || true)
+              fi
+              if [ -z "$PREV_TAG" ]; then
+                # No same-channel predecessor at all. Use the previous
+                # stable as the absolute fallback.
+                PREV_TAG=$(git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*" \
+                  | grep -vE '\-' \
+                  | awk -v cur="$TAG" '$0 < cur { print; exit }' || true)
+              fi
             else
-              PREV_TAG=$(git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*" | grep -vE '\-' | grep -v "^$TAG$" | head -1 || true)
+              PREV_TAG=$(git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*" \
+                | grep -vE '\-' \
+                | grep -v "^$TAG$" \
+                | head -1 || true)
             fi
             echo "::notice::Previous tag for $TAG = ${PREV_TAG:-<none>}"
 


### PR DESCRIPTION
## Summary

Fixes the two release-pipeline regressions surfaced when PRs #916 + #917 merged 10 seconds apart on 2026-06-07:

1. **`alpha-release.yml` for #916 lost the push race against #917** (red ❌ visible in the Actions tab for the `feat(theme): WCAG-AA service brand colour tokens…` Alpha Release run)
2. **`release.yml` for `v1.11.0-alpha.19` failed with `HTTP 422: body is too long (max 125000 chars)`** (red ❌ for the `chore(alpha): 1.11.0-alpha.19` Release run)

Both have manual workarounds (already applied for alpha.19 — see "What I did to unblock the current build" below); this PR fixes the underlying mechanics so neither happens again.

## Root causes

### 1. Push race in `alpha-release.yml` (and beta / rc by inheritance)

The workflow has `concurrency: alpha-release / cancel-in-progress: false`, which is supposed to serialise same-group runs. In practice GitHub Actions occasionally schedules both rather than queueing — visible in the run history:

| Time | Event |
|---|---|
| 17:10:12 | PR #916 squash-merged → alpha tip = `1582f75` |
| 17:10:15 | `alpha-release.yml` starts for #916 (Run 27099241578) |
| 17:10:22 | PR #917 squash-merged → alpha tip = `2866c87f` |
| 17:10:24 | `alpha-release.yml` starts for #917 (Run 27099263xxx) — should have queued, didn't |
| 17:10:44 | #916's run pushes the bump commit → **rejected** (alpha moved while computing) |
| 17:10:55-ish | #917's run pushes successfully → tag `v1.11.0-alpha.19` lands |

#916's content reached users anyway because #917 was squash-merged on top of #916, but the workflow status shows a red ❌.

### 2. `release.yml`'s tier-2 git-cliff predecessor selection grabbed historic abandoned alphas

For `v1.11.0-alpha.19` (the first alpha cut without a pre-staged `.github/release-notes/<tag>.md` file), the `ensure-release` job fell through to tier-2 (git-cliff). The PREV_TAG selection was:

```bash
PREV_TAG=$(git tag --sort=-version:refname --list "v*-alpha.*" | grep -v "^$TAG$" | head -1)
```

`--sort=-version:refname` is version-aware reverse-sort, so the historic abandoned `v2.0.0-alpha.8` (from a 2025 attempt that was never released) ranks **above** the current `v1.11.0-alpha.*` series. git-cliff then diffed `v2.0.0-alpha.8..v1.11.0-alpha.19` — months of commits — and the resulting body exceeded GitHub's 125 000-character API limit.

Same root cause hit `v1.10.0-alpha.17` earlier in the day.

## Fixes

### `alpha-release.yml` push step — rebase-on-conflict retry loop

```bash
MAX_RETRIES=5
for attempt in $(seq 1 "$MAX_RETRIES"); do
  if git push origin alpha; then break; fi
  if [ "$attempt" -eq "$MAX_RETRIES" ]; then exit 1; fi
  JITTER=$((RANDOM % 5))
  sleep "$JITTER"
  git fetch origin alpha
  git rebase --rebase-merges FETCH_HEAD
done
# Tag created AFTER successful push so it always points at the actually-pushed commit
git tag -d "${{ steps.version.outputs.tag }}" 2>/dev/null || true
git tag -a "${{ steps.version.outputs.tag }}" -m "Alpha ${{ steps.version.outputs.version }}"
git push origin "${{ steps.version.outputs.tag }}"
```

Mirrored to `beta-release.yml` and `release-candidate-release.yml` since they share the template and will hit the same race when those channels eventually take traffic.

The workflow-level `concurrency` rule is left in place — when it DOES queue (which is the common case), the retry loop is a one-iteration no-op.

### `release.yml` PREV_TAG — same-base-version first, then base-stepping fallback

```bash
STRIPPED="${TAG#v}"
CHANNEL_SUFFIX=$(echo "$STRIPPED" | sed -E 's/.*-([a-z]+)\..*/\1/')
BASE_VERSION=$(echo "$STRIPPED" | sed -E 's/-.*//')
PREV_TAG=$(git tag --sort=-version:refname --list "v${BASE_VERSION}-${CHANNEL_SUFFIX}.*" | grep -v "^$TAG$" | head -1)
if [ -z "$PREV_TAG" ]; then
  # First channel tag on this base → walk back to previous base's
  # same-channel tag, skipping semver-higher leftovers
  PREV_TAG=$(git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*-${CHANNEL_SUFFIX}.*" \
    | awk -v cur="$TAG" '$0 < cur { print; exit }')
fi
# Final fallback: previous stable
```

`awk -v cur="$TAG" '$0 < cur { print; exit }'` skips lexicographically-higher leftovers like `v2.0.0-alpha.8` and walks down until it finds a tag *below* the current one.

Stable tag selection (no prerelease suffix) is unchanged.

## What I did to unblock the current build

While this PR awaits review:

1. Created the `v1.11.0-alpha.19` Release manually via `gh release create v1.11.0-alpha.19 --prerelease --notes-file /tmp/alpha-19-notes.md`
2. Dispatched `release.yml` via `gh workflow run "Release" -f tag=v1.11.0-alpha.19` (Run ID `27099866210`)
3. The `ensure-release` step short-circuits when a Release already exists, so the build proceeded normally

The 6 platform builds are running now. End state: alpha-channel users will receive `v1.11.0-alpha.19` automatically through the in-app updater.

## Test plan

- [x] `actionlint` clean on all four modified workflows (only the pre-existing SC2129 style hints remain on untouched lines)
- [ ] **Post-merge smoke**: next alpha cut (PR #919 will be merging this PR itself → fires alpha-release.yml) should produce a clean alpha.20 with no race, and `release.yml` should generate a small same-base-version git-cliff body
- [ ] Long-term verification: when the next pair of PRs merge close together, neither should trigger the race

## Related

- 2026-06-07 release pipeline incident
- #906 — earlier `[skip ci]` recursion fix on the same workflow trio
- `.claude/memory/project_release_pipeline_gotchas.md` — should be updated post-merge with the two new patterns (concurrency-queue isn't always honoured → rebase retry; version-aware sort grabs historic abandoned tags → constrain to base version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
