### PR TITLE
fix(noise): suppress recurring ffprobe demuxing-error lines in non-verbose activity log (closes #847)

### DIFF
--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -10952,10 +10952,12 @@ async fn run_download_with_events(
                         if should_emit {
                             // Suppress Python traceback noise from the user-
                             // facing activity-log feed when verbose is off
-                            // (#660). The helper unconditionally writes to
+                            // (#660). Same gate for ffprobe demuxing noise
+                            // (#847). The helper unconditionally writes to
                             // disk so support requests stay debuggable.
-                            let is_traceback_noise =
-                                process::is_python_traceback_noise(&clean_line);
+                            let is_known_noise =
+                                process::is_python_traceback_noise(&clean_line)
+                                    || process::is_ffprobe_demux_noise(&clean_line);
                             // Phase 3.5h: humanise GAMDL "codec skip" lines
                             // — strip "(media ID: NNN)" and the Python-repr
                             // codec list. Idempotent + safe on non-matching
@@ -10966,7 +10968,7 @@ async fn run_download_with_events(
                                 &download_id,
                                 "stdout",
                                 humanised,
-                                verbose || !is_traceback_noise,
+                                verbose || !is_known_noise,
                             );
                         }
                     }
@@ -11146,12 +11148,15 @@ async fn run_download_with_events(
                             set.insert(clean_line.clone())
                         };
                         if should_emit {
-                            // Suppress Python traceback noise from the
-                            // user-facing activity-log feed in non-verbose
-                            // mode (#660). The helper unconditionally writes
-                            // to disk so support requests stay debuggable.
-                            let is_traceback_noise =
-                                process::is_python_traceback_noise(&clean_line);
+                            // Suppress Python traceback noise (#660) and
+                            // recurring ffprobe demuxing-error lines (#847)
+                            // from the user-facing activity-log feed in
+                            // non-verbose mode. The helper unconditionally
+                            // writes to disk so support requests stay
+                            // debuggable.
+                            let is_known_noise =
+                                process::is_python_traceback_noise(&clean_line)
+                                    || process::is_ffprobe_demux_noise(&clean_line);
                             // Phase 3.5h: humanise GAMDL "codec skip" lines
                             // (strips "(media ID: NNN)" + Python-repr codec
                             // list).
@@ -11161,7 +11166,7 @@ async fn run_download_with_events(
                                 &download_id,
                                 "stderr",
                                 humanised,
-                                verbose || !is_traceback_noise,
+                                verbose || !is_known_noise,
                             );
                         }
                     }

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -265,6 +265,57 @@ pub fn is_python_traceback_noise(line: &str) -> bool {
     trimmed.chars().all(|c| c == '^')
 }
 
+/// Reports whether `line` is a recurring ffprobe demuxing-error noise
+/// line that should be suppressed from the user-facing activity log
+/// when verbose mode is off (#847).
+///
+/// During enrichment, MeedyaDL runs ffprobe several times per track
+/// (codec detection, ReplayGain, mediainfo, …). Each invocation against
+/// a freshly-written M4A occasionally trips an
+/// "Invalid data found when processing input" warning that ffmpeg's
+/// stderr emits for the partial-moov-atom case at byte 0. Downloads
+/// complete fine; ffprobe falls through to a valid result on retry.
+/// But the noise produces ~20 entries per album in the activity log —
+/// reported in #847 as the most-aggravating recurring log noise.
+///
+/// Modelled exactly on [`is_python_traceback_noise`] (#660): the
+/// on-disk activity-log writer still records the line regardless so
+/// the forensic record stays complete; this helper just gates the
+/// per-line `activity-log` Tauri event when verbose is off.
+///
+/// The match is intentionally tight on the recognisable prefix —
+/// `[in#0/<demuxer-list> @ 0x…] Error during demuxing: ` — to avoid
+/// suppressing genuine ffmpeg errors that happen to share the
+/// "demuxing" / "invalid data" wording. The hex pointer in the
+/// bracket varies per invocation so we match by structure
+/// (`[in#0/…@ 0x…]` substring) rather than literal.
+#[must_use]
+pub fn is_ffprobe_demux_noise(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Required prefix shape — `[in#<digit>/<demuxer-list> @ 0x<hex>]`.
+    // `in#0/mov,mp4,m4a,3gp,3g2,mj2` is the typical demuxer-list ffmpeg
+    // selects for Apple-Music-shipped M4A files, but we keep this
+    // generic so future demuxer-list shifts don't slip past the gate.
+    let Some(after_in_marker) = trimmed.strip_prefix("[in#") else {
+        return false;
+    };
+    let Some(after_at_sign) = after_in_marker.split_once(" @ 0x").map(|(_, r)| r) else {
+        return false;
+    };
+    let Some(after_close_bracket) = after_at_sign.split_once("] ").map(|(_, r)| r) else {
+        return false;
+    };
+    // Required tail — both substrings present (order-flexible). Apple's
+    // ffmpeg has been stable on this exact wording since 5.x; if it
+    // changes upstream this gate fails open and noise resumes — which
+    // is the safe default vs accidentally suppressing genuine errors.
+    after_close_bracket.starts_with("Error during demuxing: ")
+        && after_close_bracket.contains("Invalid data found when processing input")
+}
+
 /// Reports whether `line` matches the Python exception summary pattern
 /// (e.g. `TypeError: …`, `httpx.ConnectError: Connection refused`).
 ///
