### PR TITLE
chore: docs + a11y housekeeping wave (closes #910, #925, #949, #950, #951)

### DIFF
--- a/.github/audits/gamdl-v3.7.2-v3.7.3-audit.md
+++ b/.github/audits/gamdl-v3.7.2-v3.7.3-audit.md
@@ -1,0 +1,94 @@
+# GAMDL v3.7.2 + v3.7.3 Compatibility Audit
+
+**Date**: 2026-05-28
+**GAMDL releases audited**: 3.7.2 + 3.7.3 (shipped same day)
+**Diff range**: `3.7.1..3.7.3` (3 functional commits + version metadata, ~4 lines functional change across both releases)
+**Predecessor audit**: [`gamdl-v3.5.2-audit.md`](./gamdl-v3.5.2-audit.md) (3.6 / 3.7 / 3.7.1 were rolled into a single bridging admission with no surface inspection — pure refactor / bug-fix releases)
+**Tracking issue**: #898
+
+## TL;DR
+
+Pair of bug-fix releases shipped the same day with only ~4 functional lines changed across both. **One MeedyaDL code change required** — a new `media_not_streamable` classifier bucket in [`utils/process.rs`](../../src-tauri/src/utils/process.rs) to surface the now-reachable `GamdlInterfaceMediaNotStreamableError` message cleanly. CLI / INI / wrapper-protocol surface unchanged.
+
+Highlights:
+
+- **3.7.2** uncensors music-video title / album metadata. MeedyaDL writes neither sort-order atom Apple now routes the censored variants into, so no collision.
+- **3.7.2 + 3.7.3** harden `interface/song.py` and `interface/music_video.py` against a bare `KeyError: 'playParams'` traceback for unstreamable / library-only items by introducing defensive `.get('playParams', {})` access. The streamability gate now reaches the `is_media_streamable` check reliably and surfaces `GamdlInterfaceMediaNotStreamableError("Media is not streamable: <id>")` to downstream callers — the message itself predates 3.5.2; what changed is that users now see it instead of the masked KeyError.
+
+## Methodology
+
+Identical to the v3.4 / v3.5 / v3.5.1 / v3.5.2 audits:
+
+1. Cloned `glomatico/gamdl`, materialised both tags, ran `git diff --stat 3.7.1..3.7.3` and `git diff 3.7.1..3.7.3`.
+2. Cross-referenced each hunk against MeedyaDL's integration surface:
+   - `src-tauri/src/models/gamdl_options.rs` (`to_cli_args`, INI emission gates).
+   - `src-tauri/src/services/config_service.rs` (`settings_to_ini`).
+   - `src-tauri/src/services/download_queue.rs` (stdout/stderr readers, `extract_python_exception`, completion task).
+   - `src-tauri/src/services/gamdl_capabilities.rs` (feature flags).
+   - `src-tauri/src/utils/process.rs` (`TRACK_INFO_V2_REGEX`, `ERROR_PREFIX_REGEX`, `classify_error`, `parse_gamdl_output`).
+   - `src-tauri/tool-versions.toml` (`[gamdl]` support window).
+
+## v3.7.2 — `3.7.1..3.7.2` change set
+
+| Commit | Subject |
+|---|---|
+| (interface/music_video.py) | Use uncensored title / album for music-video tags |
+| (interface/music_video.py) | Defensive `.get('playParams')` access for unstreamable MVs |
+| (version bump) | Bump version to 3.7.2 |
+
+### Hunk 1 — Uncensored MV title + album
+
+`interface/music_video.py::get_tags` swaps the title (`@nam`) and album (`@alb`) tag sources from `trackCensoredName` / `collectionCensoredName` to the uncensored `trackName` / `collectionName`. The censored variants are routed into the standard sort-order atoms `sonm` (title sort) and `soal` (album sort).
+
+**MeedyaDL impact**: zero collision. MeedyaDL writes neither `sonm` nor `soal` — see `metadata_tag_service.rs` enrichment + `tags.toml` audit. The only user-visible effect is that MV filename templates containing `{title}` or `{album}` now produce uncensored filenames after upgrade. Songs are unaffected (the change is scoped to the music-video interface).
+
+### Hunk 2 — `interface/music_video.py::get_media` defensive playParams access
+
+Replaces `media['playParams']['isLibrary']` with `media.get('playParams', {}).get('isLibrary')`. Prevents `KeyError: 'playParams'` tracebacks when Apple's response omits the field for unstreamable / library-only / region-locked content. The control-flow effect is that affected music videos now reach the existing `is_media_streamable` check and surface `GamdlInterfaceMediaNotStreamableError("Media is not streamable: <id>")` reliably.
+
+**MeedyaDL impact**: the error class predates 3.5.2 but its message was previously masked by the `KeyError` raised before reaching the streamability gate. Now the message lands in stderr. See §"Required MeedyaDL change" below.
+
+## v3.7.3 — `3.7.2..3.7.3` change set
+
+| Commit | Subject |
+|---|---|
+| (interface/song.py) | Defensive `.get('playParams')` access for unstreamable songs |
+| (version bump) | Bump version to 3.7.3 |
+
+### Hunk 1 — `interface/song.py::get_media` mirrors v3.7.2's MV fix
+
+The song interface now applies the same defensive `.get('playParams', {}).get('isLibrary')` pattern. Same control-flow effect — affected songs reach the streamability gate and surface `GamdlInterfaceMediaNotStreamableError("Media is not streamable: <id>")`.
+
+**MeedyaDL impact**: same as v3.7.2's MV path — the now-reachable error message lands in stderr.
+
+## Required MeedyaDL change
+
+Add an `is_media_not_streamable_error()` helper + dedicated `media_not_streamable` classifier bucket in [`src-tauri/src/utils/process.rs`](../../src-tauri/src/utils/process.rs), ordered **before** the generic `not_found` substring fallback in `classify_error()`. Rationale: the actionable "removed / region-locked / library-only" guidance wins over the broader "content not found" message that the generic bucket would otherwise emit.
+
+Match pattern: `"Media is not streamable"` (case-sensitive substring on the stripped error line).
+
+6 unit tests in `process::tests`:
+
+1. Bare `Media is not streamable: 12345` classifies as `media_not_streamable`.
+2. Same with a track number prefix from the parser classifies as `media_not_streamable`.
+3. Generic 404-not-found message still classifies as `not_found`.
+4. Generic `Resource Not Found` still classifies as `not_found`.
+5. Empty / unrelated error message returns `unknown`.
+6. Ordering: an error line containing both `"Media is not streamable"` and `"not found"` classifies as `media_not_streamable` (the more specific bucket wins).
+
+## CLI / INI / wrapper / regex surface
+
+| Surface | v3.7.2 + v3.7.3 status |
+|---|---|
+| `to_cli_args` (CLI flag emission) | unchanged |
+| `settings_to_ini` (INI emission) | unchanged |
+| `wrapper_url` / `wrapper_m3u8_ip` / `wrapper_decrypt_ip` | unchanged |
+| `TRACK_INFO_V2_REGEX` | unchanged |
+| `ERROR_PREFIX_REGEX` | unchanged |
+| `PYTHON_EXCEPTION_REGEX` | unchanged |
+| `GamdlFeature` gates | unchanged |
+| `tool-versions.toml` support window | bumped 3.5.2 → 3.7.4 in #947 (covers admission of 3.6 / 3.7 / 3.7.1 / 3.7.2 / 3.7.3 / 3.7.4 — this audit + the v3.7.4 sibling audit) |
+
+## Verdict — admission with one MeedyaDL code change
+
+3.7.2 + 3.7.3 admitted to the support window via PR #947's `tool-versions.toml` ceiling bump (3.5.2 → 3.7.4). The required `media_not_streamable` classifier addition + 6 unit tests landed alongside the admission as part of #898. Same release-class (defensive Apple-API access patterns) as v3.5.1 (MV m3u8 403 fix) and v3.5 (iTunes lookup follow-redirects fix).

--- a/.github/audits/gamdl-v3.7.4-audit.md
+++ b/.github/audits/gamdl-v3.7.4-audit.md
@@ -1,0 +1,91 @@
+# GAMDL v3.7.4 Compatibility Audit
+
+**Date**: 2026-06-12
+**GAMDL release audited**: 3.7.4 (released 2026-06-12)
+**Diff range**: `3.7.3..3.7.4` (5 commits: 4 functional + 1 version bump)
+**Predecessor audit**: [`gamdl-v3.7.2-v3.7.3-audit.md`](./gamdl-v3.7.2-v3.7.3-audit.md)
+**Tracking issues**: #925 (audit), #910 (upstream watch — also closed)
+
+## TL;DR
+
+Pure upstream reliability patch. **No MeedyaDL code change required.** `tool-versions.toml` ceiling bump 3.5.2 → 3.7.4 shipped in PR #947 (merged 2026-06-18). Same zero-code-change shape as v3.3 (playlist fix), v3.5 (iTunes lookup fix), v3.5.1 (music-video 403 fix), and v3.5.2 (m3u8 host migration).
+
+The four functional commits each tighten a different upstream surface — HLS variant rewrite, AMP token regex, cover-fetch HTTP timing, and API exception content typing. None reach the MeedyaDL integration boundary.
+
+## Methodology
+
+Identical to the v3.4 / v3.5 / v3.5.1 / v3.5.2 / v3.7.2-v3.7.3 audits:
+
+1. Cloned `glomatico/gamdl`, materialised both tags, ran `git diff --stat 3.7.3..3.7.4` and `git diff 3.7.3..3.7.4`.
+2. Cross-referenced each hunk against MeedyaDL's integration surface:
+   - `src-tauri/src/models/gamdl_options.rs` (`to_cli_args`, INI emission gates).
+   - `src-tauri/src/services/config_service.rs` (`settings_to_ini`).
+   - `src-tauri/src/services/download_queue.rs` (stdout/stderr readers, `extract_python_exception`, completion task).
+   - `src-tauri/src/services/gamdl_capabilities.rs` (feature flags).
+   - `src-tauri/src/services/apple_music_api.rs` (`TokenSource` 3-tier chain — independent of GAMDL's own token-extraction).
+   - `src-tauri/src/utils/process.rs` (`TRACK_INFO_V2_REGEX`, `ERROR_PREFIX_REGEX`, `classify_error`, `parse_gamdl_output`, `is_storefront_mismatch_error`).
+   - `src-tauri/tool-versions.toml` (`[gamdl]` support window).
+
+## v3.7.4 — `3.7.3..3.7.4` change set
+
+| Commit | Subject |
+|---|---|
+| 1 | `interface/song.py::_switch_m3u8_master_url_to_default` regex rewrite for HLS variants |
+| 2 | `api/apple_music.py` AMP web-player token-extraction regex update |
+| 3 | `interface/base.py::get_cover_bytes` 30s timeout + `follow_redirects=True` |
+| 4 | `api/exceptions.py::GamdlApiResponseError.content` typed `Any \| None` + JSON serialisation fallback |
+| 5 | Version bump to 3.7.4 |
+
+### Hunk 1 — HLS master URL `_default.m3u8` rewrite
+
+`interface/song.py::_switch_m3u8_master_url_to_default` adds a regex that rewrites HLS variant master URLs to the canonical `_default.m3u8` form across both `_get_m3u8_from_playback` and `_get_m3u8_master_url_from_metadata`.
+
+**MeedyaDL impact**: zero. MeedyaDL never inspects m3u8 URLs — they're consumed inside GAMDL's HLS pipeline. The only repository references to `_default.m3u8` are in comments describing GAMDL's debug-log key, not in any code path that processes the URL.
+
+### Hunk 2 — AMP web-player token-extraction regex update
+
+`api/apple_music.py::get_token` (GAMDL's own developer-token extraction) updated for two changes Apple shipped to the Music web client:
+
+1. The home-page bundle was renamed `index-legacy-*.js` → `index-*.js`; the regex pattern is updated accordingly.
+2. JWT capture tightened to require structurally valid three-segment tokens (`eyJ*.eyJ*.*`) inside quotes, rejecting incidental matches that would later 401 against amp-api.
+
+**MeedyaDL impact**: zero. This fixes GAMDL's own `get_token()` path. MeedyaDL's `apple_music_api.rs::TokenSource` three-tier chain (user MusicKit JWT > embedded > web-player keychain) is independent of GAMDL's internal token extraction.
+
+### Hunk 3 — Cover-fetch HTTP hardening
+
+`interface/base.py::get_cover_bytes` adds an explicit 30s timeout + `follow_redirects=True` on the `httpx` client used to download cover art.
+
+**MeedyaDL impact**: zero. MeedyaDL observes the resulting cover-image *files* on disk (jpg/png landed by GAMDL), not the HTTP path. MeedyaDL's own static cover-art fallback chain (#756) is unaffected.
+
+### Hunk 4 — `GamdlApiResponseError.content` typing
+
+`api/exceptions.py::GamdlApiResponseError.content` typed `Any | None` (was `str | None`). Non-string content is JSON-serialised via `json.dumps()` with `TypeError` fallback to `str()`.
+
+**MeedyaDL impact**: zero. Two regex / substring checks consume the resulting error text:
+
+1. `process::is_storefront_mismatch_error` keys on the `"Resource Not Found"` literal in the traceback — verified preserved by the new serialisation path (the literal appears in the message body, not in the structured `content` field).
+2. `PYTHON_EXCEPTION_REGEX` keys on the class-name prefix in the traceback — also preserved (the class name appears at the start of the traceback line, independent of how `content` is serialised).
+
+## CLI / INI / wrapper / regex surface
+
+| Surface | v3.7.4 status |
+|---|---|
+| `to_cli_args` (CLI flag emission) | unchanged |
+| `settings_to_ini` (INI emission) | unchanged |
+| `wrapper_url` / `wrapper_m3u8_ip` / `wrapper_decrypt_ip` | unchanged |
+| `TRACK_INFO_V2_REGEX` | unchanged |
+| `ERROR_PREFIX_REGEX` | unchanged |
+| `PYTHON_EXCEPTION_REGEX` | unchanged |
+| `is_storefront_mismatch_error` substring | preserved |
+| `GamdlFeature` gates | unchanged |
+
+## Verdict — zero-code-change admission
+
+3.7.4 admitted to the support window via PR #947's `tool-versions.toml` bump:
+
+- `maximum_tested_version`: `"3.5.2"` → `"3.7.4"`
+- `recommended_version`: `"3.5.2"` → `"3.7.4"`
+
+CLAUDE.md GAMDL section already carries the full per-commit admission paragraph. Same release-class as v3.3 / v3.5 / v3.5.1 / v3.5.2 / v3.7.1 — pure upstream reliability bug-fix with no MeedyaDL integration surface impact.
+
+`tracking issue #925` (this audit doc) and `#910` (upstream watch — body declared its own close-trigger as "when upstream tags 3.7.4 and MeedyaDL ships the admission PR") are both closed by the housekeeping wave that lands this doc.

--- a/Project_Plan.md
+++ b/Project_Plan.md
@@ -372,7 +372,7 @@ The architecture is designed with a `MediaService` trait pattern (`src-tauri/src
 
 ---
 
-### Milestone 8 — Spotify Support (v2.0.0) — [#101](https://github.com/MWBMPartners/MeedyaDL/issues/101)
+### Milestone 9 — Spotify Support (v2.1.0) — [#101](https://github.com/MWBMPartners/MeedyaDL/issues/101)
 
 **Status:** 🔲 Planned
 
@@ -419,11 +419,11 @@ Spotify integration via [votify](https://github.com/glomatico/votify), a Python 
 
 ---
 
-### Milestone 9 — YouTube Support (v2.1.0) — [#104](https://github.com/MWBMPartners/MeedyaDL/issues/104)
+### Milestone 10 — YouTube Support (v2.2.0) — [#104](https://github.com/MWBMPartners/MeedyaDL/issues/104)
 
 **Status:** 🔲 Planned
 
-YouTube integration via [yt-dlp](https://github.com/yt-dlp/yt-dlp), the most widely-used media download tool. Supports YouTube videos, shorts, playlists, channels, and audio extraction. yt-dlp also serves as the shared backend for BBC iPlayer in Milestone 10.
+YouTube integration via [yt-dlp](https://github.com/yt-dlp/yt-dlp), the most widely-used media download tool. Supports YouTube videos, shorts, playlists, channels, and audio extraction. yt-dlp also serves as the fallback engine for BBC iPlayer in Milestone 8.
 
 #### YouTube Architecture Changes
 
@@ -468,7 +468,7 @@ YouTube integration via [yt-dlp](https://github.com/yt-dlp/yt-dlp), the most wid
 
 ---
 
-### Milestone 10 — BBC iPlayer Support (v2.2.0) — [#102](https://github.com/MWBMPartners/MeedyaDL/issues/102)
+### Milestone 8 — BBC iPlayer Support (v2.0.0) — [#102](https://github.com/MWBMPartners/MeedyaDL/issues/102)
 
 **Status:** 🔲 Planned
 
@@ -526,7 +526,7 @@ These tasks span multiple milestones and should be addressed incrementally:
 - ✅ **Service registry** — `EngineRegistry` in `engine_registry.rs` provides runtime query layer for `engines.toml` with `resolve_engine()`, `resolve_engine_chain()`, `detect_platform()`. `EngineCommandBuilder` trait + `run_engine()` in `engine_runner.rs` abstract subprocess spawning (#107)
 - ✅ **Per-service settings** — `PerServiceSettings` in `settings.rs` nests per-service config (Apple Music, Spotify stub, YouTube stub) with `engine_priority` overrides per platform (#107)
 - ✅ **Rename MusicService → MediaService** — reflect that BBC iPlayer and YouTube are not music-only services (#314)
-- 🔲 **Shared dependency management** — yt-dlp used by both YouTube (M9) and BBC iPlayer (M10); install once, share across services
+- 🔲 **Shared dependency management** — yt-dlp used by both YouTube (M10) and BBC iPlayer (M8); install once, share across services
 - ✅ **Service-aware fallback chains** — engine fallback via `try_engine_fallback()` for multi-engine platforms (e.g., BBC iPlayer: get_iplayer → yt-dlp) (#107)
 - 🔲 **Help documentation** — add per-service help topics (e.g., `help/spotify.md`, `help/youtube.md`, `help/bbc-iplayer.md`)
 - 🔲 **Per-service settings UI tabs** — infrastructure exists but needs React Settings page integration
@@ -567,7 +567,7 @@ None at this time.
 - **All dependencies are self-contained** in the app data directory — no system-wide installations
 - **Conventional commits** are used throughout for automated changelog generation
 - **Every source file** includes copyright headers with automated year updates
-- **yt-dlp is shared** between YouTube (M9) and BBC iPlayer (M10) — install once, configure per-service
+- **yt-dlp is shared** between YouTube (M10) and BBC iPlayer (M8) — install once, configure per-service
 
 ---
 

--- a/help/supported-services.md
+++ b/help/supported-services.md
@@ -37,7 +37,7 @@ See [Downloading Music](downloading-music.md) for detailed usage instructions.
 
 ## Coming Soon
 
-### Spotify (Milestone M8 — v2.0.0)
+### Spotify (Milestone M9 — v2.1.0)
 
 | Feature | Planned |
 |---------|---------|
@@ -52,7 +52,7 @@ See [Downloading Music](downloading-music.md) for detailed usage instructions.
 **Authentication:** OAuth (cookie-based auth as fallback)
 **Note:** Spotify does not offer lossless audio — maximum quality is Ogg Vorbis 320kbps.
 
-### YouTube (Milestone M9 — v2.1.0)
+### YouTube (Milestone M10 — v2.2.0)
 
 | Feature | Planned |
 |---------|---------|
@@ -66,7 +66,7 @@ See [Downloading Music](downloading-music.md) for detailed usage instructions.
 **Authentication:** Optional (cookies for age-restricted/member content)
 **Note:** Also covers YouTube Music. Audio extraction available.
 
-### BBC iPlayer (Milestone M10 — v2.2.0)
+### BBC iPlayer (Milestone M8 — v2.0.0)
 
 | Feature | Planned |
 |---------|---------|

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -516,7 +516,7 @@ impl Default for AppleMusicSettings {
 
 /// Per-service settings for Spotify downloads (stub).
 ///
-/// Will be populated in milestone M8 (v2.0.0) when Votify
+/// Will be populated in milestone M9 (v2.1.0) when Votify
 /// integration is implemented.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
@@ -527,7 +527,7 @@ pub struct SpotifySettings {
 
 /// Per-service settings for YouTube/YouTube Music downloads (stub).
 ///
-/// Will be populated in milestone M9 (v2.1.0) when yt-dlp
+/// Will be populated in milestone M10 (v2.2.0) when yt-dlp
 /// integration is implemented.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]

--- a/src-tauri/src/services/engine_runner.rs
+++ b/src-tauri/src/services/engine_runner.rs
@@ -237,7 +237,7 @@ impl EngineCommandBuilder for GamdlCommandBuilder {
 
 /// Command builder stub for the Votify engine (Spotify downloads).
 ///
-/// Not yet functional — will be implemented in milestone M8 (v2.0.0).
+/// Not yet functional — will be implemented in milestone M9 (v2.1.0).
 /// Votify is a pip-installed Python package, similar to GAMDL.
 pub struct VotifyCommandBuilder;
 
@@ -252,15 +252,15 @@ impl EngineCommandBuilder for VotifyCommandBuilder {
         _urls: &[String],
         _cli_args: &[String],
     ) -> Result<Command, String> {
-        Err("Votify engine is not yet implemented (planned for v2.0.0)".to_string())
+        Err("Votify engine is not yet implemented (planned for v2.1.0)".to_string())
     }
 }
 
-/// Command builder stub for yt-dlp (YouTube / BBC iPlayer downloads).
+/// Command builder stub for yt-dlp (BBC iPlayer / YouTube downloads).
 ///
-/// Not yet functional — will be implemented in milestones M9/M10.
-/// yt-dlp is a pip-installed Python package shared between YouTube
-/// and BBC iPlayer services.
+/// Not yet functional — will be implemented in milestones M8/M10.
+/// yt-dlp is a pip-installed Python package shared between BBC iPlayer
+/// (fallback engine) and YouTube (primary engine).
 pub struct YtdlpCommandBuilder;
 
 impl EngineCommandBuilder for YtdlpCommandBuilder {
@@ -274,13 +274,13 @@ impl EngineCommandBuilder for YtdlpCommandBuilder {
         _urls: &[String],
         _cli_args: &[String],
     ) -> Result<Command, String> {
-        Err("yt-dlp engine is not yet implemented (planned for v2.1.0)".to_string())
+        Err("yt-dlp engine is not yet implemented (planned for v2.0.0)".to_string())
     }
 }
 
 /// Command builder stub for get_iplayer (BBC iPlayer primary engine).
 ///
-/// Not yet functional — will be implemented in milestone M10.
+/// Not yet functional — will be implemented in milestone M8 (v2.0.0).
 /// get_iplayer uses a different installation method (system binary,
 /// not pip) and has a distinct CLI interface.
 pub struct GetIplayerCommandBuilder;
@@ -296,7 +296,7 @@ impl EngineCommandBuilder for GetIplayerCommandBuilder {
         _urls: &[String],
         _cli_args: &[String],
     ) -> Result<Command, String> {
-        Err("get_iplayer engine is not yet implemented (planned for v2.2.0)".to_string())
+        Err("get_iplayer engine is not yet implemented (planned for v2.0.0)".to_string())
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -947,7 +947,10 @@ function App() {
                 .getState()
                 .addToast(`URL received from external link${codecSuffix}`, 'info');
 
-              console.log(`Deep link received: ${url}${codec ? `, codec=${codec}` : ''}`);
+              // dev-only diagnostic; the user already gets the toast above
+              // (#951 — matches the console.debug convention in useTheme.ts
+              // and main.tsx, suppressed at default browser log levels)
+              console.debug(`Deep link received: ${url}${codec ? `, codec=${codec}` : ''}`);
             } catch (err) {
               console.error('Error in deep-link-download handler:', err);
             }

--- a/src/components/download/QueueItem.tsx
+++ b/src/components/download/QueueItem.tsx
@@ -614,7 +614,9 @@ function QueueItemComponent({
             <button
               onClick={() => onCancel(item.id)}
               className="p-1.5 rounded-platform text-content-tertiary hover:text-status-error hover:bg-surface-elevated transition-colors"
-              title="Cancel"
+              // a11y: title matches aria-label so sighted-hover tooltip
+              // and screen-reader announcement say the same thing (#950)
+              title="Cancel download"
               aria-label="Cancel download"
             >
               <X size={14} />
@@ -630,7 +632,9 @@ function QueueItemComponent({
             <button
               onClick={() => onRetry(item.id)}
               className="p-1.5 rounded-platform text-content-tertiary hover:text-content-primary hover:bg-surface-elevated transition-colors"
-              title="Retry"
+              // a11y: title matches aria-label so sighted-hover tooltip
+              // and screen-reader announcement say the same thing (#950)
+              title="Retry download"
               aria-label="Retry download"
             >
               <RotateCcw size={14} />

--- a/src/components/help/HelpViewer.tsx
+++ b/src/components/help/HelpViewer.tsx
@@ -979,7 +979,7 @@ Apple Music is the primary and most feature-rich service in MeedyaDL. It support
 
 ---
 
-## Spotify (Planned - v2.0.0)
+## Spotify (Planned - v2.1.0)
 
 **Engine:** [Votify](https://github.com/glomatico/votify) (installed via pip)
 
@@ -998,7 +998,7 @@ Spotify support will include:
 
 ---
 
-## YouTube / YouTube Music (Planned - v2.1.0)
+## YouTube / YouTube Music (Planned - v2.2.0)
 
 **Engine:** [yt-dlp](https://github.com/yt-dlp/yt-dlp) (installed via pip)
 
@@ -1016,7 +1016,7 @@ YouTube support will include:
 
 ---
 
-## BBC iPlayer (Planned - v2.2.0)
+## BBC iPlayer (Planned - v2.0.0)
 
 **Engines:** [get_iplayer](https://github.com/get-iplayer/get_iplayer) (primary) / [yt-dlp](https://github.com/yt-dlp/yt-dlp) (fallback)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -858,12 +858,12 @@ export interface AppleMusicServiceSettings {
   content_advisory_in_filenames: boolean;
 }
 
-/** Spotify-specific service settings (stub for M8) */
+/** Spotify-specific service settings (stub for M9) */
 export interface SpotifyServiceSettings {
   cookies_path: string | null;
 }
 
-/** YouTube/YouTube Music service settings (stub for M9) */
+/** YouTube/YouTube Music service settings (stub for M10) */
 export interface YouTubeServiceSettings {
   cookies_path: string | null;
 }


### PR DESCRIPTION
## Summary

Tight follow-up wave to PR #947 — closes 5 issues (3 newly identified during the audit-discovery workflow `wv461v32a`, 2 from the existing backlog whose trigger conditions are met) plus drops 3 more (#936 / #885 / #886) via batched issue close. Mostly docs + a11y polish; zero behaviour change.

## What's included

### [#949](../issues/949) — Milestone numbering fix (6 files)

The authoritative milestone table at [Project_Plan.md:358-362](Project_Plan.md#L358-L362) was renumbered at some point (BBC iPlayer bumped to M8, Spotify to M9, YouTube to M10) but six other files plus Project_Plan.md's own per-milestone section headers + prose bullets still carried the legacy numbering (Spotify=M8, YouTube=M9, BBC iPlayer=M10).

**Bug surfaces in user-facing Help** — clicking the in-app Help > Supported Services or reading [help/supported-services.md](help/supported-services.md) showed the wrong service mapped to v2.0.0 / v2.1.0 / v2.2.0.

13 single-line edits across:
- \`src-tauri/src/services/engine_runner.rs\` — 3 stub builder error messages + 3 doc-comment lines
- \`src-tauri/src/models/settings.rs\` — 2 doc-comment lines
- \`src/types/index.ts\` — 2 comment annotations
- \`src/components/help/HelpViewer.tsx\` — 3 user-visible heading lines
- \`help/supported-services.md\` — 3 section heading lines
- \`Project_Plan.md\` — 3 section headers + 2 prose bullets

### [#925](../issues/925) + [#910](../issues/910) — GAMDL audit docs backfill

CLAUDE.md carried full per-commit admission paragraphs for v3.7.2, v3.7.3, and v3.7.4, but the corresponding standalone audit docs under \`.github/audits/\` were never written. This PR lifts the existing prose into the established audit-doc format used by [gamdl-v3.5.2-audit.md](.github/audits/gamdl-v3.5.2-audit.md):

- \`.github/audits/gamdl-v3.7.2-v3.7.3-audit.md\` — pair of bug-fix releases shipped same-day (2026-05-28); documents the uncensored MV title/album switch + defensive \`.get('playParams')\` access + the one MeedyaDL code change required (\`is_media_not_streamable_error\` classifier).
- \`.github/audits/gamdl-v3.7.4-audit.md\` — 4-functional-commit reliability patch (2026-06-12); HLS variant rewrite + AMP token regex + cover-fetch HTTP hardening + API exception content typing. Zero-code-change admission.

Closes #910 (whose body declared its own close-trigger as \"when upstream tags 3.7.4 and MeedyaDL ships the admission PR\" — condition met by PR #947's version bump + this doc backfill).

### [#951](../issues/951) — console.log → console.debug

[src/App.tsx:950](src/App.tsx#L950) deep-link handler logged via \`console.log\`. The prevailing convention elsewhere is \`console.debug\` (\`src/hooks/useTheme.ts:188-196\`, \`src/main.tsx:90\`) so dev-only diagnostics are suppressed at the browser's default log level. Line above already shows a user-facing toast, so the console line is purely dev-diagnostic.

### [#950](../issues/950) — Cancel/Retry tooltip a11y

Sibling to #945. The Cancel + Retry buttons in QueueItem had \`title=\"Cancel\"\` / \`title=\"Retry\"\` but \`aria-label=\"Cancel download\" / \"Retry download\"\` — sighted-hover tooltip didn't match screen-reader announcement. Updated \`title\` to the longer form so both match.

## Sibling issue triage (parallel close, not in this PR)

These were closed via \`gh issue close\` during the housekeeping wave:

- **#936** — closed as duplicate of #935 (the HTTP-layer syllable-lyrics fix shipped in #947's bundle; #936 was a sibling issue split during scope-planning).
- **#885** — closed (not planned) per the issue body's own \"Defer until M8 starts\" recommendation. Re-evaluate when #102 work begins.
- **#886** — closed (not planned) for the same reason as #885.

## Verification

- ✅ \`cargo check\` clean (engine_runner.rs + settings.rs string changes only)
- ✅ \`npm run type-check\` clean (types/index.ts + App.tsx + QueueItem.tsx are doc-comment + tooltip + console-method edits)
- ✅ \`rg M8.*BBC|M9.*Spotify|M10.*YouTube help/supported-services.md Project_Plan.md src/components/help/HelpViewer.tsx\` confirms the new mapping; inverse grep returns empty
- ✅ Project_Plan.md table at L358-362 unchanged (was already correct)
- ✅ \`.github/audits/\` ls shows v3.5.2, v3.5.1, v3.4-v3.5, v3.2, **and now v3.7.2-v3.7.3 + v3.7.4** — cumulative coverage complete for the support window

## Test plan

- [ ] **#949** Open in-app Help > Supported Services — verify the visible roadmap reads "Spotify v2.1.0", "YouTube v2.2.0", "BBC iPlayer v2.0.0".
- [ ] **#949** Paste a Spotify URL with no M9 build — engine_runner error toast should say \"planned for v2.1.0\" (was v2.0.0).
- [ ] **#925** Check both new audit docs render correctly on GitHub.
- [ ] **#951** With browser devtools log level set to default (info), paste a \`meedyadl://\` deep link — \"Deep link received: …\" line should NOT appear in console. Switch log level to verbose → it appears.
- [ ] **#950** Hover Cancel/Retry on a queue item — tooltip says "Cancel download" / "Retry download" (was "Cancel" / "Retry"). VoiceOver still announces the long form (was already correct via aria-label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)