### PR TITLE
fix(release): anchor placeholder-leak checks so rich notes don't fail the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1678,8 +1678,11 @@ jobs:
           # present (because the guide check comes BEFORE the cleanup
           # write in the legacy flow). Set a flag the post-cleanup
           # branch reads.
+          # Anchored for the same reason as the verify step below: prose
+          # that merely mentions the placeholder must not trigger a
+          # spurious cleanup-write.
           if gh release view "$TAG" --repo "$REPO" --json body --jq '.body' \
-            | grep -q "Release in progress"; then
+            | grep -qE "^Release in progress"; then
             NEEDS_PLACEHOLDER_CLEANUP="1"
           else
             NEEDS_PLACEHOLDER_CLEANUP="0"
@@ -1794,7 +1797,15 @@ jobs:
             echo "::warning::Could not fetch release body for $TAG — skipping placeholder check"
             exit 0
           fi
-          if echo "$BODY" | grep -q "Release in progress"; then
+          # Anchored to line-start to MATCH the strip regex above
+          # (`re.sub(r'(?m)^Release in progress…')`). An unanchored grep
+          # false-positives on legitimate notes content that merely
+          # *mentions* the placeholder — e.g. a changelog entry for the
+          # #1046 self-heal work — which failed the whole release job and
+          # left the draft unpublished (v1.12.0-alpha.36). The real
+          # placeholder is always its own line, so anchoring is both
+          # correct and sufficient.
+          if echo "$BODY" | grep -qE "^Release in progress"; then
             echo "::error::Release body for $TAG still contains the 'Release in progress' placeholder."
             echo "::error::This is the #857 / PR #741 regression — the strip-and-replace logic in finalize-release is not catching every race."
             echo "::error::Recover with: gh release edit $TAG --repo $REPO --notes-file /path/to/proper-notes.md"


### PR DESCRIPTION
Fixes the failed Release build for `v1.12.0-alpha.36` (the source of alpha's red check status).

## Root cause
The `Verify placeholder did not leak into release body` step greps the release body for `Release in progress` **unanchored**, while the strip logic that removes it is **anchored to line-start** (`re.sub(r'(?m)^Release in progress…')`).

After #1046 made prerelease notes richer (commit subjects + technical changelog), a legitimate changelog entry *describing the placeholder fix* matched the unanchored grep. So:

1. the verify step exited 1 →
2. the `Auto-publish prerelease draft` step (which runs after it) never ran →
3. **alpha.36's release is stuck as an unpublished draft** (its tag 404s on the public releases API).

The notes themselves rendered perfectly — only the guard misfired.

## Fix
Anchor both placeholder greps (the verify step and the `NEEDS_PLACEHOLDER_CLEANUP` detector) to `^Release in progress`, matching the strip regex. A genuine leaked placeholder is always its own line, so the guard stays fully effective.

Verified both directions: prose merely mentioning the phrase no longer fires (the false positive that broke the build); a genuine leaked placeholder on its own line still fires. `yaml.safe_load` passes.

## Follow-up
Once merged, alpha.36's stuck draft can be published by re-running the Release workflow for that tag, or simply superseded by the next alpha.

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_