### PR TITLE
ci(release-notes): fail fast when Apply Release Notes runs from a ref without the notes infrastructure

### DIFF
--- a/.github/workflows/apply-release-notes.yml
+++ b/.github/workflows/apply-release-notes.yml
@@ -92,6 +92,66 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # `workflow_dispatch` is only registered for a workflow file that
+      # lives on the default branch, but the "Checkout code" step above
+      # has no `ref:` -- it checks out whatever ref was DISPATCHED, and
+      # the GitHub UI's "Run workflow" branch dropdown defaults to the
+      # default branch. If that ref doesn't happen to carry the curated
+      # notes files and the three helper scripts this workflow shells
+      # out to (they may still live only on a channel branch -- see the
+      # "Operational notes" header comment), every step below fails in
+      # confusing ways (missing-file errors from deep inside a script,
+      # or a silent "no notes files to lint"). Catch that up front, on
+      # the actual files rather than a hardcoded branch name, so this
+      # guard keeps working once that infrastructure legitimately lands
+      # on the default branch for real.
+      - name: Verify release-notes infrastructure is present on this ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          MISSING=0
+
+          for script in scripts/release-notes/apply-notes.sh \
+                        scripts/release-notes/splice-body.py \
+                        scripts/release-notes/lint-notes.py; do
+            if [ ! -r "$script" ]; then
+              echo "::error::Missing or unreadable: ${script}"
+              MISSING=1
+            fi
+          done
+
+          NOTES_FILES=(.github/release-notes/v*.md)
+          NOTES_COUNT="${#NOTES_FILES[@]}"
+          if [ "$NOTES_COUNT" -eq 0 ]; then
+            echo "::error::No .github/release-notes/v*.md files found."
+            MISSING=1
+          fi
+
+          if [ "$MISSING" -ne 0 ]; then
+            {
+              echo "### Apply Release Notes -- wrong ref checked out"
+              echo
+              echo "This workflow was dispatched against \`${REF_NAME}\`, which does not"
+              echo "carry the release-notes system it depends on (the three"
+              echo "\`scripts/release-notes/*.sh\` / \`*.py\` helper scripts and/or any"
+              echo "\`.github/release-notes/v*.md\` notes files are missing from this"
+              echo "checkout)."
+              echo
+              echo "Re-run this workflow dispatched against a branch that actually"
+              echo "carries the release-notes infrastructure, for example:"
+              echo
+              echo '```'
+              echo 'gh workflow run "Apply Release Notes" --repo MWBMPartners/MeedyaDL --ref alpha -f tag=all -f dry_run=true'
+              echo '```'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "OK -- ${REF_NAME}: found 3 release-notes scripts and ${NOTES_COUNT} notes file(s)."
+
       # Same shape release.yml's own tag derivation validates (release.yml
       # ~L181) -- accepts only vX.Y.Z with an optional semver-legal
       # pre-release suffix, or the literal 'all'. Rejecting anything else


### PR DESCRIPTION
## Summary

Cherry-picks the dispatch-ref guard onto `main`, identical to the copy in #1061 (verified byte-for-byte), so the two branches stay in sync and the eventual promotion merges cleanly.

**This is the copy that matters most.** `main` carries none of the release-notes infrastructure — zero `.github/release-notes/*.md` files and none of the three `scripts/release-notes/` helpers. Now that #1060 put the workflow on `main` to make it dispatchable, the UI's "Run workflow" button exists and **defaults its branch dropdown to `main`** — so the single most likely user action is the one that cannot work.

Without this guard that failure surfaces as an obscure missing-file error partway through. With it, the run stops immediately and says exactly what happened and what to do instead.

## What the guard does

Runs directly after checkout. Verifies the three helper scripts are present and readable, and that at least one `.github/release-notes/v*.md` exists. On failure it names the actual ref and prints the working command to **both** the job log and the step summary, so the fix is visible without opening logs.

It checks **for the files, not for a branch name** — deliberately. Hardcoding "must be `alpha`" would break the moment `alpha` promotes and `main` legitimately gains the release-notes system. As written, the guard needs no maintenance when that happens: it simply starts passing on `main`.

## Scope of changes

- [x] CI / workflows (`.github/`) — one step added to one workflow
- [ ] Everything else — none

## Test plan

- [x] Simulated **both** outcomes. Failure (empty tree, ref `main`): exit 1 with all four `::error::` lines and the full recovery block. Success (a tree with the infrastructure): exit 0, `found 3 release-notes scripts and 31 notes file(s)`, empty step summary
- [x] `actionlint` (v1.7.7) clean; `bash -n` clean on every `run:` block; YAML parses
- [x] Verified byte-identical to the `alpha`-targeted copy in #1061

## Security review

- [x] `github.ref_name` consumed via `env:`, never interpolated into `run:`
- [x] No new action references
- [x] Read-only — inspects the checkout and exits
- [x] No secrets, credentials, or absolute paths
- [x] No application code touched

## Related

Fixes a trap introduced by #1060. Companion to #1061, which carries the same guard plus the missing `v1.12.0-alpha.38` notes file.

Release-Note: none

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_