### PR TITLE
sec+ci: bring main's audit hardening to alpha + tighten release-yml recursion guard (closes #938, #939, #940; refs #937)

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -70,9 +70,16 @@ jobs:
     # event has `[skip ci]` in the head commit, including the tag push).
     # The job-level `if:` here only gates *this* workflow, leaving every
     # other workflow free to receive the tag push event as normal.
+    # Match the bot's commit shape specifically: `chore(alpha): X.Y.Z-alpha.N`
+    # (space after the colon + the literal `-alpha.` from the version suffix).
+    # The previous looser `startsWith(..., 'chore(alpha):')` accidentally
+    # matched HUMAN-merged PRs like `chore(alpha): combined housekeeping…`
+    # (observed: PR #954 was silently suppressed on 2026-06-21). Combining
+    # `startsWith` with `contains('-alpha.')` requires the version suffix
+    # to be present — which a human commit subject never carries.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message, 'chore(alpha):')
+      !(startsWith(github.event.head_commit.message, 'chore(alpha): ') && contains(github.event.head_commit.message, '-alpha.'))
     steps:
       - name: Checkout alpha
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -54,9 +54,12 @@ jobs:
     # event has `[skip ci]` in the head commit, including the tag push).
     # The job-level `if:` here only gates *this* workflow, leaving every
     # other workflow free to receive the tag push event as normal.
+    # See alpha-release.yml for the recursion-guard rationale + the
+    # PR #954 incident write-up (human commit `chore(alpha): combined
+    # housekeeping…` was silently suppressed by the loose `startsWith`).
     if: |
       github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message, 'chore(beta):')
+      !(startsWith(github.event.head_commit.message, 'chore(beta): ') && contains(github.event.head_commit.message, '-beta.'))
     steps:
       - name: Checkout beta
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-candidate-release.yml
+++ b/.github/workflows/release-candidate-release.yml
@@ -63,9 +63,12 @@ jobs:
     # and dispatched `release.yml` manually. The job-level `if:` here
     # only gates *this* workflow, leaving every other workflow free to
     # receive the tag push event as normal — both problems solved.
+    # See alpha-release.yml for the recursion-guard rationale + the
+    # PR #954 incident write-up (human commit was silently suppressed
+    # by the original looser `startsWith` check).
     if: |
       github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message, 'chore(rc):')