@@ -1477,6 +1528,96 @@ mod tests {
         assert!(!is_python_traceback_noise("Downloading album..."));
         assert!(!is_python_traceback_noise(
             "[INFO     12:34:56] [Track 1/12] Downloading \"Hello\""
+        ));
+    }
+
+    // ----------------------------------------------------------
+    // ffprobe demuxing-noise detector tests (#847)
+    // ----------------------------------------------------------
+
+    #[test]
+    fn is_ffprobe_demux_noise_recognises_canonical_apple_music_shape() {
+        // Verbatim from the #847 issue report — fires every track during
+        // enrichment.
+        assert!(is_ffprobe_demux_noise(
+            "[in#0/mov,mp4,m4a,3gp,3g2,mj2 @ 0x954c14000] Error during demuxing: Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn is_ffprobe_demux_noise_tolerates_leading_whitespace_and_alt_hex_widths() {
+        // Some ffmpeg builds prefix the line with a single space; some
+        // hex pointers are wider on 64-bit platforms.
+        assert!(is_ffprobe_demux_noise(
+            "  [in#0/mov,mp4,m4a,3gp,3g2,mj2 @ 0x7b8c1c000] Error during demuxing: Invalid data found when processing input"
+        ));
+        assert!(is_ffprobe_demux_noise(
+            "[in#0/mov,mp4,m4a,3gp,3g2,mj2 @ 0xff00ff00ff00ff00] Error during demuxing: Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn is_ffprobe_demux_noise_recognises_alternate_demuxer_lists() {
+        // Future-proofing — ffmpeg's auto-selected demuxer list may
+        // change as more formats are added. The match keys on the
+        // structural `[in#<digit>/<list> @ 0x<hex>]` shape, not the
+        // exact comma-separated demuxer names.
+        assert!(is_ffprobe_demux_noise(
+            "[in#0/aac @ 0xabc123] Error during demuxing: Invalid data found when processing input"
+        ));
+        assert!(is_ffprobe_demux_noise(
+            "[in#1/wav,mp3 @ 0x1234] Error during demuxing: Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn is_ffprobe_demux_noise_rejects_genuine_ffmpeg_errors() {
+        // Other ffmpeg errors that happen to share words must NOT be
+        // suppressed — they're rare but actionable when they fire.
+        // Pattern requires BOTH "Error during demuxing:" prefix AND
+        // "Invalid data found when processing input" — so e.g. a
+        // muxer error or a generic "Invalid data" without the demuxing
+        // prefix passes through.
+        assert!(!is_ffprobe_demux_noise(
+            "[in#0/mov,mp4,m4a,3gp,3g2,mj2 @ 0x954c14000] Error muxing packet (track 2)"
+        ));
+        assert!(!is_ffprobe_demux_noise(
+            "[in#0/mov @ 0x1234] Could not find codec parameters for stream 0"
+        ));
+        assert!(!is_ffprobe_demux_noise(
+            "Invalid data found when processing input"
+        ));
+        // No `[in#…]` prefix → not the noise we're after.
+        assert!(!is_ffprobe_demux_noise(
+            "Error during demuxing: Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn is_ffprobe_demux_noise_rejects_unrelated_lines() {
+        assert!(!is_ffprobe_demux_noise(""));
+        assert!(!is_ffprobe_demux_noise("  "));
+        assert!(!is_ffprobe_demux_noise(
+            "[INFO     12:34:56] [Track 1/12] Downloading \"Hello\""
+        ));
+        assert!(!is_ffprobe_demux_noise(
+            "Traceback (most recent call last):"
+        ));
+        // Line that LOOKS like a bracketed prefix but uses a different
+        // shape (e.g. structlog's `[level    HH:MM:SS]` prefix on
+        // GAMDL v3.0+ wrapped lines).
+        assert!(!is_ffprobe_demux_noise(
+            "[INFO     12:34:56] [in#0/mov,mp4 @ 0x1234] Error during demuxing: Invalid data found when processing input"
+        ));
+    }
+
+    #[test]
+    fn is_ffprobe_demux_noise_requires_zero_x_hex_pointer_form() {
+        // ffmpeg always prints the pointer as `0x<hex>`; if upstream
+        // ever switches format the gate fails open (noise resumes)
+        // rather than over-suppressing.
+        assert!(!is_ffprobe_demux_noise(
+            "[in#0/mov,mp4,m4a,3gp,3g2,mj2 @ 12345] Error during demuxing: Invalid data found when processing input"
         ));
     }
 


### PR DESCRIPTION
## Summary

Closes #847 — the most-aggravating recurring log noise in the user-facing activity log. ffprobe's \"Invalid data found when processing input\" warning fires from stderr on virtually every track during enrichment as ffmpeg encounters the partial-moov-atom case at byte 0. Downloads complete; ffprobe falls through to a valid result on retry. But ~20 noise lines per album turned the activity log into static.

Implementation modelled exactly on the shipped #660 pattern (\`is_python_traceback_noise\` + non-verbose suppression in \`download_queue.rs::emit_subprocess_line\` gate). Verbose mode still surfaces everything; on-disk activity-log writer still records every line so support requests stay debuggable.

## What changed

- **New \`process::is_ffprobe_demux_noise\`** in [src-tauri/src/utils/process.rs](src-tauri/src/utils/process.rs). Match keys on the structural \`[in#<digit>/<demuxer-list> @ 0x<hex>]\` prefix plus both required tail substrings (\`Error during demuxing:\` AND \`Invalid data found when processing input\`).
- **Wired into both stdout + stderr gates** in [src-tauri/src/services/download_queue.rs](src-tauri/src/services/download_queue.rs) at lines ~10958 and ~11155. \`is_known_noise\` now combines both \`is_python_traceback_noise\` (#660) and \`is_ffprobe_demux_noise\` (this PR). The 5th arg to \`emit_subprocess_line\` (\`show_in_ui\`) stays \`verbose || !is_known_noise\`.

## Design choices

**Why a tight structural match rather than a regex on the literal demuxer list?** Future ffmpeg may auto-select a different comma-separated demuxer list (the canonical \`mov,mp4,m4a,3gp,3g2,mj2\` set could shift to include / exclude formats). The match keys on the bracket shape \`[in#N/...\` + the \`@ 0x<hex>]\` pointer suffix, which has been stable across ffmpeg 4.x / 5.x / 6.x / 7.x. If upstream ever switches the pointer format the gate fails OPEN (noise resumes) rather than over-suppressing genuine errors. Safe-default direction.

**Why combine with the existing #660 gate rather than a separate emit path?** Single \`is_known_noise\` boolean keeps the call site readable + avoids the \"every new noise filter doubles the branching\" pattern. Future noise gates land in the same OR chain.

## Tests

6 new unit tests pin the contract — all green:

| Test | What it pins |
|---|---|
| canonical Apple Music shape | verbatim from #847 issue report |
| leading-whitespace + wider hex pointer tolerance | ffmpeg builds + 64-bit platform variations |
| alternate demuxer lists (aac, wav,mp3) | future-proof against ffmpeg's auto-selection changes |
| genuine ffmpeg errors pass through | muxer errors, parameter errors, generic \"Invalid data\" without the demuxing prefix all still visible |
| empty / unrelated / traceback lines pass through | no false positives |
| wrapped GAMDL \`[INFO     HH:MM:SS]\` prefix doesn't trigger | structlog-prefixed lines aren't confused with ffmpeg's prefix |
| requires \`0x<hex>\` pointer form | upstream format change → gate fails open (safe) |

## Verification

- ✅ \`cargo test --lib is_ffprobe_demux_noise\` — 6/6 pass
- ✅ Full test suite green (no regression)
- ✅ Verbose mode unchanged — every line still emits both on-disk + UI
- ✅ Disk writer unchanged — forensic record stays complete

## Test plan

- [ ] Download an album in non-verbose mode → ffprobe demuxing-error lines no longer appear in the activity log (was ~4 lines per track).
- [ ] Toggle verbose mode → lines reappear immediately.
- [ ] Check \`{app_data_dir}/logs/activity-YYYY-MM-DD.log\` — every suppressed line is still recorded on disk.
- [ ] Provoke a genuine non-demuxing ffmpeg error (e.g. paste an empty file at the codec-detection step) → it should still surface in the activity log (the gate is tight enough not to swallow real errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)