### PR TITLE
fix(release-notes): guard against wrong-ref dispatch, and add the missing v1.12.0-alpha.38 notes

### DIFF
--- a/.github/release-notes/v1.12.0-alpha.38.md
+++ b/.github/release-notes/v1.12.0-alpha.38.md
@@ -1,0 +1,43 @@
+# MeedyaDL 1.12.0-alpha.38
+
+MeedyaDL's app icon is sharper at small sizes on every platform, and on Mac, MeedyaDL can now
+offer to move into an Applications/MeedyaSuite folder.
+
+### What's new
+
+- **MeedyaDL can offer to move into an Applications/MeedyaSuite folder (Mac only).** If
+  MeedyaDL is installed directly inside your Mac's shared Applications folder, it will ask —
+  once, when you open it — whether to move into an Applications/MeedyaSuite folder, so it's
+  easy to find even if you add other MeedyaSuite apps down the line. Choose **Move MeedyaDL**
+  and it moves itself there and reopens automatically — on some Macs you may be asked to
+  approve the move with an administrator password. Choose **Not now** and MeedyaDL keeps
+  running right where it was, and won't ask again. If the move doesn't go through, MeedyaDL
+  shows you a message and keeps running from its original spot, and will offer again the next
+  time you open it. ([details](https://github.com/MWBMPartners/MeedyaDL/issues/1057))
+
+### What's fixed
+
+- **The app icon is sharper at small sizes.** In places like the system tray on Windows and
+  Linux, or small icon views in Finder and File Explorer, MeedyaDL's icon used to blur into a
+  smudge. It now stays crisp and readable at those sizes.
+
+### Notes
+
+- The Applications/MeedyaSuite folder offer above is Mac-only. The sharper icon fix, though,
+  ships on every platform — Windows, Linux, and ChromeOS included.
+- MeedyaDL only offers to move into an Applications/MeedyaSuite folder when it's installed
+  directly in the shared Applications folder — a personal Applications folder, or a copy still
+  running straight from the installer disk image, won't trigger it.
+- If you're upgrading MeedyaDL rather than starting from a fresh install, you might not see
+  the sharper icon straight away — some systems keep showing a cached copy of the old one
+  until you reinstall or restart.
+- If you're updating from an older release, MeedyaDL automatically carries your settings,
+  download queue, download history, and saved credentials over to this version the first time
+  you open it — there's nothing for you to do, and your previous data is left untouched as a
+  backup.
+- Release notes are now automatically checked before they're published, to help catch wording
+  problems before a release goes out.
+- This is a pre-release on the **alpha** channel — early access to work in progress. The
+  in-app updater serves the latest stable unless you've opted into Alpha.
+
+_Full technical changelog: [v1.12.0-alpha.37 → v1.12.0-alpha.38](https://github.com/MWBMPartners/MeedyaDL/compare/v1.12.0-alpha.37...v1.12.0-alpha.38) · [CHANGELOG.md](https://github.com/MWBMPartners/MeedyaDL/blob/main/CHANGELOG.md)_

--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -92,6 +92,66 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # `workflow_dispatch` is only registered for a workflow file that
+      # lives on the default branch, but the "Checkout code" step above
+      # has no `ref:` -- it checks out whatever ref was DISPATCHED, and
+      # the GitHub UI's "Run workflow" branch dropdown defaults to the
+      # default branch. If that ref doesn't happen to carry the curated
+      # notes files and the three helper scripts this workflow shells
+      # out to (they may still live only on a channel branch -- see the
+      # "Operational notes" header comment), every step below fails in
+      # confusing ways (missing-file errors from deep inside a script,
+      # or a silent "no notes files to lint"). Catch that up front, on
+      # the actual files rather than a hardcoded branch name, so this
+      # guard keeps working once that infrastructure legitimately lands
+      # on the default branch for real.
+      - name: Verify release-notes infrastructure is present on this ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          MISSING=0
+
+          for script in scripts/release-notes/apply-notes.sh \
+                        scripts/release-notes/splice-body.py \
+                        scripts/release-notes/lint-notes.py; do
+            if [ ! -r "$script" ]; then
+              echo "::error::Missing or unreadable: ${script}"
+              MISSING=1
+            fi
+          done
+
+          NOTES_FILES=(.github/release-notes/v*.md)
+          NOTES_COUNT="${#NOTES_FILES[@]}"
+          if [ "$NOTES_COUNT" -eq 0 ]; then
+            echo "::error::No .github/release-notes/v*.md files found."
+            MISSING=1
+          fi
+
+          if [ "$MISSING" -ne 0 ]; then
+            {
+              echo "### Apply Release Notes -- wrong ref checked out"
+              echo
+              echo "This workflow was dispatched against \`${REF_NAME}\`, which does not"
+              echo "carry the release-notes system it depends on (the three"
+              echo "\`scripts/release-notes/*.sh\` / \`*.py\` helper scripts and/or any"
+              echo "\`.github/release-notes/v*.md\` notes files are missing from this"
+              echo "checkout)."
+              echo
+              echo "Re-run this workflow dispatched against a branch that actually"
+              echo "carries the release-notes infrastructure, for example:"
+              echo
+              echo '```'
+              echo 'gh workflow run "Apply Release Notes" --repo MWBMPartners/MeedyaDL --ref alpha -f tag=all -f dry_run=true'
+              echo '```'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "OK -- ${REF_NAME}: found 3 release-notes scripts and ${NOTES_COUNT} notes file(s)."
+
       # Same shape release.yml's own tag derivation validates (release.yml
       # ~L181) -- accepts only vX.Y.Z with an optional semver-legal
       # pre-release suffix, or the literal 'all'. Rejecting anything else


### PR DESCRIPTION
## Summary

Two fixes that together unblock the retrospective repair of published release bodies.

**1. Fail fast when Apply Release Notes is dispatched against the wrong ref.** The workflow was cherry-picked onto `main` so GitHub would register its dispatch trigger — but `main` carries **none** of the infrastructure it needs (verified: zero `.github/release-notes/*.md` files, and all three `scripts/release-notes/` helpers absent). The checkout step has no pinned `ref:`, so it checks out whatever was dispatched. Worse, the UI's "Run workflow" button defaults its branch dropdown to `main`, making the broken path the obvious one. Without this guard the failure surfaces as a confusing missing-file error deep in a later step.

The guard checks for **the files, not the branch name** — deliberately, so it keeps working unchanged once `alpha` promotes and `main` legitimately gains the release-notes system.

**2. Add the missing `v1.12.0-alpha.38` notes file.** The published body for that tag names the app's internal bundle identifier and describes where data is stored on disk — both banned by the confidentiality policy added in #1059. The retro-fix workflow skips any tag without a curated file, so authoring this is the only route to correcting it.

## Why the notes file went through two drafts

The first draft was **rejected by an accuracy review** that checked its claims against the source. It contained statements that were simply untrue:

- *"Nothing changes for Windows, Linux, or ChromeOS"* — false; the icon fix ships on every platform (`icon.ico`, the Linux PNGs and all four tray icons were regenerated in this tag). Only the folder feature is Mac-only.
- *"imported cookies … are migrated"* — false; the migration copies settings, queue, history, logs and specific keychain entries. Cookies are not in that list.
- *"Coming from v1.10.2 or any earlier build"* — wrong threshold; the identifier changed in **alpha.37**, so every prerelease from alpha.18 through alpha.36 is *newer* than v1.10.2 and still affected.
- Claimed the icon *"reads clearly everywhere"* — unverified; the only check that has actually run is a numeric assertion at 32px. Real-hardware confirmation has not happened.
- Omitted that macOS caches icons, so users updating in place likely **won't** see the change — which would have made the note read as untrue to a large share of readers.
- Described the failure path wrongly (it does show an error, and it does re-offer later) and never mentioned that non-admin users get an administrator-password prompt.

The rewrite verifies every claim against `app_relocation.rs`, `AppRelocationModal.tsx`, `bundle_migration.rs`, and the actual `alpha.37..alpha.38` diff.

## Scope of changes

- [x] CI / workflows (`.github/`) — one step added to one workflow
- [x] Documentation — one new release-notes file
- [ ] Rust backend / frontend / IPC / settings — none

## Test plan

- [x] Guard simulated **both ways**: fails with exit 1 and the full recovery message in a tree missing the scripts and notes; passes with `found 3 release-notes scripts and 31 notes file(s)` in this tree
- [x] `actionlint` (v1.7.7) clean
- [x] Every embedded `run:` block passes `bash -n`; YAML parses clean
- [x] `lint-notes.py` on the new file: zero findings. Full corpus: exit 0 (one pre-existing warning in an untouched file)
- [x] `Release-Note:` trailers validated via `--trailer`

## Security review

- [x] `github.ref_name` consumed via `env:`, never interpolated into `run:`
- [x] No new action references; existing pin untouched
- [x] Guard is read-only — it inspects the checkout and exits, touching nothing
- [x] No secrets, credentials, or absolute paths
- [x] No application code touched

## Follow-up

The same guard needs cherry-picking to `main`, since `main`'s copy is the one that runs when someone clicks the UI button. That lands as a separate PR.

## Related

Follows #1059 and #1060. Unblocks repairing **five** published bodies that currently disclose implementation detail — two more than the first pass found, including one exposing a default host and port.

Release-Note: none

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_