### PR TITLE
fix(artwork): animated cover art reliability — browser-grade HTTP headers on FFmpeg HLS + primary catalog call; expanded JSON path chain for square/portrait

### DIFF
--- a/src-tauri/src/services/animated_artwork_service.rs
+++ b/src-tauri/src/services/animated_artwork_service.rs
@@ -504,14 +504,43 @@ async fn download_hls_to_mp4(
     );
 
     // Run FFmpeg to download the HLS stream and remux to MP4.
-    // Flags:
-    //   -i {url}          -- input HLS stream
-    //   -c copy           -- copy streams without re-encoding (preserves HEVC quality)
+    //
+    // ### Browser-grade headers (added 2026-06-21 — reliability fix)
+    //
+    // Apple's motion-art CDN edges (`mvod-akamaized.itunes.apple.com`
+    // and friends) have tightened over the past year and now reject
+    // requests that lack browser-grade headers. FFmpeg's default
+    // User-Agent (`Lavf/<version>`) gets a 403 on either the master
+    // m3u8, a variant playlist, or a segment fetch — and from the
+    // user's point of view this manifests as "animated artwork
+    // doesn't work reliably" even when MeedyaDL successfully
+    // discovered the HLS URL from the catalog API.
+    //
+    // We pass the same `Origin` / `Referer` / `User-Agent` triple
+    // that the Apple Music web player sends. Mirrors the
+    // syllable-lyrics fix (#935/#936) but applied at the HLS layer.
+    //
+    // FFmpeg's `-headers` flag takes a `\r\n`-delimited blob; the
+    // trailing `\r\n` is mandatory or the last header line is
+    // silently dropped. `-user_agent` is a dedicated flag because
+    // FFmpeg would otherwise also append its default `Lavf` UA;
+    // the dedicated flag cleanly overrides.
+    //
+    // Other flags:
+    //   -i {url}             -- input HLS stream
+    //   -c copy              -- copy streams without re-encoding (preserves HEVC quality)
     //   -movflags +faststart -- move moov atom to start for faster playback
