### PR TITLE
feat(app)!: bundle id → com.meedyasuite.meedyadl + migration shim + release-notes guard fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1678,8 +1678,11 @@ jobs:
           # present (because the guide check comes BEFORE the cleanup
           # write in the legacy flow). Set a flag the post-cleanup
           # branch reads.
+          # Anchored for the same reason as the verify step below: prose
+          # that merely mentions the placeholder must not trigger a
+          # spurious cleanup-write.
           if gh release view "$TAG" --repo "$REPO" --json body --jq '.body' \
-            | grep -q "Release in progress"; then
+            | grep -qE "^Release in progress"; then
             NEEDS_PLACEHOLDER_CLEANUP="1"
           else
             NEEDS_PLACEHOLDER_CLEANUP="0"
@@ -1794,7 +1797,15 @@ jobs:
             echo "::warning::Could not fetch release body for $TAG — skipping placeholder check"
             exit 0
           fi
-          if echo "$BODY" | grep -q "Release in progress"; then
+          # Anchored to line-start to MATCH the strip regex above
+          # (`re.sub(r'(?m)^Release in progress…')`). An unanchored grep
+          # false-positives on legitimate notes content that merely
+          # *mentions* the placeholder — e.g. a changelog entry for the
+          # #1046 self-heal work — which failed the whole release job and
+          # left the draft unpublished (v1.12.0-alpha.36). The real
+          # placeholder is always its own line, so anchoring is both
+          # correct and sufficient.
+          if echo "$BODY" | grep -qE "^Release in progress"; then
             echo "::error::Release body for $TAG still contains the 'Release in progress' placeholder."
             echo "::error::This is the #857 / PR #741 regression — the strip-and-replace logic in finalize-release is not catching every race."
             echo "::error::Recover with: gh release edit $TAG --repo $REPO --notes-file /path/to/proper-notes.md"

--- a/help/troubleshooting.md
+++ b/help/troubleshooting.md
@@ -319,9 +319,9 @@ The application crashes immediately on startup, and macOS shows a dialog asking 
 
   | Platform | Path |
   | --- | --- |
-  | macOS | `~/Library/Application Support/io.github.meedyadl/queue.json` |
-  | Windows | `%APPDATA%/io.github.meedyadl/queue.json` |
-  | Linux | `~/.local/share/io.github.meedyadl/queue.json` |
+  | macOS | `~/Library/Application Support/com.meedyasuite.meedyadl/queue.json` |
+  | Windows | `%APPDATA%/com.meedyasuite.meedyadl/queue.json` |
+  | Linux | `~/.local/share/com.meedyasuite.meedyadl/queue.json` |
 
   Deleting this file clears any queued or failed downloads from the previous session but does not affect your settings, cookies, or already-downloaded files.
 
@@ -358,9 +358,9 @@ Changes to settings are not persisted between application restarts.
 
   | Platform | Settings Directory |
   | --- | --- |
-  | macOS | `~/Library/Application Support/io.github.meedyadl/` |
-  | Windows | `%APPDATA%/io.github.meedyadl/` |
-  | Linux | `~/.local/share/io.github.meedyadl/` |
+  | macOS | `~/Library/Application Support/com.meedyasuite.meedyadl/` |
+  | Windows | `%APPDATA%/com.meedyasuite.meedyadl/` |
+  | Linux | `~/.local/share/com.meedyasuite.meedyadl/` |
 
   If fixing permissions does not help, try deleting the `settings.json` file in that directory to reset all settings to their defaults. MeedyaDL will recreate the file on next launch.
 
@@ -469,9 +469,9 @@ The default `logs/` directory:
 
 | Platform | Log File Location |
 | --- | --- |
-| macOS | `~/Library/Application Support/io.github.meedyadl/logs/` |
-| Windows | `%APPDATA%/io.github.meedyadl/logs/` |
-| Linux | `~/.local/share/io.github.meedyadl/logs/` |
+| macOS | `~/Library/Application Support/com.meedyasuite.meedyadl/logs/` |
+| Windows | `%APPDATA%/com.meedyasuite.meedyadl/logs/` |
+| Linux | `~/.local/share/com.meedyasuite.meedyadl/logs/` |
 
 You can override the location of `activity-*.log` files via **Settings > Advanced > Diagnostics > On-disk activity log location** — useful for pointing logs at an external drive. The `meedyadl.*` tracing logs and `session-*` files always live in the default directory.
 
@@ -543,9 +543,9 @@ When MeedyaDL encounters a crash (Rust panic) or an unhandled frontend error, it
 
 | Platform | Crash Report Directory |
 | --- | --- |
-| macOS | `~/Library/Application Support/io.github.meedyadl/crashes/` |
-| Windows | `%APPDATA%/io.github.meedyadl/crashes/` |
-| Linux | `~/.local/share/io.github.meedyadl/crashes/` |
+| macOS | `~/Library/Application Support/com.meedyasuite.meedyadl/crashes/` |
+| Windows | `%APPDATA%/com.meedyasuite.meedyadl/crashes/` |
+| Linux | `~/.local/share/com.meedyasuite.meedyadl/crashes/` |
 
 Crash reports are named `crash-YYYYMMDD-HHMMSS.json` and are automatically cleaned up after 30 days.
 

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -48,11 +48,21 @@ use crate::context_err;
 /// - **account** = the `key` parameter passed to each command
 ///
 /// This means credentials appear in Keychain Access (macOS) as:
-///   Service: "io.github.meedyadl"
+///   Service: "com.meedyasuite.meedyadl"
 ///   Account: "`wrapper_url`" (or whatever key was used)
 ///
+/// **Not** derived from `tauri.conf.json`'s `identifier` field at compile
+/// time -- this has always been a manually-maintained value that
+/// historically just happened to equal the bundle identifier. Points at
+/// `crate::utils::platform::CURRENT_BUNDLE_IDENTIFIER` (shared with
+/// `services::apple_music_api::SERVICE_NAME`) rather than duplicating the
+/// literal. Entries written under the OLD value
+/// (`crate::utils::platform::OLD_BUNDLE_IDENTIFIER`) before the
+/// 2026-07-24 rename are migrated forward by `services::bundle_migration`
+/// on first launch -- see that module for the full account list.
+///
 /// See: <https://docs.rs/keyring/latest/keyring/struct.Entry.html>
