### PR TITLE
fix(ci): resolve main's CI-rot (js-yaml audit + clippy-1.97 lint) — unblocks #1037

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,16 +3710,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4731,9 +4731,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -5461,9 +5461,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -7225,7 +7225,7 @@ pub fn process_queue(
             &download_id,
             &format!(
                 "URLs: {:?} | Codec: {} | Native priority: {}",
-                &urls,
+                urls,
                 primary_codec_for_companions,
                 download_options.song_codec_priority.is_some()
             ),


### PR DESCRIPTION
## Why

`main` (dormant since 2026-07-06) fails CI purely from **toolchain/advisory drift**, not from any code change — which is what shows the 6 red checks on Dependabot PR #1037 (the brace-expansion bump inherits main's red CI). Two rot classes, both fixed here (mechanically, no behaviour change):

1. **Frontend — `npm audit --audit-level=high`**: `npm audit fix` (lockfile-only) bumps `js-yaml` 4.2.0→4.3.0 (GHSA-52cp-r559-cp3m), `brace-expansion` 5.0.6→5.0.8, `fast-uri` 3.1.2→3.1.4. No `package.json` change. `npm audit --audit-level=high` → 0 vulnerabilities.
2. **Backend — `cargo clippy -- -D warnings`**: `useless_borrows_in_formatting` at `download_queue.rs:7228` (`&urls` → `urls`). The lint got stricter in clippy 1.97 (CI uses `dtolnay/rust-toolchain@stable` = latest), newly flagging positional `{:?}` args. The agent installed clippy 1.97.1 to reproduce the *exact* CI error and confirm the fix.

## Verification (with rustc/clippy 1.97.1)
- `npm audit --audit-level=high` → exit 0
- `cargo clippy -- -D warnings` → exit 0 (verified after a clean rebuild)
- `cargo test --lib` → **1206 passed, 0 failed**
- `npm run type-check` → clean

## Relationship to #1037 / the realignment
These are the same two rot classes already fixed on `alpha` this session (F12/F13). This is a **targeted** main fix so #1037 goes green now; the full set of alpha's improvements reaches main later via the human-led Phase-4 promotion (#1040). After this merges, #1037's CI (rebased on the fixed `main`) should go green — it can then be merged or closed (its brace-expansion bump is already superseded by this PR's `5.0.8`).

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_