-    //   -y                -- overwrite output file if it exists
-    //   -loglevel warning -- suppress verbose output, only show warnings/errors
+    //   -y                   -- overwrite output file if it exists
+    //   -loglevel warning    -- suppress verbose output, only show warnings/errors
+    let browser_user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15";
+    let apple_music_headers = "Origin: https://music.apple.com\r\nReferer: https://music.apple.com/\r\n";
+
     let output = Command::new(&ffmpeg_bin)
         .args([
+            "-user_agent",
+            browser_user_agent,
+            "-headers",
+            apple_music_headers,
             "-i",
             m3u8_url,
             "-c",

--- a/src-tauri/src/services/apple_music_api.rs
+++ b/src-tauri/src/services/apple_music_api.rs
@@ -934,11 +934,31 @@ pub async fn fetch_album_metadata(
 
     log::debug!("Querying Apple Music API for album metadata: {url}");
 
+    // Browser-grade headers (added 2026-06-21).
+    //
+    // `Origin: https://music.apple.com` is the critical header for
+    // users on the web-player-extracted developer token tier. When
+    // absent, `amp-api.music.apple.com`'s edge silently strips the
+    // `editorialVideo` block from the response — so animated artwork
+    // URLs that DO exist for the album never reach MeedyaDL, and the
+    // activity log lies with "not offered by Apple Music".
+    //
+    // Adding the header is a no-op for users on full MusicKit
+    // credentials (Apple doesn't gate full-JWT responses on Origin)
+    // and a real fix for users on the web-player-token tier. The
+    // Referer + Safari User-Agent match what the web client sends,
+    // mirroring the syllable-lyrics fix (#935/#936) at the catalog
+    // layer.
     let client = crate::utils::http_client::build_simple(30)?;
     let response = client
         .get(&url)
         .header("Authorization", format!("Bearer {jwt}"))
-        .header("User-Agent", "meedyadl")
+        .header("Origin", "https://music.apple.com")
+        .header("Referer", "https://music.apple.com/")
+        .header(
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+        )
         .send()
         .await
         .map_err(|e| format!("Apple Music API request failed: {e}"))?;
@@ -1055,24 +1075,35 @@ pub async fn fetch_album_metadata(
         .and_then(|v| v.as_str())
         .map(std::string::ToString::to_string);
 
-    // Extract animated artwork HLS URLs from editorialVideo
+    // Extract animated artwork HLS URLs from editorialVideo.
+    //
+    // Priority chains follow the ITAM Enhancer userscript's canonical
+    // mapping (https://skriptey.github.io/Userscripts/ITAMenhancer/),
+    // which prefers the full-resolution `motion{Square,Tall}Video*` keys
+    // over the cropped `motionDetail*` keys we used to be the only
+    // probe for. Background: per the discovery audit (2026-06-21), a
+    // number of recent Apple Music releases ship the full-resolution
+    // variant under `motionSquareVideo1x1` / `motionTallVideo3x4`
+    // *only*; the legacy `motionDetailSquare` / `motionDetailTall`
+    // keys are absent, so the previous single-key extraction silently
+    // produced `None` and the activity log lied with "not offered by
+    // Apple Music" for albums that demonstrably have animated artwork.
+    //
+    // `extract_motion_url` also handles the localised/nested shape
+    // (`"video": { "url": "https://..." }`) that some non-US storefronts
+    // emit, since `as_str()` on an object silently returns None.
     let editorial_video = attributes.get("editorialVideo");
 
     let artwork_square_url = editorial_video
-        .and_then(|ev| ev.get("motionDetailSquare"))
-        .and_then(|m| m.get("video"))
-        .and_then(|v| v.as_str())
-        .map(std::string::ToString::to_string);
+        .and_then(|ev| extract_motion_url_chain(ev, &["motionSquareVideo1x1", "motionDetailSquare"]));
 
     let artwork_tall_url = editorial_video
-        .and_then(|ev| ev.get("motionDetailTall"))
-        .and_then(|m| m.get("video"))
-        .and_then(|v| v.as_str())
-        .map(std::string::ToString::to_string);
+        .and_then(|ev| extract_motion_url_chain(ev, &["motionTallVideo3x4", "motionDetailTall"]));
 
     // #538: Album-level 16:9 editorial spotlight video. The same
-    // `editorialVideo` block can carry both portrait (`motionDetailTall`)
-    // and wide (`motionArtistFullscreen16x9` / `motionArtistWide16x9`)
+    // `editorialVideo` block can carry both portrait
+    // (`motionTallVideo3x4` / `motionDetailTall`) and wide
+    // (`motionArtistFullscreen16x9` / `motionArtistWide16x9`)
     // variants; the wide variants are album-cinematic teasers
     // distinct from the static album cover. Priority matches the
     // artist-spotlight code path (#455 / #538): prefer
@@ -1081,14 +1112,9 @@ pub async fn fetch_album_metadata(
     // already covered by `artwork_square_url`/`artwork_tall_url`
     // and intentionally excluded — they're tightly cropped around
     // the cover and would look wrong as a 16:9 spotlight.
-    let album_spotlight_url = editorial_video
-        .and_then(|ev| {
-            ev.get("motionArtistFullscreen16x9")
-                .or_else(|| ev.get("motionArtistWide16x9"))
-        })
-        .and_then(|m| m.get("video"))
-        .and_then(|v| v.as_str())
-        .map(std::string::ToString::to_string);
+    let album_spotlight_url = editorial_video.and_then(|ev| {
+        extract_motion_url_chain(ev, &["motionArtistFullscreen16x9", "motionArtistWide16x9"])
+    });
 
     // Static cover artwork (#756). The `artwork.url` is a template
     // with `{w}`, `{h}`, `{f}` placeholders we can substitute when
@@ -1146,6 +1172,44 @@ pub async fn fetch_album_metadata(
         artwork_height,
         raw_json: album_data.clone(),
     }))
+}
+
+/// Extract the HLS master-playlist URL from one motion key inside an
+/// `editorialVideo` block. Two shapes observed in the wild:
+///
+/// - `"motionDetailSquare": { "video": "https://.../master.m3u8" }` —
+///   string-valued `video`, the legacy and still-most-common shape
+/// - `"motionDetailSquare": { "video": { "url": "https://.../master.m3u8" } }` —
+///   nested-object shape on some recent / localised storefronts
+///
+/// The legacy single-key extraction (`.as_str()` on `video`) silently
+/// returned `None` for the nested shape, leading the activity log to
+/// emit "not offered by Apple Music" for albums that *did* have
+/// animated artwork in that variant. Returns `None` when the key is
+/// missing OR when neither shape yields a string URL.
+fn extract_motion_url(motion_block: Option<&serde_json::Value>) -> Option<String> {
+    let video = motion_block?.get("video")?;
+    if let Some(s) = video.as_str() {
+        return Some(s.to_string());
+    }
+    video
+        .get("url")
+        .and_then(|v| v.as_str())
+        .map(std::string::ToString::to_string)
+}
+
+/// Try each key in `priority_chain` in order against `editorial_video`,
+/// returning the first non-empty HLS URL. Used by the album-metadata
+/// parser for square / portrait / spotlight variants. Mirrors ITAM
+/// Enhancer's `pick(...)` helper — keys are tried left-to-right so the
+/// highest-quality variant we recognise wins.
+fn extract_motion_url_chain(
+    editorial_video: &serde_json::Value,
+    priority_chain: &[&str],
+) -> Option<String> {
+    priority_chain
+        .iter()
+        .find_map(|key| extract_motion_url(editorial_video.get(*key)))
 }
 
 /// Parse track metadata from the album API response's relationships.tracks field.
@@ -2916,6 +2980,133 @@ pub async fn fetch_artist_promo_video(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----------------------------------------------------------
+    // Animated artwork JSON path extraction (2026-06-21)
+    //
+    // Pins the ITAM-Enhancer-priority chain and the nested-shape
+    // tolerance so a future Apple API shape change is caught
+    // immediately by CI rather than silently emitting "not offered".
+    // ----------------------------------------------------------
+
+    fn json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).expect("test JSON must parse")
+    }
+
+    #[test]
+    fn extract_motion_url_handles_string_video_shape() {
+        let block = json(r#"{"video": "https://example.com/master.m3u8"}"#);
+        assert_eq!(
+            extract_motion_url(Some(&block)).as_deref(),
+            Some("https://example.com/master.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_handles_nested_video_url_shape() {
+        let block = json(r#"{"video": {"url": "https://example.com/nested.m3u8"}}"#);
+        assert_eq!(
+            extract_motion_url(Some(&block)).as_deref(),
+            Some("https://example.com/nested.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_returns_none_when_video_missing() {
+        let block = json(r#"{"other": "field"}"#);
+        assert!(extract_motion_url(Some(&block)).is_none());
+    }
+
+    #[test]
+    fn extract_motion_url_returns_none_for_none_input() {
+        assert!(extract_motion_url(None).is_none());
+    }
+
+    #[test]
+    fn extract_motion_url_chain_prefers_first_key() {
+        // ITAM Enhancer prefers motionSquareVideo1x1 over motionDetailSquare;
+        // when both exist the chain must return the preferred one.
+        let ev = json(
+            r#"{
+                "motionSquareVideo1x1": {"video": "https://preferred.com/m.m3u8"},
+                "motionDetailSquare":   {"video": "https://legacy.com/m.m3u8"}
+            }"#,
+        );
+        assert_eq!(
+            extract_motion_url_chain(&ev, &["motionSquareVideo1x1", "motionDetailSquare"])
+                .as_deref(),
+            Some("https://preferred.com/m.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_chain_falls_through_to_legacy_key() {
+        // Real-world case: album only exposes motionDetailSquare.
+        // Previous single-key extraction would have worked for this case
+        // but missed the inverse (only motionSquareVideo1x1 present, see
+        // below). The chain must handle both.
+        let ev = json(
+            r#"{"motionDetailSquare": {"video": "https://legacy.com/m.m3u8"}}"#,
+        );
+        assert_eq!(
+            extract_motion_url_chain(&ev, &["motionSquareVideo1x1", "motionDetailSquare"])
+                .as_deref(),
+            Some("https://legacy.com/m.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_chain_finds_preferred_only_key() {
+        // The bug this fix addresses: recent releases sometimes ONLY
+        // ship motionSquareVideo1x1 / motionTallVideo3x4. The legacy
+        // single-key extractor silently returned None for these.
+        let ev = json(
+            r#"{"motionSquareVideo1x1": {"video": "https://only-preferred.com/m.m3u8"}}"#,
+        );
+        assert_eq!(
+            extract_motion_url_chain(&ev, &["motionSquareVideo1x1", "motionDetailSquare"])
+                .as_deref(),
+            Some("https://only-preferred.com/m.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_chain_returns_none_when_all_keys_absent() {
+        let ev = json(r#"{"someOtherKey": {"video": "x"}}"#);
+        assert!(
+            extract_motion_url_chain(&ev, &["motionSquareVideo1x1", "motionDetailSquare"])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_chain_skips_keys_with_missing_video_field() {
+        // Defensive: a key exists but `.video` is absent — chain should
+        // continue to the next candidate rather than short-circuit.
+        let ev = json(
+            r#"{
+                "motionSquareVideo1x1": {"unrelated": "field"},
+                "motionDetailSquare":   {"video": "https://fallback.com/m.m3u8"}
+            }"#,
+        );
+        assert_eq!(
+            extract_motion_url_chain(&ev, &["motionSquareVideo1x1", "motionDetailSquare"])
+                .as_deref(),
+            Some("https://fallback.com/m.m3u8")
+        );
+    }
+
+    #[test]
+    fn extract_motion_url_chain_portrait_chain_matches_square_shape() {
+        // Symmetry check: portrait uses the same two-key pattern.
+        let ev = json(
+            r#"{"motionTallVideo3x4": {"video": "https://portrait.com/m.m3u8"}}"#,
+        );
+        assert_eq!(
+            extract_motion_url_chain(&ev, &["motionTallVideo3x4", "motionDetailTall"]).as_deref(),
+            Some("https://portrait.com/m.m3u8")
+        );
+    }
 
     // ----------------------------------------------------------
     // Storefront-rewrite tests (#666)


### PR DESCRIPTION
## Summary

Three targeted fixes for the "animated cover art doesn't work reliably" report. A background discovery workflow (`w41okd8v1`) identified **seven compounding root causes**; this PR addresses the top three that affect users on full MusicKit credentials — the most reproducible failure category for the reporter.

## The fixes

### 1. Browser-grade headers on the FFmpeg HLS download

Apple's motion-art CDN edges (`mvod-akamaized.itunes.apple.com`) have tightened and now reject requests lacking browser-grade headers. FFmpeg's default `User-Agent: Lavf/<version>` gets 403 on either the master m3u8, variant playlist, or a segment fetch — even when MeedyaDL correctly discovered the HLS URL from the catalog API. Fix: pass `Origin: https://music.apple.com` + `Referer` + Safari `User-Agent` via FFmpeg's `-headers` + `-user_agent` flags.

### 2. Expanded JSON path chain for square + portrait keys

Legacy single-key extraction (`editorialVideo.motionDetailSquare.video` / `motionDetailTall.video`) silently misses two shapes:

- **Preferred keys**: recent Apple Music releases ship the full-resolution animated artwork **only** under `motionSquareVideo1x1` / `motionTallVideo3x4` (ITAM Enhancer's canonical priority) — legacy keys absent
- **Nested `.video.url` shape**: some localised storefronts wrap the URL as `{"video": {"url": "..."}}` instead of `{"video": "..."}`

Fix: two new helpers `extract_motion_url` + `extract_motion_url_chain` handle both shapes, try preferred keys first, fall back to legacy. **Filenames preserved** — MeedyaDL keeps `FrontCover.mp4` / `FrontCoverPortrait.mp4` / `AlbumSpotlightCover.mp4` per user direction; ITAM Enhancer's `_squarecover` naming NOT adopted.

### 3. (Bonus) Browser-grade headers on the primary catalog API call

For users on the web-player-extracted developer token tier, `amp-api.music.apple.com` silently strips `editorialVideo` from responses when `Origin` header is absent. So even Fix 2's expanded key chain would come up empty for those users. No-op for full MusicKit credentials, real fix for web-player-token tier.

## Not in this PR (deferred to follow-up issue)

Discovery found four additional root causes — better as separate work:

- New `fetch_animated_artwork_fallback` (belt-and-braces amp-api fallback path) + `animated_artwork_fallback_enabled` setting
- Distinct activity-log "unavailable" lines (replace generic "not offered by Apple Music" with three specific reasons)
- Linux dot-rename hide fix (`FrontCover.mp4` → `.FrontCover.mp4` breaks Plex/Infuse/Jellyfin lookup)
- Storefront geo-lock warnings (surface when metadata came from fallback storefront)

## Tests

**10 new unit tests in `apple_music_api::tests`** pinning the JSON path extraction contract — all pass locally.

## Verification

- ✅ `cargo test --lib services::apple_music_api::tests::extract_motion` → 10/10 pass
- ✅ `cargo check` clean
- ✅ Filenames verified unchanged (`FrontCover.mp4`, `FrontCoverPortrait.mp4`, `AlbumSpotlightCover.mp4`)

## Test plan

- [ ] Download an album with animated artwork you've previously seen fail. Verify `FrontCover.mp4` and (if the album has it) `FrontCoverPortrait.mp4` land in the album folder at > 0 bytes.
- [ ] Check activity log — should see "Animated artwork: square downloaded (N MB → FrontCover.mp4)" instead of "square not offered by Apple Music" for albums that DO have animated art.
- [ ] Download an album with NO animated artwork. Verify the log still shows "not offered" for both variants (regression check).
- [ ] If you have a friend on the web-player token tier (no MusicKit creds), have them download the same album — should also see success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)