-const SERVICE_NAME: &str = "io.github.meedyadl";
+const SERVICE_NAME: &str = crate::utils::platform::CURRENT_BUNDLE_IDENTIFIER;
 
 /// Keychain accounts the universal `store_credential` / `get_credential` /
 /// `delete_credential` IPCs are allowed to touch.

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -111,9 +111,9 @@ pub fn get_platform_info() -> PlatformInfo {
 ///
 /// This is the self-contained directory where Python, GAMDL, tools,
 /// and settings are stored. The path varies by platform:
-/// - macOS: `~/Library/Application Support/io.github.meedyadl/`
-/// - Windows: `%APPDATA%/io.github.meedyadl/`
-/// - Linux: `~/.local/share/io.github.meedyadl/`
+/// - macOS: `~/Library/Application Support/com.meedyasuite.meedyadl/`
+/// - Windows: `%APPDATA%/com.meedyasuite.meedyadl/`
+/// - Linux: `~/.local/share/com.meedyasuite.meedyadl/`
 ///
 /// The frontend uses this path for:
 /// - Displaying the data directory location in the settings page

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,11 +92,11 @@ pub mod utils;
 fn setup_tracing(sentry_enabled: bool) -> tracing_appender::non_blocking::WorkerGuard {
     use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-    // Determine the log directory. Use the platform app data dir if available,
-    // otherwise fall back to the OS temp dir.
-    let log_dir = dirs::data_dir()
-        .map(|d| d.join("io.github.meedyadl").join("logs"))
-        .unwrap_or_else(|| std::env::temp_dir().join("MeedyaDL").join("logs"));
+    // Determine the log directory. `resolve_early_app_data_root()` is
+    // infallible (falls back to the OS temp dir internally) and also
+    // handles the bundle-identifier-rename transition window -- see its
+    // doc comment in `utils/platform.rs`.
+    let log_dir = utils::platform::resolve_early_app_data_root().join("logs");
 
     // Ensure the log directory exists
     let _ = std::fs::create_dir_all(&log_dir);
@@ -306,10 +306,14 @@ fn setup_panic_handler() {
             "context": {}
         });
 
-        // Write the crash report to disk
-        let crash_dir = dirs::data_dir()
-            .map(|d| d.join("io.github.meedyadl").join("crashes"))
-            .unwrap_or_else(|| std::env::temp_dir().join("MeedyaDL").join("crashes"));
+        // Write the crash report to disk. `resolve_early_app_data_root()`
+        // is infallible and transition-aware -- see its doc comment in
+        // `utils/platform.rs`. The panic hook is installed before Tauri
+        // init and can also fire much later, so this stays correct across
+        // the whole app lifetime (post-migration it always resolves to the
+        // current identifier's directory, since that will have a
+        // `settings.json` by then).
+        let crash_dir = utils::platform::resolve_early_app_data_root().join("crashes");
 
         if std::fs::create_dir_all(&crash_dir).is_ok() {
             let filename = format!("crash-{}.json", chrono::Utc::now().format("%Y%m%d-%H%M%S"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1429,6 +1429,28 @@ pub fn run() {
                 log::info!("App data directory: {}", app_data_dir.display());
             }
 
+            // One-time migration from the pre-2026-07-24 bundle identifier
+            // (`io.github.meedyadl` -> `com.meedyasuite.meedyadl`). MUST run
+            // here -- as early as possible in `.setup()`, immediately after
+            // the new app data directory is created above, and BEFORE
+            // anything below reads `settings.json` / `queue.json` /
+            // `history.json` from it (queue recovery, activity log dir
+            // resolution, the download index first-startup ingest, etc. all
+            // happen later in this closure). Copies legacy data + keychain
+            // entries forward; see `services::bundle_migration` for the
+            // full non-destructive, idempotent design.
+            let migration_summary = services::bundle_migration::run(&app_data_dir);
+            if !migration_summary.is_empty() {
+                utils::activity_log::emit_app_log(
+                    app.handle(),
+                    &format!(
+                        "First-launch migration from legacy app identifier '{}': {}",
+                        utils::platform::OLD_BUNDLE_IDENTIFIER,
+                        migration_summary.join("; ")
+                    ),
+                );
+            }
+
             // Set up the system tray icon with context menu and event handlers.
             // The `_tray` binding keeps the TrayIcon alive for the app's lifetime;
             // dropping it would remove the icon from the system tray.

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -9,9 +9,9 @@
 // ## Persistence
 //
 // The settings file is stored at:
-//   - macOS:   ~/Library/Application Support/io.github.meedyadl/settings.json
-//   - Windows: %APPDATA%/io.github.meedyadl/settings.json
-//   - Linux:   ~/.config/io.github.meedyadl/settings.json
+//   - macOS:   ~/Library/Application Support/com.meedyasuite.meedyadl/settings.json
+//   - Windows: %APPDATA%/com.meedyasuite.meedyadl/settings.json
+//   - Linux:   ~/.local/share/com.meedyasuite.meedyadl/settings.json
 //
 // The `commands/settings.rs` Tauri commands handle loading and saving this
 // file. On first launch (or when the file is missing/corrupt), `Default::default()`

--- a/src-tauri/src/services/apple_music_api.rs
+++ b/src-tauri/src/services/apple_music_api.rs
@@ -52,7 +52,17 @@ pub const MEDIA_USER_TOKEN_COOKIE_NAME: &str = "media-user-token";
 const WEBPLAYER_TOKEN_KEYCHAIN_KEY: &str = "webplayer_developer_token";
 
 /// Keychain service name (shared with `credentials.rs`).
-const SERVICE_NAME: &str = "io.github.meedyadl";
+///
+/// **Not** derived from `tauri.conf.json`'s `identifier` field at compile
+/// time -- this has always been a manually-maintained value that
+/// historically just happened to equal the bundle identifier. Points at
+/// `crate::utils::platform::CURRENT_BUNDLE_IDENTIFIER` (rather than
+/// duplicating the literal) so there is exactly one place to update if the
+/// bundle identifier ever changes again. Entries written under the OLD
+/// value (`crate::utils::platform::OLD_BUNDLE_IDENTIFIER`) before the
+/// 2026-07-24 rename are migrated forward by `services::bundle_migration`
+/// on first launch -- see that module for the full account list.
+const SERVICE_NAME: &str = crate::utils::platform::CURRENT_BUNDLE_IDENTIFIER;
 
 /// Browser-grade User-Agent used for Apple Music catalog / amp-api requests
 /// that ride the web-player developer-token tier. Apple's edges
@@ -731,7 +741,7 @@ pub fn has_embedded_musickit_developer_token() -> bool {
 ///
 /// Uses the `keyring` crate with the same service name as the rest of
 /// `MeedyaDL`'s credential system. The key is stored under:
-///   Service: "io.github.meedyadl"
+///   Service: "com.meedyasuite.meedyadl"
 ///   Account: "`musickit_private_key`"
 ///
 /// # Errors

--- a/src-tauri/src/services/bundle_migration.rs
+++ b/src-tauri/src/services/bundle_migration.rs
@@ -1,0 +1,607 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// First-launch migration from the pre-2026-07-24 bundle identifier.
+// ====================================================================
+//
+// MeedyaDL's Tauri `identifier` was renamed from `io.github.meedyadl` to
+// `com.meedyasuite.meedyadl`. Because Tauri derives both the app-data
+// directory AND (indirectly, via our own `SERVICE_NAME` constants) the
+// convention used for OS-keychain entries from that identifier, the
+// rename silently orphaned every existing user's on-disk settings, queue,
+// history, logs, crash reports, portable Python runtime, external tools --
+// AND every keychain-stored credential (MusicKit private key, web player
+// developer token, dev-access sentinel).
+//
+// This module runs once, early in `lib.rs::run()`'s `.setup()` hook
+// (before anything else reads/writes the new app-data directory or the
+// queue/settings/history files), and copies the user's data across so
+// nothing is lost. It is intentionally:
+//
+//   - **Non-destructive**: everything is COPIED, never MOVED. The old
+//     directory and old keychain entries are left fully intact as a
+//     safety net -- if this migration has a bug, the user's original
+//     data is still sitting exactly where it always was.
+//   - **Idempotent**: gated by a marker file written into the NEW app
+//     data directory once the migration has been attempted. Re-running
+//     the app never re-copies anything.
+//   - **Resilient**: every individual copy/keychain operation is wrapped
+//     so a single failure (permission error, disk full, keychain locked)
+//     logs a warning and moves on to the next item. A failed migration
+//     must never prevent the app from starting -- worst case the user
+//     re-enters a credential or re-downloads the portable Python runtime.
+//
+// See `utils::platform::{OLD_BUNDLE_IDENTIFIER, CURRENT_BUNDLE_IDENTIFIER}`
+// for the two identifier constants this module bridges between.
+
+use crate::utils::platform::{CURRENT_BUNDLE_IDENTIFIER, OLD_BUNDLE_IDENTIFIER};
+use std::path::{Path, PathBuf};
+
+/// Marker file written into the NEW app data directory once this
+/// migration has been attempted (successfully or not -- see module doc:
+/// individual failures are logged and skipped, not retried forever).
+/// Its presence is the sole gate for "has this already run".
+const MIGRATION_MARKER_FILENAME: &str = ".migrated-from-io.github.meedyadl";
+
+/// Top-level flat files copied from the old app-data root into the new
+/// one, if the new copy doesn't already exist.
+const DATA_FILES: &[&str] = &["settings.json", "settings.json.sha256", "queue.json", "history.json"];
+
+/// Directories merged (per-file, skip-if-exists) from the old app-data
+/// root into the new one. Unlike `RUNTIME_DIRS`, these are small and
+/// grow incrementally, so a per-file merge (rather than an all-or-nothing
+/// directory copy) is the more useful semantics here.
+const MERGED_DIRS: &[&str] = &["logs", "crashes"];
+
+/// Large, all-or-nothing directories copied wholesale from the old
+/// app-data root into the new one, ONLY when the destination doesn't
+/// exist at all yet (the portable Python runtime and external tools are
+/// each an internally-consistent installation; a partial merge could
+/// leave a broken hybrid).
+const RUNTIME_DIRS: &[&str] = &["python", "tools"];
+
+/// Keychain accounts (the `keyring::Entry` "account" half of the
+/// (service, account) pair -- see `commands::credentials::SERVICE_NAME`
+/// and `services::apple_music_api::SERVICE_NAME`) that this app has ever
+/// written under the shared `SERVICE_NAME` keychain service. Enumerated
+/// by grepping every `keyring::Entry::new(SERVICE_NAME, ...)` call site
+/// in the codebase as of the 2026-07-24 rename:
+/// - `musickit_private_key` (`apple_music_api::get/store_private_key_from/in_keychain`,
+///   also reachable via `commands::credentials`'s generic store/get/delete
+///   allowlist)
+/// - `webplayer_developer_token` (`apple_music_api::get/store/clear_webplayer_token_*`)
+/// - `dev_access_token` (`commands::credentials`'s Konami-code dev access
+///   sentinel)
+///
+/// If a future PR adds another `keyring::Entry::new(SERVICE_NAME, ...)`
+/// call site, add its account key here too -- this list does NOT update
+/// itself.
+const KEYCHAIN_ACCOUNTS: &[&str] = &[
+    "musickit_private_key",
+    "webplayer_developer_token",
+    "dev_access_token",
+];
+
+/// Runs the one-time first-launch migration. Must be called from
+/// `lib.rs::run()`'s `.setup()` hook, as early as possible -- specifically
+/// BEFORE any code reads `settings.json` / `queue.json` / `history.json`
+/// from the new app-data directory, so the "is this a fresh install"
+/// check below can't be fooled by files this same launch already wrote.
+///
+/// `new_app_data_dir` is the already-created (via `create_dir_all`)
+/// current app-data root, i.e. `platform::get_app_data_dir(app.handle())`
+/// -- passed in rather than recomputed so the caller's existing
+/// `std::fs::create_dir_all` call and log line stay the single source of
+/// truth for "the new directory exists".
+///
+/// Returns a short human-readable summary of what was migrated (empty if
+/// nothing was), so the caller can optionally surface it via the activity
+/// log. Never panics; every fallible step is individually logged and
+/// skipped on error.
+///
+/// # Fresh-install fast path
+/// The very first thing this function does is check whether the OLD
+/// (`io.github.meedyadl`) app-data directory genuinely contains our data
+/// (concretely: has a `settings.json`). If it doesn't -- the overwhelming
+/// common case, both for brand new installs and for every launch after
+/// the first on an upgraded machine once the marker exists -- the
+/// function returns immediately: no marker file is written, no directory
+/// is created, and NO keychain probing happens. A fresh install must be a
+/// true no-op, paying only the cost of a couple of `stat` calls per
+/// launch.
+///
+/// Only when that check passes (there is real legacy data to consider)
+/// do we go on to check the migration marker and, if genuinely needed,
+/// perform the filesystem copy + keychain migration.
+#[must_use]
+pub fn run(new_app_data_dir: &Path) -> Vec<String> {
+    run_inner(legacy_app_data_dir(), new_app_data_dir)
+}
+
+/// Testable core of [`run`], parameterised over the OLD app-data
+/// directory rather than resolving it internally via `dirs::data_dir()`.
+/// This lets unit tests exercise every branch (fresh install / legacy
+/// data present with no marker / legacy data present with marker) with a
+/// synthetic temp directory instead of depending on -- or risking
+/// mutating -- whatever the real OS data directory and OS keychain
+/// happen to contain on the machine running the tests.
+fn run_inner(old_app_data_dir: Option<PathBuf>, new_app_data_dir: &Path) -> Vec<String> {
+    // --- Fast path: nothing to migrate -----------------------------------
+    // This MUST be the first thing the function does, and must not create
+    // any directories, files, or touch the keychain. See doc comment.
+    let Some(old_app_data_dir) = old_app_data_dir else {
+        log::debug!("Could not determine the OS data directory -- skipping migration check.");
+        return Vec::new();
+    };
+    if !old_app_data_dir.join("settings.json").is_file() {
+        log::debug!(
+            "No legacy app data at {} -- fresh install (or already migrated + cleaned up by \
+             the user), migration is a no-op.",
+            old_app_data_dir.display()
+        );
+        return Vec::new();
+    }
+
+    // From here on we know there is genuinely legacy data on disk, so
+    // it's worth paying for the marker-file idempotency check.
+    let marker_path = new_app_data_dir.join(MIGRATION_MARKER_FILENAME);
+    if marker_path.exists() {
+        // Already attempted on a previous launch (regardless of outcome).
+        // Filesystem copies are one-shot by design -- see module doc.
+        return Vec::new();
+    }
+
+    log::info!(
+        "Legacy app data found at {} -- running one-time bundle-identifier migration \
+         ('{OLD_BUNDLE_IDENTIFIER}' -> '{CURRENT_BUNDLE_IDENTIFIER}')",
+        old_app_data_dir.display()
+    );
+
+    let mut summary: Vec<String> = Vec::new();
+
+    migrate_filesystem_data(&old_app_data_dir, new_app_data_dir, &mut summary);
+    migrate_keychain_entries(&mut summary);
+
+    // Write the marker LAST and unconditionally (best-effort), so this
+    // function never runs its (potentially slow, e.g. copying a portable
+    // Python runtime) filesystem pass more than once per install, even if
+    // individual items above failed. The old directory and old keychain
+    // entries are untouched, so a user who hits a partial-migration bug
+    // can always be pointed at manual recovery by support -- deleting
+    // this marker file re-arms the migration for the next launch.
+    let marker_contents = if summary.is_empty() {
+        "Legacy directory was present but nothing new was migrated (destination already had \
+         this data).\n"
+            .to_string()
+    } else {
+        format!("{}\n", summary.join("\n"))
+    };
+    if let Err(e) = std::fs::write(&marker_path, marker_contents) {
+        log::warn!(
+            "Failed to write migration marker at {} ({e}) -- migration will be re-attempted \
+             on next launch. This is non-fatal (all migration steps are idempotent / \
+             skip-if-exists), just slightly wasteful.",
+            marker_path.display()
+        );
+    }
+
+    if summary.is_empty() {
+        log::info!(
+            "Bundle-identifier migration: legacy directory found but destination already \
+             provisioned -- nothing new migrated."
+        );
+    } else {
+        log::info!("Bundle-identifier migration complete: {}", summary.join("; "));
+    }
+
+    summary
+}
+
+/// Filesystem half of the migration: settings/queue/history, logs,
+/// crashes, and the portable Python + tools installations. Only called
+/// once `run()` has already confirmed `old_app_data_dir` genuinely has
+/// our data and the migration marker is absent.
+fn migrate_filesystem_data(old_app_data_dir: &Path, new_app_data_dir: &Path, summary: &mut Vec<String>) {
+    // Only migrate into a genuinely fresh new-identifier install. If
+    // `settings.json` already exists in the new directory, either a
+    // previous launch already migrated it (but somehow lost the marker --
+    // extra safety net) or the user already has independent data there;
+    // either way we must not overwrite it.
+    if new_app_data_dir.join("settings.json").exists() {
+        log::debug!(
+            "New app data directory already has settings.json -- skipping filesystem migration."
+        );
+        return;
+    }
+
+    log::info!(
+        "Copying (not moving) legacy app data from {} into {}",
+        old_app_data_dir.display(),
+        new_app_data_dir.display()
+    );
+
+    // --- Flat data files -------------------------------------------------
+    for name in DATA_FILES {
+        let old_file = old_app_data_dir.join(name);
+        let new_file = new_app_data_dir.join(name);
+        if new_file.exists() || !old_file.is_file() {
+            continue;
+        }
+        match std::fs::copy(&old_file, &new_file) {
+            Ok(_) => {
+                log::info!("Migrated {name} from legacy app data directory");
+                summary.push(format!("copied {name}"));
+            }
+            Err(e) => {
+                log::warn!("Failed to migrate {name} from legacy app data directory: {e} (non-fatal)");
+            }
+        }
+    }
+
+    // --- Merged directories (logs, crashes) ------------------------------
+    for name in MERGED_DIRS {
+        let old_dir = old_app_data_dir.join(name);
+        if !old_dir.is_dir() {
+            continue;
+        }
+        let new_dir = new_app_data_dir.join(name);
+        match copy_dir_recursive(&old_dir, &new_dir, true) {
+            Ok(0) => {}
+            Ok(count) => {
+                log::info!("Migrated {count} file(s) from legacy {name}/ directory");
+                summary.push(format!("copied {count} file(s) in {name}/"));
+            }
+            Err(e) => {
+                log::warn!("Failed to migrate legacy {name}/ directory: {e} (non-fatal)");
+            }
+        }
+    }
+
+    // --- Runtime directories (python, tools) ------------------------------
+    // All-or-nothing: only copied when the destination doesn't exist yet,
+    // to avoid producing a hybrid/broken installation from a partial
+    // merge of two independently-provisioned runtimes.
+    for name in RUNTIME_DIRS {
+        let old_dir = old_app_data_dir.join(name);
+        if !old_dir.is_dir() {
+            continue;
+        }
+        let new_dir = new_app_data_dir.join(name);
+        if new_dir.exists() {
+            log::debug!(
+                "{name}/ already present in new app data directory -- skipping runtime migration"
+            );
+            continue;
+        }
+        log::info!("Migrating legacy {name}/ runtime directory -- this may take a moment...");
+        match copy_dir_recursive(&old_dir, &new_dir, false) {
+            Ok(count) => {
+                log::info!("Migrated legacy {name}/ runtime directory ({count} file(s))");
+                summary.push(format!("copied {name}/ runtime ({count} file(s))"));
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to migrate legacy {name}/ runtime directory: {e} (non-fatal -- \
+                     the app will re-provision it if needed, at the cost of a re-download)."
+                );
+            }
+        }
+    }
+}
+
+/// Keychain half of the migration. For each known account, copies the
+/// secret from the OLD service name to the NEW one, but only when the NEW
+/// entry doesn't already exist (never overwrite) and the OLD entry does
+/// (nothing to migrate otherwise). The OLD entry is left in place.
+///
+/// Only called from `run()` after it has already confirmed the legacy
+/// FILESYSTEM directory genuinely contains our data. This is a deliberate
+/// trade-off: it means the rare case of a user who deleted the legacy
+/// app-data directory (or never had one, e.g. a synced/scripted install)
+/// but still has leftover legacy keychain entries won't get those
+/// migrated automatically. That's judged acceptable in exchange for the
+/// stronger guarantee that a fresh install performs ZERO keychain
+/// probing -- see `run()`'s doc comment for the fast-path rationale.
+fn migrate_keychain_entries(summary: &mut Vec<String>) {
+    for account in KEYCHAIN_ACCOUNTS {
+        match migrate_single_keychain_entry(account) {
+            Ok(true) => {
+                log::info!("Migrated keychain entry '{account}' to the new app identifier");
+                summary.push(format!("migrated keychain entry '{account}'"));
+            }
+            Ok(false) => {
+                // Nothing to do: either no legacy entry existed, or the
+                // new entry was already present.
+            }
+            Err(e) => {
+                log::warn!(
+                    "Keychain migration for '{account}' failed (non-fatal -- the user may need \
+                     to re-enter this credential): {e}"
+                );
+            }
+        }
+    }
+}
+
+/// Migrates a single (service, account) keychain entry from the OLD
+/// service name to the NEW one. Returns `Ok(true)` if a value was
+/// actually copied, `Ok(false)` if there was nothing to do (no legacy
+/// value, or a new value already present), and `Err` on an unexpected
+/// keychain backend error (locked, permission denied, unavailable).
+fn migrate_single_keychain_entry(account: &str) -> Result<bool, String> {
+    // Check the NEW entry first -- if it already has a value we must not
+    // overwrite it (the user may have re-entered credentials manually).
+    let new_entry = keyring::Entry::new(CURRENT_BUNDLE_IDENTIFIER, account)
+        .map_err(|e| format!("failed to open new keychain entry: {e}"))?;
+    match new_entry.get_password() {
+        Ok(_) => return Ok(false),
+        Err(keyring::Error::NoEntry) => {}
+        Err(e) => return Err(format!("failed to check new keychain entry: {e}")),
+    }
+
+    let old_entry = keyring::Entry::new(OLD_BUNDLE_IDENTIFIER, account)
+        .map_err(|e| format!("failed to open legacy keychain entry: {e}"))?;
+    let value = match old_entry.get_password() {
+        Ok(v) => v,
+        // Nothing stored under the old identifier -- nothing to migrate.
+        Err(keyring::Error::NoEntry) => return Ok(false),
+        Err(e) => return Err(format!("failed to read legacy keychain entry: {e}")),
+    };
+
+    // Deliberately does NOT delete `old_entry` -- see module doc
+    // "non-destructive" guarantee. A stale-but-harmless duplicate in the
+    // old service namespace is an acceptable trade for never being able
+    // to lose a credential to a migration bug.
+    new_entry
+        .set_password(&value)
+        .map_err(|e| format!("failed to write new keychain entry: {e}"))?;
+
+    Ok(true)
+}
+
+/// Resolves the OLD app-data root directory (pre-2026-07-24 identifier),
+/// using the same `dirs::data_dir()`-based construction that
+/// `platform::get_app_data_dir`'s own fallback branch and
+/// `platform::resolve_early_app_data_root()` already rely on for
+/// consistency with how Tauri itself derives `app_data_dir()` on macOS /
+/// Windows / Linux (identifier appended directly to the OS data-dir
+/// root). Returns `None` only if the `dirs` crate can't determine the OS
+/// data directory at all (exceedingly rare).
+fn legacy_app_data_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(OLD_BUNDLE_IDENTIFIER))
+}
+
+/// Recursively copies the contents of `src` into `dst`, creating
+/// directories as needed. Returns the number of files actually copied.
+///
+/// When `skip_existing_files` is `true`, a destination file that already
+/// exists is left untouched (merge semantics -- used for `logs/`,
+/// `crashes/`). When `false`, every source file is copied unconditionally
+/// (used for `python/`, `tools/`, which are only ever invoked against a
+/// destination that doesn't exist yet -- see call site guard above).
+///
+/// Symlinks are skipped rather than followed, to avoid the (unlikely, but
+/// possible on a hand-edited install) risk of an infinite loop or copying
+/// data outside the intended tree; none of our own managed directories
+/// (`logs/`, `crashes/`, `python/`, `tools/`) legitimately contain
+/// symlinks.
+fn copy_dir_recursive(src: &Path, dst: &Path, skip_existing_files: bool) -> std::io::Result<u64> {
+    std::fs::create_dir_all(dst)?;
+    let mut copied = 0u64;
+
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if file_type.is_symlink() {
+            continue;
+        } else if file_type.is_dir() {
+            copied += copy_dir_recursive(&src_path, &dst_path, skip_existing_files)?;
+        } else if file_type.is_file() {
+            if skip_existing_files && dst_path.exists() {
+                continue;
+            }
+            std::fs::copy(&src_path, &dst_path)?;
+            copied += 1;
+        }
+    }
+
+    Ok(copied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal legacy-style app-data tree under a fresh temp dir
+    /// for use as `src` in `copy_dir_recursive` tests.
+    fn make_tree(root: &Path, files: &[&str]) {
+        for rel in files {
+            let path = root.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, rel).unwrap();
+        }
+    }
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_files() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let src = tmp.join("src");
+        let dst = tmp.join("dst");
+        make_tree(&src, &["a.txt", "sub/b.txt", "sub/deeper/c.txt"]);
+
+        let copied = copy_dir_recursive(&src, &dst, false).unwrap();
+        assert_eq!(copied, 3);
+        assert!(dst.join("a.txt").exists());
+        assert!(dst.join("sub/b.txt").exists());
+        assert!(dst.join("sub/deeper/c.txt").exists());
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn copy_dir_recursive_skip_existing_does_not_overwrite() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let src = tmp.join("src");
+        let dst = tmp.join("dst");
+        make_tree(&src, &["a.txt"]);
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(dst.join("a.txt"), "already-here").unwrap();
+
+        let copied = copy_dir_recursive(&src, &dst, true).unwrap();
+        assert_eq!(copied, 0);
+        assert_eq!(std::fs::read_to_string(dst.join("a.txt")).unwrap(), "already-here");
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn copy_dir_recursive_no_skip_overwrites() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let src = tmp.join("src");
+        let dst = tmp.join("dst");
+        make_tree(&src, &["a.txt"]);
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(dst.join("a.txt"), "old-value").unwrap();
+
+        let copied = copy_dir_recursive(&src, &dst, false).unwrap();
+        assert_eq!(copied, 1);
+        assert_eq!(std::fs::read_to_string(dst.join("a.txt")).unwrap(), "a.txt");
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // ------------------------------------------------------------------
+    // `run_inner` is used (rather than the public `run`) for every test
+    // below that needs to control whether a "legacy directory" exists, so
+    // tests are deterministic and never depend on -- or risk reading --
+    // whatever the real OS data directory happens to contain on the
+    // machine running the tests.
+    //
+    // None of these tests exercise `migrate_keychain_entries` end-to-end
+    // (i.e. none reach the "legacy dir has settings.json AND no marker"
+    // branch), matching this codebase's existing convention (see
+    // `commands::credentials::tests`) of not exercising real OS-keychain
+    // I/O from unit tests -- CI/sandboxed runners may have no Secret
+    // Service / Credential Manager / Keychain backend available at all.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn run_inner_is_a_true_noop_when_old_dir_does_not_exist() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let old_dir = tmp.join("old-does-not-exist");
+        let new_dir = tmp.join("new");
+        std::fs::create_dir_all(&new_dir).unwrap();
+
+        let summary = run_inner(Some(old_dir), &new_dir);
+
+        assert!(summary.is_empty());
+        // Fresh-install fast path: must not create the marker file, and
+        // must not create anything else inside the new directory either.
+        assert!(!new_dir.join(MIGRATION_MARKER_FILENAME).exists());
+        assert_eq!(std::fs::read_dir(&new_dir).unwrap().count(), 0);
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn run_inner_is_a_true_noop_when_old_dir_exists_but_has_no_settings_json() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let old_dir = tmp.join("old");
+        let new_dir = tmp.join("new");
+        // Old directory exists but is empty / foreign (no settings.json)
+        // -- e.g. some unrelated leftover directory, not genuine legacy
+        // MeedyaDL data.
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::create_dir_all(&new_dir).unwrap();
+
+        let summary = run_inner(Some(old_dir), &new_dir);
+
+        assert!(summary.is_empty());
+        assert!(!new_dir.join(MIGRATION_MARKER_FILENAME).exists());
+        assert_eq!(std::fs::read_dir(&new_dir).unwrap().count(), 0);
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn run_inner_short_circuits_when_marker_already_present() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let old_dir = tmp.join("old");
+        let new_dir = tmp.join("new");
+        // Old directory DOES have genuine legacy data...
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::write(old_dir.join("settings.json"), "{\"legacy\":true}").unwrap();
+        std::fs::write(old_dir.join("queue.json"), "[]").unwrap();
+        // ...but the new directory already has the marker from a prior
+        // launch, so nothing should be (re-)copied.
+        std::fs::create_dir_all(&new_dir).unwrap();
+        std::fs::write(new_dir.join(MIGRATION_MARKER_FILENAME), "already ran").unwrap();
+
+        let summary = run_inner(Some(old_dir), &new_dir);
+
+        assert!(summary.is_empty());
+        assert!(!new_dir.join("settings.json").exists());
+        assert!(!new_dir.join("queue.json").exists());
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn does_not_migrate_filesystem_when_new_settings_already_exists() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let old_dir = tmp.join("old");
+        let new_dir = tmp.join("new");
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::write(old_dir.join("settings.json"), "{\"legacy\":true}").unwrap();
+        std::fs::create_dir_all(&new_dir).unwrap();
+        std::fs::write(new_dir.join("settings.json"), "{\"already\":\"here\"}").unwrap();
+
+        let mut summary = Vec::new();
+        migrate_filesystem_data(&old_dir, &new_dir, &mut summary);
+        assert!(summary.is_empty());
+        // The existing (new-directory) settings.json must be untouched.
+        assert_eq!(
+            std::fs::read_to_string(new_dir.join("settings.json")).unwrap(),
+            "{\"already\":\"here\"}"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn migrate_filesystem_data_copies_flat_files_and_merged_dirs() {
+        let tmp = std::env::temp_dir().join(format!("meedyadl-migration-test-{}", uuid::Uuid::new_v4()));
+        let old_dir = tmp.join("old");
+        let new_dir = tmp.join("new");
+        std::fs::create_dir_all(&old_dir).unwrap();
+        std::fs::create_dir_all(&new_dir).unwrap();
+
+        std::fs::write(old_dir.join("settings.json"), "{\"legacy\":true}").unwrap();
+        std::fs::write(old_dir.join("settings.json.sha256"), "deadbeef").unwrap();
+        std::fs::write(old_dir.join("queue.json"), "[]").unwrap();
+        std::fs::write(old_dir.join("history.json"), "[]").unwrap();
+        make_tree(&old_dir.join("logs"), &["meedyadl.2026-07-01.log"]);
+        make_tree(&old_dir.join("crashes"), &["crash-20260701.json"]);
+
+        let mut summary = Vec::new();
+        migrate_filesystem_data(&old_dir, &new_dir, &mut summary);
+
+        assert!(!summary.is_empty());
+        assert!(new_dir.join("settings.json").exists());
+        assert!(new_dir.join("settings.json.sha256").exists());
+        assert!(new_dir.join("queue.json").exists());
+        assert!(new_dir.join("history.json").exists());
+        assert!(new_dir.join("logs/meedyadl.2026-07-01.log").exists());
+        assert!(new_dir.join("crashes/crash-20260701.json").exists());
+        // Non-destructive: legacy copies must still be present too.
+        assert!(old_dir.join("settings.json").exists());
+        assert!(old_dir.join("logs/meedyadl.2026-07-01.log").exists());
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+}

--- a/src-tauri/src/services/config_service.rs
+++ b/src-tauri/src/services/config_service.rs
@@ -284,9 +284,9 @@ fn migrate_settings(settings: &mut AppSettings) {
 /// * `Err(message)` - If the settings file exists but couldn't be parsed
 pub fn load_settings(app: &AppHandle) -> Result<AppSettings, String> {
     // Resolve the settings file path: {app_data_dir}/settings.json
-    // On macOS: ~/Library/Application Support/io.github.meedyadl/settings.json
-    // On Windows: %APPDATA%\io.github.meedyadl\settings.json
-    // On Linux: ~/.config/io.github.meedyadl/settings.json
+    // On macOS: ~/Library/Application Support/com.meedyasuite.meedyadl/settings.json
+    // On Windows: %APPDATA%\com.meedyasuite.meedyadl\settings.json
+    // On Linux: ~/.local/share/com.meedyasuite.meedyadl/settings.json
     let settings_path = platform::get_app_data_dir(app).join("settings.json");
 
     let mut settings = if settings_path.exists() {
@@ -415,11 +415,15 @@ pub fn load_settings(app: &AppHandle) -> Result<AppSettings, String> {
 ///
 /// Falls back to `AppSettings::default()` if the file is missing or unreadable.
 /// Does NOT sync to GAMDL's config.ini (no `AppHandle` available).
+///
+/// Uses `platform::resolve_early_app_data_root()` rather than the current
+/// bundle identifier directly so that, for exactly the first launch after
+/// the `io.github.meedyadl` -> `com.meedyasuite.meedyadl` rename (before
+/// `services::bundle_migration` has run inside `.setup()`), this still
+/// finds the user's pre-existing `sentry_enabled` value instead of
+/// silently resetting it to the default for one launch.
 pub fn load_settings_from_default_path() -> Result<AppSettings, String> {
-    let settings_dir = dirs::data_dir()
-        .map(|d| d.join("io.github.meedyadl"))
-        .ok_or_else(|| "Cannot determine app data directory".to_string())?;
-    let settings_path = settings_dir.join("settings.json");
+    let settings_path = platform::resolve_early_app_data_root().join("settings.json");
 
     if settings_path.exists() {
         let contents = std::fs::read_to_string(&settings_path)

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -631,6 +631,18 @@ pub mod legacy_folder_merge;
 /// Diagnostics; quarantine action lands as a follow-up.
 pub mod integrity_scan;
 
+/// First-launch migration from the pre-2026-07-24 bundle identifier
+/// (`io.github.meedyadl` -> `com.meedyasuite.meedyadl`).
+///
+/// Copies (never moves) settings/queue/history/logs/crashes/python/tools
+/// from the old OS app-data directory into the new one, and migrates the
+/// handful of OS-keychain entries (MusicKit private key, web player
+/// developer token, dev-access sentinel) forward. Idempotent via a marker
+/// file; every step is individually best-effort so a failure never blocks
+/// startup. Called once from `lib.rs::run()`'s `.setup()` hook, before
+/// anything else touches the new app-data directory.
+pub mod bundle_migration;
+
 /// Only compiled in test mode (`cargo test`).
 #[cfg(test)]
 mod integration_tests;

--- a/src-tauri/src/utils/platform.rs
+++ b/src-tauri/src/utils/platform.rs
@@ -12,13 +12,26 @@
 //
 // All of this data lives under a single root directory that varies by
 // operating system:
-//   - macOS:   ~/Library/Application Support/io.github.meedyadl/
-//   - Windows: %APPDATA%\io.github.meedyadl\
-//   - Linux:   ~/.local/share/io.github.meedyadl/
+//   - macOS:   ~/Library/Application Support/com.meedyasuite.meedyadl/
+//   - Windows: %APPDATA%\com.meedyasuite.meedyadl\
+//   - Linux:   ~/.local/share/com.meedyasuite.meedyadl/
 //
 // The functions in this module resolve paths relative to that root. They
 // are used by the `services` layer (python_manager, dependency_manager,
 // config_service) and by the `commands::system` IPC handlers.
+//
+// Bundle identifier rename (2026-07-24): the app's Tauri `identifier` was
+// renamed from `io.github.meedyadl` to `com.meedyasuite.meedyadl`. Because
+// Tauri derives `app_data_dir()` from that identifier, this moved every
+// existing user's app-data root to a brand new OS path. `services::
+// bundle_migration` runs once at startup (before anything else touches the
+// new directory) to copy the old directory's contents across and migrate
+// OS-keychain entries. The two constants below are the single source of
+// truth for "old" vs "new" identifier strings, reused by that migration
+// module AND by the handful of call sites (`setup_tracing`,
+// `load_settings_from_default_path`) that must resolve an app-data path
+// *before* a Tauri `AppHandle` exists and so cannot call
+// `get_app_data_dir()`.
 //
 // Directory layout under the app data root:
 //   {app_data}/
@@ -44,6 +57,60 @@ use std::path::{Path, PathBuf};
 // Reference: https://docs.rs/tauri/latest/tauri/trait.Manager.html
 use tauri::{AppHandle, Manager};
 
+/// The bundle identifier `MeedyaDL` used **before** the 2026-07-24 rename.
+///
+/// Kept around permanently as the source path for the first-launch
+/// migration in `services::bundle_migration`, and for the keychain
+/// `SERVICE_NAME` constants in `apple_music_api.rs` / `commands::
+/// credentials` (which read the OLD service name once to migrate secrets,
+/// then never touch it again).
+pub const OLD_BUNDLE_IDENTIFIER: &str = "io.github.meedyadl";
+
+/// The current bundle identifier. **Must be kept in sync with the
+/// `identifier` field in `tauri.conf.json`** — Tauri's own path resolver
+/// (`app.path().app_data_dir()`) reads that file at compile time via
+/// `tauri::generate_context!()`, but this constant exists separately for
+/// the small number of call sites that need an app-data path *before* an
+/// `AppHandle` is constructed (see module doc above) and therefore can't
+/// reach the Tauri-derived value.
+pub const CURRENT_BUNDLE_IDENTIFIER: &str = "com.meedyasuite.meedyadl";
+
+/// Resolves an app-data ROOT directory for startup code that runs
+/// **before** a Tauri `AppHandle` exists (`lib.rs::run()`'s tracing setup
+/// and the early settings load used only to read `sentry_enabled`, both of
+/// which execute ahead of `Builder::default().setup()`). `get_app_data_dir`
+/// cannot be used at that point because it requires an `AppHandle`.
+///
+/// # Bundle-identifier-rename transition behaviour
+/// The one-time migration in `services::bundle_migration` runs inside
+/// `.setup()`, i.e. AFTER this function's two call sites already ran for
+/// the current launch. To avoid a jarring "logs/Sentry setting reset for
+/// exactly one launch" experience immediately after upgrading past the
+/// rename, this prefers the NEW identifier's directory when it already has
+/// a `settings.json` (steady state, including post-migration), but falls
+/// back to the OLD identifier's directory when only IT has one (the first
+/// launch after upgrading, before `.setup()`'s migration has copied
+/// anything across yet). A brand new install (neither directory has
+/// settings yet) resolves to the NEW directory.
+///
+/// This is a read-side convenience only — it never writes or copies
+/// anything. The authoritative, durable migration (which actually copies
+/// files and is safe to call repeatedly) is `bundle_migration::run()`.
+#[must_use]
+pub fn resolve_early_app_data_root() -> PathBuf {
+    let base = dirs::data_dir().unwrap_or_else(std::env::temp_dir);
+    let new_dir = base.join(CURRENT_BUNDLE_IDENTIFIER);
+    let old_dir = base.join(OLD_BUNDLE_IDENTIFIER);
+
+    if new_dir.join("settings.json").exists() {
+        new_dir
+    } else if old_dir.join("settings.json").exists() {
+        old_dir
+    } else {
+        new_dir
+    }
+}
+
 /// Returns the root application data directory for `MeedyaDL`.
 ///
 /// This is the self-contained directory where all application data lives:
@@ -54,9 +121,9 @@ use tauri::{AppHandle, Manager};
 /// - GAMDL configuration
 ///
 /// Platform-specific locations:
-/// - macOS:   `~/Library/Application Support/io.github.meedyadl/`
-/// - Windows: `%APPDATA%\io.github.meedyadl\`
-/// - Linux:   `~/.local/share/io.github.meedyadl/`
+/// - macOS:   `~/Library/Application Support/com.meedyasuite.meedyadl/`
+/// - Windows: `%APPDATA%\com.meedyasuite.meedyadl\`
+/// - Linux:   `~/.local/share/com.meedyasuite.meedyadl/`
 ///
 /// # Fallback behaviour
 /// If Tauri's path resolver fails (which should not happen in normal
@@ -77,7 +144,7 @@ use tauri::{AppHandle, Manager};
 #[must_use]
 pub fn get_app_data_dir(app: &AppHandle) -> PathBuf {
     // Tauri's `app.path().app_data_dir()` reads the `identifier` field from
-    // `tauri.conf.json` (e.g., "io.github.meedyadl") and appends it
+    // `tauri.conf.json` (e.g., "com.meedyasuite.meedyadl") and appends it
     // to the OS-standard application data directory.
     app.path().app_data_dir().unwrap_or_else(|_| {
         // Fallback: construct the path manually using the `dirs` crate,
@@ -87,7 +154,7 @@ pub fn get_app_data_dir(app: &AppHandle) -> PathBuf {
         // Reference: https://docs.rs/dirs/latest/dirs/fn.data_dir.html
         dirs::data_dir()
             .unwrap_or_else(|| PathBuf::from("."))
-            .join("io.github.meedyadl")
+            .join(CURRENT_BUNDLE_IDENTIFIER)
     })
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicedouble/tauri-schema/v2/schema.json",
   "productName": "MeedyaDL",
   "version": "1.12.0-alpha.36",
-  "identifier": "io.github.meedyadl",
+  "identifier": "com.meedyasuite.meedyadl",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",

--- a/src/components/help/HelpViewer.tsx
+++ b/src/components/help/HelpViewer.tsx
@@ -787,9 +787,9 @@ MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg...
 
 ### Application Won't Start
 - Delete the settings file from the app data directory and restart
-- On macOS: ~/Library/Application Support/io.github.meedyadl/
-- On Windows: %APPDATA%/io.github.meedyadl/
-- On Linux: ~/.config/io.github.meedyadl/`,
+- On macOS: ~/Library/Application Support/com.meedyasuite.meedyadl/
+- On Windows: %APPDATA%/com.meedyasuite.meedyadl/
+- On Linux: ~/.local/share/com.meedyasuite.meedyadl/`,
   },
   {
     id: 'disclaimer',

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -102,7 +102,7 @@ export function getPlatformInfo(): Promise<PlatformInfo> {
  * Returns the absolute path to the application's data directory.
  *
  * Rust handler: `get_app_data_dir()` in `src-tauri/src/commands/system.rs`
- * Returns: string (e.g., "~/Library/Application Support/io.github.meedyadl")
+ * Returns: string (e.g., "~/Library/Application Support/com.meedyasuite.meedyadl")
  *
  * The data directory stores settings.json, logs, and cached dependency binaries.
  *

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -508,7 +508,7 @@ export interface GamdlOptions {
  * Mirrors: Rust struct `AppSettings` in `src-tauri/src/models/settings.rs`
  *
  * This interface represents the full, flattened settings object stored
- * in the app's data directory (e.g., `~/Library/Application Support/io.github.meedyadl/settings.json`).
+ * in the app's data directory (e.g., `~/Library/Application Support/com.meedyasuite.meedyadl/settings.json`).
  * Unlike `GamdlOptions` (where all fields are optional), all fields here
  * are required because the Rust backend provides defaults for every setting.
  *


### PR DESCRIPTION
⚠️ **BREAKING CHANGE** (bundle identifier). Combined PR — absorbs the former #1056 so only **one** PR merges into `alpha` (avoids a two-PR merge race, each of which would auto-cut its own alpha release and force a rebase of the other). The two changesets are **disjoint** — verified no shared files.

---

## 1. Bundle-ID rename + first-launch migration shim
Renames `io.github.meedyadl` → `com.meedyasuite.meedyadl`, which relocates the OS app-data directory **and** the keychain namespace. A first-launch migration shim copies existing users' data + credentials across so nobody is orphaned.

**Functional references updated:** `tauri.conf.json` identifier; pre-`AppHandle` hardcoded paths in `platform.rs` / `config_service.rs` / `lib.rs` (tracing + panic handler); and — the subtle one — the keychain `SERVICE_NAME` in `apple_music_api.rs` + `credentials.rs`, which were **hardcoded literals equal to the bundle id** (never Tauri-derived), now a shared `platform::CURRENT_BUNDLE_IDENTIFIER`.

**Migration (`services/bundle_migration.rs`), runs at top of `setup()`:**
- **Fresh-install fast path:** returns immediately with **zero side effects** — no directory creation, no marker file, **no keychain probing** — unless the old `io.github.meedyadl/settings.json` genuinely exists. Unit-tested (3 no-op tests assert zero filesystem side effects).
- **When legacy data exists:** copies `settings.json`(+`.sha256`), `queue.json`, `history.json`; merges `logs/` + `crashes/`; copies `python/` + `tools/` (skip-if-present); migrates the 3 keychain accounts (`musickit_private_key`, `webplayer_developer_token`, `dev_access_token`). **Never deletes or moves the old data** (safety net). Every step is try/logged and never blocks startup.
- Also fixes a pre-existing doc bug (Linux path `~/.config` → `~/.local/share`).

## 2. Release-notes guard fix (was #1056)
Fixes the failed Release build for `v1.12.0-alpha.36`. The `Verify placeholder did not leak` step grepped the body for `Release in progress` **unanchored**, while the strip logic is **anchored to line-start**. After #1046 made notes richer, a legitimate changelog entry *mentioning* the placeholder matched → the step exited 1 → the `Auto-publish prerelease draft` step never ran → **alpha.36's release is stuck as an unpublished draft**. Both greps are now anchored to `^Release in progress`, matching the strip regex. Verified genuine leaks still fire; prose mentioning the phrase no longer does.

## Verification
`cargo check` clean · `cargo clippy --all-targets -- -D warnings` clean · `npm run type-check` clean · `cargo test --lib` **1524 passed / 0 failed** · `npm run test` **560 passed** · `release.yml` YAML valid.

## Notes for the record
1. The new keychain `SERVICE_NAME` literal is `com.meedyasuite.meedyadl`.
2. `legacy_app_data_dir()` assumes `dirs::data_dir().join(identifier)` == Tauri's real `app_data_dir()` per-OS (mirrors the existing pre-rename fallback; **not runtime-verified on a real installed build** — worth a smoke test post-merge).
3. Keychain migration is gated behind the filesystem "old settings.json exists" check, which deliberately avoids a macOS keychain-access prompt on fresh installs; the trade-off is no auto-migration for the rare user who deleted app-data but kept keychain entries (recoverable — old entries are never deleted).

## Follow-up
Once merged, `v1.12.0-alpha.36`'s stuck draft can be published by re-running the Release workflow for that tag, or simply superseded by the next alpha (which will now build correctly).

Release-Note: The app has a new identifier; your existing settings and saved logins are migrated automatically on first launch.
Release-Note: Prerelease builds no longer fail to publish when their release notes mention the internal placeholder text.