### PR TITLE
fix(ci): channel-release supply-chain hardening — lockfile pin (#995) + bundled-engine pin/integrity (#984)

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -143,9 +143,26 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Regenerate Cargo.lock
+      - name: Sync Cargo.lock to bumped version (#995)
+        # `cargo generate-lockfile` fully re-resolves EVERY dependency to
+        # the newest semver-compatible version on the registry, including
+        # the unpinned `meedya-fingerprint`/`meedya-lyrics` git deps
+        # (branch = "main"). That means the tag we're about to build could
+        # ship crate versions that never ran through CI's `cargo test` /
+        # `cargo clippy` / `cargo-deny` gates on this exact combination —
+        # supply-chain drift introduced solely by the version-bump step.
+        #
+        # `cargo update --package meedyadl` re-resolves ONLY the local
+        # `meedyadl` package's own lockfile entry (its version, matching
+        # the Cargo.toml just patched above) and leaves every other
+        # dependency — including the git deps — exactly as CI validated
+        # them. No network access is required: the local package's
+        # manifest is read from disk, so this works even if a runner has
+        # no route to crates.io or the git remotes.
         working-directory: src-tauri
-        run: cargo generate-lockfile
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: cargo update --package meedyadl --precise "$NEW_VERSION"
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -119,9 +119,17 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Regenerate Cargo.lock
+      - name: Sync Cargo.lock to bumped version (#995)
+        # See alpha-release.yml's matching step for the full rationale:
+        # `cargo generate-lockfile` re-resolves ALL dependencies (including
+        # the unpinned `meedya-fingerprint`/`meedya-lyrics` git deps) to
+        # newest-compatible, shipping untested crate versions on the tag.
+        # `cargo update --package meedyadl` touches only the local
+        # `meedyadl` package's own lockfile entry, offline-safe.
         working-directory: src-tauri
-        run: cargo generate-lockfile
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: cargo update --package meedyadl --precise "$NEW_VERSION"
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/release-candidate-release.yml
+++ b/.github/workflows/release-candidate-release.yml
@@ -128,9 +128,17 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Regenerate Cargo.lock
+      - name: Sync Cargo.lock to bumped version (#995)
+        # See alpha-release.yml's matching step for the full rationale:
+        # `cargo generate-lockfile` re-resolves ALL dependencies (including
+        # the unpinned `meedya-fingerprint`/`meedya-lyrics` git deps) to
+        # newest-compatible, shipping untested crate versions on the tag.
+        # `cargo update --package meedyadl` touches only the local
+        # `meedyadl` package's own lockfile entry, offline-safe.
         working-directory: src-tauri
-        run: cargo generate-lockfile
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: cargo update --package meedyadl --precise "$NEW_VERSION"
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -801,15 +801,36 @@ jobs:
           # --- Install pip engines ---
           # Parse engines.toml for bundled+enabled pip packages.
           # Uses Python (available on all runners) to parse TOML.
+          #
+          # Bare package names (e.g. "gamdl") resolve to PyPI *latest* on
+          # `pip install`, which bypasses the runtime support-window
+          # ceiling that `install_gamdl()` / `gamdl_capabilities::
+          # pip_version_spec()` enforce at runtime (`gamdl>={minimum_version},
+          # <={maximum_tested_version}` from tool-versions.toml's [gamdl]
+          # section). Without this, the offline installer could bundle an
+          # above-ceiling, untested GAMDL release the app itself would only
+          # ever install via the explicit opt-in "Untested" upgrade flow —
+          # #984. Only `gamdl` is pinned this way; other bundled pip
+          # engines (e.g. votify) are intentionally left unpinned unless
+          # tool-versions.toml grows a matching section for them too.
           PIP_PACKAGES=$(python3 -c "
           import tomllib, sys
           with open('src-tauri/engines.toml', 'rb') as f:
               data = tomllib.load(f)
-          pkgs = [
-              e.get('pip_package', '')
-              for e in data.get('engines', {}).values()
-              if e.get('bundled') and e.get('enabled') and e.get('install_method') == 'pip' and e.get('pip_package')
-          ]
+          with open('src-tauri/tool-versions.toml', 'rb') as f:
+              tool_versions = tomllib.load(f)
+          gamdl_min = tool_versions.get('gamdl', {}).get('minimum_version')
+          gamdl_max = tool_versions.get('gamdl', {}).get('maximum_tested_version')
+          pkgs = []
+          for e in data.get('engines', {}).values():
+              if not (e.get('bundled') and e.get('enabled') and e.get('install_method') == 'pip' and e.get('pip_package')):
+                  continue
+              pkg = e['pip_package']
+              # Mirror gamdl_capabilities::pip_version_spec() — pin gamdl to
+              # the tested support window instead of shipping PyPI latest.
+              if pkg == 'gamdl' and gamdl_min and gamdl_max:
+                  pkg = f'gamdl>={gamdl_min},<={gamdl_max}'
+              pkgs.append(pkg)
           print(' '.join(pkgs))
           ")
 
@@ -861,10 +882,33 @@ jobs:
               echo "Downloading $tool from mirror: $ASSET_URL"
               TOOL_DIR="$DEPS_DIR/tools/$tool"
               mkdir -p "$TOOL_DIR"
-              curl -sL "$ASSET_URL" -o "/tmp/${tool}.${EXT}"
+              # TODO(#984): verify a published checksum (e.g. checksums.txt
+              # or a per-asset *.sha256) once the MeedyaDL-Tools mirror
+              # publishes one — this repo's release process is out of
+              # scope for this change. Until then, `-f` makes curl fail
+              # loudly on HTTP errors (was previously silent — a 404
+              # response body would get written to disk and only fail
+              # later, confusingly, at the tar/unzip step) and the
+              # explicit non-empty + archive-integrity checks below are a
+              # fail-safe against a truncated/corrupt download from the
+              # mutable `latest` tag, though neither substitutes for real
+              # integrity verification against a signed/known-good hash.
+              curl -fsSL "$ASSET_URL" -o "/tmp/${tool}.${EXT}"
+              if [ ! -s "/tmp/${tool}.${EXT}" ]; then
+                echo "::error::Downloaded archive for $tool is empty ($ASSET_URL)"
+                exit 1
+              fi
               if [ "$EXT" = "zip" ]; then
+                if ! unzip -tqq "/tmp/${tool}.${EXT}" >/dev/null; then
+                  echo "::error::Downloaded archive for $tool is not a valid zip ($ASSET_URL)"
+                  exit 1
+                fi
                 unzip -qo "/tmp/${tool}.${EXT}" -d "$TOOL_DIR"
               else
+                if ! tar -tzf "/tmp/${tool}.${EXT}" >/dev/null; then
+                  echo "::error::Downloaded archive for $tool is not a valid tar.gz ($ASSET_URL)"
+                  exit 1
+                fi
                 tar -xzf "/tmp/${tool}.${EXT}" -C "$TOOL_DIR"
               fi
               rm -f "/tmp/${tool}.${EXT}"


### PR DESCRIPTION
Closes #995. Partially addresses #984 (see deferral).

## #995 — channel builds no longer ship untested dependency versions
The alpha/beta/rc release workflows ran `cargo generate-lockfile`, which **fully re-resolves every dependency** on each build — so tags compiled against the newest semver-compatible crates (and unpinned `meedya-*` git deps), not the CI-validated `Cargo.lock`. Replaced with **`cargo update --package meedyadl --precise "$NEW_VERSION"`** (reusing the existing `steps.version.outputs.version`), which updates *only* the local package's lock entry.

**Verified locally:** bumped `Cargo.toml` in a scratch copy and diffed `Cargo.lock` — exactly one line moves (the `meedyadl` version); no other crate versions change; runs fully offline.

## #984 — offline-installer engine pinning + download integrity
- **(a) gamdl pin (done):** the `bundle_engines=true` pip step now parses `tool-versions.toml [gamdl]` and emits **`gamdl>={min},<={max}`** (currently `gamdl>=3.0,<=3.8.4`) — matching the runtime `pip_version_spec()` ceiling, so the signed offline installer can no longer bake in an Untested GAMDL. votify stays unpinned (no tool-versions entry).
- **(b) mirror integrity (partial + deferred):** hardened the mirror-tool `curl` from `-sL` → **`curl -fsSL`** (fails on HTTP errors instead of writing a 404 page to disk) and added **archive-integrity checks** (`unzip -tqq` / `tar -tzf`) that fail the build on a corrupt download. Full `sha256sum -c` verification is **deferred** — it requires the mirror repo (`MeedyaDL-Tools`) to publish a `checksums.txt`, which is a cross-repo change out of this session's scope. Left a `# TODO(#984)` at the site. **#984 stays open** for that piece.

## Verification
`yaml.safe_load` passes on all 4 workflows; `actionlint` v1.7.7 → exit 0; diff scoped to the targeted steps only. (Release workflows can't execute here — reviewed for correctness + linted.)

_Note surfaced during this work:_ CLAUDE.md references the mirror repo as both `MWBMPartners/MeedyaDL-Tools` and `MeedyaSuite/MeedyaDL-Tools` — worth reconciling (folding into the docs-refresh task).

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_