+      !(startsWith(github.event.head_commit.message, 'chore(rc): ') && contains(github.event.head_commit.message, '-rc.'))
     steps:
       - name: Checkout release-candidate
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -88,10 +88,15 @@ pub async fn restore_from_backup(
 ///
 /// **Frontend caller:** `deleteBackup(snapshotPath)` in
 /// `src/lib/tauri-commands.ts`.
+///
+/// Backed by `backup_service::delete_backup` which now requires `app`
+/// for path-containment verification (#939). A subverted WebView passing
+/// an arbitrary path is rejected with a clear error.
 #[tauri::command]
-pub async fn delete_backup(snapshot_path: String) -> Result<(), String> {
+pub async fn delete_backup(app: AppHandle, snapshot_path: String) -> Result<(), String> {
     let path = PathBuf::from(snapshot_path);
-    tauri::async_runtime::spawn_blocking(move || backup_service::delete_backup(&path))
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn_blocking(move || backup_service::delete_backup(&app_clone, &path))
         .await
         .map_err(|e| format!("Delete backup task panicked: {e}"))?
 }

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -54,6 +54,55 @@ use crate::context_err;
 /// See: <https://docs.rs/keyring/latest/keyring/struct.Entry.html>
 const SERVICE_NAME: &str = "io.github.meedyadl";
 
+/// Keychain accounts the universal `store_credential` / `get_credential` /
+/// `delete_credential` IPCs are allowed to touch.
+///
+/// **Adding to this list MUST be reviewed for post-XSS exfiltration
+/// risk** — high-sensitivity entries should ideally have dedicated
+/// per-secret IPCs (e.g. `has_webplayer_token`, `clear_webplayer_token`,
+/// `check_dev_access`) rather than ride the universal accessor.
+///
+/// Pre-#938, these three IPCs accepted **any** key string, so any
+/// post-XSS attacker (hostile help-content markdown, compromised npm
+/// dep, future stored-XSS) could `invoke('get_credential', { key:
+/// 'webplayer_developer_token' })` or worse — `'musickit_private_key'`
+/// — and exfiltrate Apple Developer credentials from the OS keychain.
+/// The allowlist closes that escalation path while preserving the only
+/// legitimate frontend caller in
+/// `src/components/settings/tabs/AdvancedTab.tsx`.
+///
+/// Current entries:
+/// * `musickit_private_key` — set/get by the AdvancedTab MusicKit
+///   credentials editor.
+///
+/// Other keychain accounts stay reachable only via their dedicated
+/// IPCs:
+/// * `webplayer_developer_token` → `has_webplayer_token`,
+///   `clear_webplayer_token`.
+/// * `dev_access_token` → `check_dev_access`, `activate_dev_access`,
+///   `deactivate_dev_access`.
+const ALLOWED_CREDENTIAL_KEYS: &[&str] = &["musickit_private_key"];
+
+/// Verify that the supplied credential key is on the allowlist.
+///
+/// The error message is deliberately generic — it does NOT disclose
+/// which keys are on the allowlist or what's gated elsewhere, so an
+/// attacker can't use the IPC error response as a key-enumeration
+/// oracle.
+fn check_credential_key_allowed(key: &str) -> Result<(), String> {
+    if ALLOWED_CREDENTIAL_KEYS.contains(&key) {
+        Ok(())
+    } else {
+        // Logged with WARN so an operator inspecting the tracing log
+        // can see brute-force probes after the fact, but the IPC
+        // response stays opaque.
+        log::warn!(
+            "Credential IPC rejected disallowed key '{key}' (allowlist enforcement, #938)"
+        );
+        Err(format!("Unknown credential key: {key}"))
+    }
+}
+
 /// Stores a credential securely in the OS keychain.
 ///
 /// **Frontend caller:** `storeCredential(key, value)` in `src/lib/tauri-commands.ts`
@@ -85,6 +134,11 @@ const SERVICE_NAME: &str = "io.github.meedyadl";
 /// The value is never logged — only the key name is logged for auditability.
 #[tauri::command]
 pub async fn store_credential(key: String, value: String) -> Result<(), String> {
+    // #938 — reject any key not on the allowlist BEFORE creating a
+    // keyring handle, so an attacker probing the IPC can't enumerate
+    // valid keys via keyring-error vs allowlist-error response shapes.
+    check_credential_key_allowed(&key)?;
+
     // Create a keyring entry handle for the (service, key) pair.
     // Entry::new() can fail if the OS keychain backend is unavailable.
     // See: https://docs.rs/keyring/latest/keyring/struct.Entry.html#method.new
@@ -132,6 +186,13 @@ pub async fn store_credential(key: String, value: String) -> Result<(), String> 
 /// * `Err(String)` - Keychain access error (locked, permission denied, etc.).
 #[tauri::command]
 pub async fn get_credential(key: String) -> Result<Option<String>, String> {
+    // #938 — reject any key not on the allowlist. CRITICAL: return
+    // `Err` (not `Ok(None)`) so the response distinguishes
+    // "you're not allowed to read this" from "this key is unset". An
+    // `Ok(None)` would let an attacker probe whether a sensitive key
+    // exists via the response shape.
+    check_credential_key_allowed(&key)?;
+
     // Create a keyring entry handle for the lookup
     let entry = context_err!(
         keyring::Entry::new(SERVICE_NAME, &key),
@@ -176,6 +237,13 @@ pub async fn get_credential(key: String) -> Result<Option<String>, String> {
 /// * `Err(String)` - Keychain access error (locked, permission denied, etc.).
 #[tauri::command]
 pub async fn delete_credential(key: String) -> Result<(), String> {
+    // #938 — reject any key not on the allowlist before touching the
+    // keyring. Same threat model as store_credential: an attacker
+    // shouldn't be able to delete dedicated-IPC keys
+    // (`webplayer_developer_token`, `dev_access_token`) via the
+    // universal accessor.
+    check_credential_key_allowed(&key)?;
+
     // Create a keyring entry handle for the deletion
     let entry = context_err!(
         keyring::Entry::new(SERVICE_NAME, &key),
@@ -431,9 +499,26 @@ pub fn check_dev_access(app: tauri::AppHandle) -> bool {
 /// `dev_access_enabled` in settings. Returns whether activation succeeded.
 ///
 /// On failure, returns `false` silently (no error hint to prevent brute-forcing).
+///
+/// **Rate-limited** at 5 attempts per 60-second sliding window (#940). Plain
+/// SHA-256 with no salt and no throttle is wordlist-trivial for any code with
+/// IPC access (post-XSS, hostile markdown, compromised npm dep); the limit
+/// turns thousands-of-attempts-per-second brute force into ≤5/min. Legit users
+/// type the passphrase by hand so the cap has zero UX cost. Mirrors the
+/// existing rate-limiter pattern used by `start_download`,
+/// `import_cookies_from_browser`, and `check_all_updates`.
 #[tauri::command]
 pub async fn activate_dev_access(app: tauri::AppHandle, passphrase: String) -> bool {
     use sha2::{Digest, Sha256};
+
+    // Reject after 5 attempts in the rolling 60-second window. The IPC
+    // returns `-> bool` (not Result) so we map the rate-limit Err to
+    // a plain `false` — visually indistinguishable to the attacker from
+    // a wrong-passphrase rejection, denying them a usable oracle.
+    if crate::utils::rate_limiter::check_rate_limit("activate_dev_access", 5, 60).is_err() {
+        log::warn!("activate_dev_access: rate-limited (possible brute-force attempt)");
+        return false;
+    }
 
     // Hash the provided passphrase and compare against the embedded hash.
     let hash = format!("{:x}", Sha256::digest(passphrase.as_bytes()));
@@ -483,6 +568,8 @@ pub async fn deactivate_dev_access(app: tauri::AppHandle) -> Result<(), String> 
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn musickit_id_normalization_logic() {
         let team = " ab12cd34ef ".trim().to_ascii_uppercase();
@@ -491,5 +578,87 @@ mod tests {
         assert_eq!(key, "99ZZ88YY77");
         assert_eq!(team.len(), 10);
         assert_eq!(key.len(), 10);
+    }
+
+    // ----------------------------------------------------------
+    // Credential allowlist tests (#938)
+    // ----------------------------------------------------------
+    //
+    // Pin the allowlist contract — if a future contributor adds a key
+    // here, they need to deliberately update these tests (which forces
+    // the post-XSS-risk review the allowlist's whole purpose).
+
+    #[test]
+    fn allowlist_accepts_musickit_private_key() {
+        // The single legitimate frontend caller (AdvancedTab.tsx).
+        assert!(check_credential_key_allowed("musickit_private_key").is_ok());
+    }
+
+    #[test]
+    fn allowlist_rejects_webplayer_developer_token() {
+        // Critical: this key MUST stay off the allowlist — it has a
+        // dedicated IPC (`has_webplayer_token` / `clear_webplayer_token`).
+        // If a future PR adds it here, the post-XSS escalation primitive
+        // returns.
+        assert!(check_credential_key_allowed("webplayer_developer_token").is_err());
+    }
+
+    #[test]
+    fn allowlist_rejects_dev_access_token() {
+        // Critical: this key MUST stay off the allowlist — it's the
+        // dev-access sentinel set/cleared by `activate_dev_access` /
+        // `deactivate_dev_access`. Allowlist'ing it would let any
+        // post-XSS script read the unlock sentinel.
+        assert!(check_credential_key_allowed("dev_access_token").is_err());
+    }
+
+    #[test]
+    fn allowlist_rejects_arbitrary_keys() {
+        // Defence against probing — random keys, fuzzing payloads,
+        // common credential-naming guesses all rejected.
+        for key in &[
+            "",
+            "wrapper_url",
+            "musickit_private_key_v2",
+            "../../../etc/passwd",
+            "musickit_private_key\0extra",
+            "MusicKit_Private_Key", // case-sensitive — exact match required
+            "musickit_private_key ", // trailing space — exact match required
+        ] {
+            assert!(
+                check_credential_key_allowed(key).is_err(),
+                "key '{}' should be rejected by allowlist",
+                key
+            );
+        }
+    }
+
+    #[test]
+    fn allowlist_error_message_is_generic_not_enumerable() {
+        // Verify the error response doesn't leak allowlist contents —
+        // an attacker shouldn't be able to use the error string to
+        // enumerate which keys are valid.
+        let err1 = check_credential_key_allowed("alpha_key").unwrap_err();
+        let err2 = check_credential_key_allowed("beta_key").unwrap_err();
+
+        // Both errors should be the same generic shape (just the key
+        // echoed back), NOT something like "alpha_key — try
+        // 'musickit_private_key' instead".
+        assert!(err1.starts_with("Unknown credential key:"));
+        assert!(err2.starts_with("Unknown credential key:"));
+
+        // And critically, MUST NOT mention any allowed key.
+        for allowed in ALLOWED_CREDENTIAL_KEYS {
+            assert!(
+                !err1.contains(allowed),
+                "error must not enumerate allowed key '{}'",
+                allowed
+            );
+            assert!(
+                !err2.contains(allowed),
+                "error must not enumerate allowed key '{}'",
+                allowed
+            );
+        }
     }
 }

--- a/src-tauri/src/services/backup_service.rs
+++ b/src-tauri/src/services/backup_service.rs
@@ -166,6 +166,17 @@ pub fn restore_from_backup(app: &AppHandle, snapshot_dir: &Path) -> Result<Resto
         ));
     }
 
+    // #939 — defence against caller-supplied path escape. Without this
+    // check, any code with IPC access (post-XSS, hostile markdown,
+    // compromised npm dep) could call `restoreFromBackup('/tmp/attacker')`
+    // and the backend would dutifully copy attacker-supplied
+    // settings.json / queue.json / history.json over the live files,
+    // taking control of cookies path, wrapper URL (auth tokens), and
+    // MusicKit JWT on next load. Canonicalising the parent and
+    // requiring exact equality with `{app_data_dir}/backups/` closes
+    // the gap without changing the legitimate UI flow.
+    assert_snapshot_under_backups_root(app, snapshot_dir)?;
+
     let app_data = platform::get_app_data_dir(app);
     let mut restored = Vec::new();
     let mut skipped = Vec::new();
@@ -259,12 +270,49 @@ pub fn list_backups(app: &AppHandle) -> Result<Vec<BackupEntry>, String> {
 
 /// Remove a specific snapshot directory by absolute path. Used by the
 /// UI's per-entry delete button.
-pub fn delete_backup(snapshot_dir: &Path) -> Result<(), String> {
+///
+/// Path containment is verified — only directories whose parent is the
+/// canonical `{app_data_dir}/backups/` root may be deleted. See #939 for
+/// the threat-model rationale.
+pub fn delete_backup(app: &AppHandle, snapshot_dir: &Path) -> Result<(), String> {
     if !snapshot_dir.exists() {
         return Ok(());
     }
+    assert_snapshot_under_backups_root(app, snapshot_dir)?;
     fs::remove_dir_all(snapshot_dir)
         .map_err(|e| format!("Failed to delete snapshot {snapshot_dir:?}: {e}"))
+}
+
+/// Verify that `snapshot_dir` is a direct child of `{app_data_dir}/backups/`.
+///
+/// Canonicalises both paths first so symlink-based escape attempts are
+/// rejected. Returns `Err` with a clear message on mismatch so the
+/// caller-side IPC can propagate it to the user (or log it for an audit
+/// trail). Returns `Ok(())` only when the snapshot's parent matches the
+/// backups root byte-for-byte after canonicalisation.
+///
+/// #939 — closes the arbitrary-path-write/delete vulnerability where a
+/// subverted WebView could pass any path into `restore_from_backup` /
+/// `delete_backup` and the backend would trust it.
+fn assert_snapshot_under_backups_root(app: &AppHandle, snapshot_dir: &Path) -> Result<(), String> {
+    let canonical_snapshot_parent = snapshot_dir
+        .parent()
+        .ok_or_else(|| "Snapshot path has no parent directory".to_string())?
+        .canonicalize()
+        .map_err(|e| format!("Failed to canonicalise snapshot parent: {e}"))?;
+
+    let canonical_backups_root = backups_root(app)
+        .canonicalize()
+        .map_err(|e| format!("Failed to canonicalise backups root: {e}"))?;
+
+    if canonical_snapshot_parent != canonical_backups_root {
+        return Err(format!(
+            "Snapshot path must live directly under {}/, not {}",
+            canonical_backups_root.display(),
+            canonical_snapshot_parent.display(),
+        ));
+    }
+    Ok(())
 }
 
 /// Trim the backups directory down to `keep` most-recent snapshots.


### PR DESCRIPTION
## Summary

Two surgical fixes per the user's "Option B + workflow guard fix" direction. Fixes alpha's security gap (3 audit-hardening files brought from main verbatim) and fixes the active alpha-release.yml automation bug (recursion guard too loose, suppressed PR #954 yesterday).

## Security cherry-pick to alpha (closes #938, #939, #940)

The 3 audit-hardening files from PR #947 (merged to main 2026-06-19 but never reached alpha due to the 39/676-commit divergence):

| File | Diff vs alpha | What it adds |
|---|---|---|
| \`src-tauri/src/commands/credentials.rs\` | +169 lines | \`ALLOWED_CREDENTIAL_KEYS = [\"musickit_private_key\"]\` allowlist on \`store_credential\` / \`get_credential\` / \`delete_credential\`; \`activate_dev_access\` 5/min rate limit; 5 regression-guard unit tests pinning the non-enumerable error contract |
| \`src-tauri/src/services/backup_service.rs\` | +49 lines | \`assert_snapshot_under_backups_root\` helper — canonicalises both sides, requires byte-for-byte parent equality, symlink-defended via \`canonicalize\` |
| \`src-tauri/src/commands/backup.rs\` | +7 lines | \`delete_backup\` signature extended to take \`&AppHandle\` so it can call the new helper |

**Why these are safe to bring verbatim**: the diffs are pure additions (alpha had no parallel evolution on these specific files). I diffed each carefully — \`backup_service.rs\` removes 1 line (the old \`delete_backup\` signature) and adds 49; \`backup.rs\` removes 2 lines and adds 7. Both surgical.

Verified post-merge:
- \`cargo check\` clean
- \`cargo test --lib commands::credentials\` → **6/6 pass** (5 new from #938 + 1 existing musickit_id_normalization)

## Recursion-guard tightening (refs #937)

PR #947 shipped this on all 3 channel-release workflows:

\`\`\`yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  !startsWith(github.event.head_commit.message, 'chore(alpha):')
\`\`\`

**Bug discovered 2026-06-21**: PR #954's squash-merge title was \`chore(alpha): combined housekeeping…\` — matched the loose \`startsWith\` and was silently suppressed. Alpha-release.yml didn't fire, alpha.26 didn't auto-cut.

**Fix**: require BOTH the prefix AND the version-suffix substring (\`-alpha.\`, \`-beta.\`, \`-rc.\`):

\`\`\`yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  !(startsWith(github.event.head_commit.message, 'chore(alpha): ') && contains(github.event.head_commit.message, '-alpha.'))
\`\`\`

A human commit subject like \`chore(alpha): combined housekeeping\` matches the prefix but lacks \`-alpha.\` so it passes through. A bot bump like \`chore(alpha): 1.11.0-alpha.26\` matches both so it's skipped. The space after the colon (\`'chore(alpha): '\`) also defends against typo edge-cases like \`chore(alpha):no-space\`.

Same shape applied to beta (\`-beta.\`) and release-candidate (\`-rc.\`). Inline comment in each file documents the incident.

YAML lint: 3/3 files valid.

## What's deliberately NOT in this PR

- **Full alpha↔main convergence** — 69-file conflict surface. Tracked separately; can be split into a multi-session merge OR left to the natural realign-alpha cycle after the next stable cut.
- **#951 console.debug, #952 milestone numbering + GAMDL audit docs** — these landed on main via PR #952 but are non-critical (some already redundant on alpha; milestone bug only existed on main). Worth bringing when bandwidth allows.
- **README, Project_Plan, version manifests** — version-bump conflicts are intrinsic to the alpha↔main divergence and best resolved at the next stable cut.

## Verification

- ✅ \`cargo check\` clean
- ✅ \`cargo test --lib commands::credentials\` → 6/6
- ✅ YAML lint on all 3 channel-release workflows
- ✅ All commits in this PR replay cleanly from alpha; no force-push needed
- ✅ Recursion guard now requires both prefix + version-suffix shape — verified against the actual PR #954 commit message that was incorrectly suppressed

## Test plan

- [ ] Cut a new alpha prerelease by pushing any non-bot commit to alpha. Verify alpha-release.yml FIRES (it should — the guard is now tight enough that only `chore(alpha): X.Y.Z-alpha.N` shape is suppressed).
- [ ] After the bot pushes \`chore(alpha): 1.11.0-alpha.27\` (the next bump), verify alpha-release.yml is SKIPPED (recursion break works).
- [ ] In devtools, run \`invoke('get_credential', { key: 'webplayer_developer_token' })\` — must error with the generic "Unknown credential key" message (allowlist enforced).
- [ ] In devtools, run \`invoke('restore_from_backup', { snapshot_path: '/tmp/attacker' })\` — must error with "must live directly under …/backups/" message.
- [ ] Open the dev-access modal and enter 6 wrong passphrases in rapid succession — 6th attempt should return \`false\` immediately without hashing (rate limit triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)