### PR TITLE
fix(updates): repair pre-release update detection and the first-run update/setup ordering

### DIFF
--- a/src-tauri/src/services/gamdl_service.rs
+++ b/src-tauri/src/services/gamdl_service.rs
@@ -666,8 +666,19 @@ pub async fn check_latest_gamdl_version() -> Result<String, String> {
     // API format: https://pypi.org/pypi/{package}/json
     // Response structure: { "info": { "version": "2.8.4", ... }, "releases": { ... } }
     // Ref: https://warehouse.pypa.io/api-reference/json.html
+    //
+    // Uses the house `build_simple(10)` client (matching the sibling PyPI
+    // lookup in `update_checker.rs::fetch_gamdl_release_wheel_filenames`)
+    // instead of a bare `reqwest::get()`, which has NO timeout at all. On a
+    // network that silently drops packets rather than refusing the
+    // connection, the untimed call could hang for its full OS-level TCP
+    // timeout (up to ~2 minutes) — delaying the setup wizard on a machine
+    // whose very first screen is meant to get the user unblocked quickly.
     let url = "https://pypi.org/pypi/gamdl/json";
-    let response = reqwest::get(url)
+    let client = crate::utils::http_client::build_simple(10)?;
+    let response = client
+        .get(url)
+        .send()
         .await
         .map_err(|e| format!("Failed to check PyPI: {e}"))?;
 

--- a/src-tauri/src/services/update_checker.rs
+++ b/src-tauri/src/services/update_checker.rs
@@ -29,8 +29,14 @@
 //
 // ## Version Comparison
 //
-// Versions are compared as semver tuples (major, minor, patch). The `is_newer()`
-// function parses "X.Y.Z" strings into (u32, u32, u32) and uses tuple comparison.
+// Versions are compared via `is_newer()`, which is pre-release aware. The
+// base "X.Y.Z" component is parsed into a (u32, u32, u32) tuple and compared
+// first; when two versions share the same base (e.g. two alpha builds of the
+// same upcoming release), the comparison falls through to the pre-release
+// channel (Alpha < Beta < Rc < Stable, via the existing `UpdateChannel`
+// ordering) and finally to the numeric pre-release counter (e.g. `alpha.37`
+// vs `alpha.38`). This lets in-app updates work correctly between
+// consecutive pre-releases, not just up to the next stable release.
 //
 // ## Compatibility Gating
 //
@@ -402,31 +408,98 @@ async fn fetch_gamdl_release_wheel_filenames(version: &str) -> Result<Vec<String
     Ok(filenames)
 }
 
-/// Compares two semver version strings and returns true if `latest` is strictly newer than `current`.
+/// Parses the `(major, minor, patch)` base version out of a version string,
+/// ignoring any pre-release suffix (everything from the first `-` onward).
 ///
-/// Uses simple tuple comparison on (major, minor, patch). Unparseable parts default to 0.
-/// Equal versions return false (not newer).
+/// Missing or unparseable parts default to 0, making this forgiving of
+/// version strings like "2.0" (treated as 2.0.0) or "v2.1" (0.0.0 — the
+/// leading "v" makes the major segment unparseable, matching the pre-#C-fix
+/// behaviour so plain-semver callers see no change).
+///
+/// Splitting off the suffix BEFORE splitting on `.` is the fix for the core
+/// bug this module shipped with: `"1.12.0-alpha.38".split('.')` yields
+/// `["1", "12", "0-alpha", "38"]`, and `"0-alpha".parse::<u32>()` fails —
+/// silently coercing the patch component to 0 and making every pre-release
+/// of a given base version compare equal to every other. Stripping the
+/// suffix first means the base-tuple comparison is unaffected by whatever
+/// pre-release label follows it.
+fn parse_base_semver(v: &str) -> (u32, u32, u32) {
+    let base = v.split('-').next().unwrap_or(v);
+    let parts: Vec<&str> = base.split('.').collect();
+    let major = parts.first().and_then(|p| p.parse().ok()).unwrap_or(0);
+    let minor = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(0);
+    let patch = parts.get(2).and_then(|p| p.parse().ok()).unwrap_or(0);
+    (major, minor, patch)
+}
+
+/// Extracts the numeric counter from a pre-release suffix (e.g. the `38` in
+/// `"1.12.0-alpha.38"`). Returns 0 for a stable version (no `-` present) or
+/// a suffix with no parseable second segment (e.g. a bare `"-rc"`).
+fn extract_prerelease_counter(v: &str) -> u32 {
+    match v.split_once('-') {
+        Some((_, suffix)) => suffix
+            .split('.')
+            .nth(1)
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(0),
+        None => 0,
+    }
+}
+
+/// Compares two semver-ish version strings and returns true if `latest` is
+/// strictly newer than `current`.
+///
+/// Pre-release aware (fixes the bug where consecutive prereleases sharing a
+/// base version — e.g. `"1.12.0-alpha.37"` -> `"1.12.0-alpha.38"` — always
+/// compared equal, since the naive `.split('.')` parse coerced the "0-alpha"
+/// patch segment to 0 for both sides). Comparison proceeds in three tiers,
+/// each only consulted when the previous tier is equal:
+///
+/// 1. **Base version** `(major, minor, patch)`, via [`parse_base_semver`].
+///    A stable release always outranks any pre-release of an *older* base
+///    (e.g. `"1.13.0-alpha.1"` beats `"1.12.0"`).
+/// 2. **Channel rank**, via the existing [`UpdateChannel::from_tag`]
+///    ordering (`Alpha < Beta < Rc < Stable`) — reused rather than
+///    reimplemented so the two "which pre-release is more stable" notions
+///    in this codebase can never drift apart. A stable release of the same
+///    base outranks any pre-release of that base (e.g. `"1.12.0"` beats
+///    `"1.12.0-alpha.38"`).
+/// 3. **Pre-release counter**, via [`extract_prerelease_counter`] — the
+///    trailing `.N` on same-channel pre-releases of the same base (e.g.
+///    `alpha.38` beats `alpha.37`).
+///
+/// This function is shared by every version-comparison call site in this
+/// module (GAMDL, the app itself, Python, pip engines, and binary tools) —
+/// changing its behaviour affects all of them. Plain semver strings with no
+/// pre-release suffix behave exactly as before this fix (tier 1 alone
+/// decides, since tiers 2/3 both evaluate to "equal" for two stable
+/// strings).
 ///
 /// Examples:
-/// - `is_newer("1.0.0`", "1.0.1") => true  (patch bump)
-/// - `is_newer("1.0.0`", "1.0.0") => false (same version)
-/// - `is_newer("2.0.0`", "1.9.9") => false (downgrade)
+/// - `is_newer("1.0.0", "1.0.1")` => true (patch bump)
+/// - `is_newer("1.0.0", "1.0.0")` => false (same version)
+/// - `is_newer("2.0.0", "1.9.9")` => false (downgrade)
+/// - `is_newer("1.12.0-alpha.37", "1.12.0-alpha.38")` => true (counter bump)
+/// - `is_newer("1.12.0-alpha.38", "1.12.0")` => true (stable outranks prerelease of same base)
+/// - `is_newer("1.12.0", "1.13.0-alpha.1")` => true (newer base outranks channel/counter)
 fn is_newer(current: &str, latest: &str) -> bool {
-    // Parse version string into (major, minor, patch) tuple.
-    // Missing or unparseable parts default to 0, making this forgiving
-    // of version strings like "2.0" (treated as 2.0.0) or "v2.1" (0.0.0 — the "v" makes it unparseable).
-    let parse = |v: &str| -> (u32, u32, u32) {
-        let parts: Vec<&str> = v.split('.').collect();
-        let major = parts.first().and_then(|p| p.parse().ok()).unwrap_or(0);
-        let minor = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(0);
-        let patch = parts.get(2).and_then(|p| p.parse().ok()).unwrap_or(0);
-        (major, minor, patch)
-    };
+    let c_base = parse_base_semver(current);
+    let l_base = parse_base_semver(latest);
+    if l_base != c_base {
+        // Rust's tuple comparison is lexicographic: major, then minor, then patch.
+        return l_base > c_base;
+    }
 
-    let c = parse(current);
-    let l = parse(latest);
-    // Rust's tuple comparison is lexicographic: compares major first, then minor, then patch
-    l > c
+    // Same base version — the more stable channel wins (Stable > Rc > Beta > Alpha).
+    let c_channel = UpdateChannel::from_tag(current);
+    let l_channel = UpdateChannel::from_tag(latest);
+    if l_channel != c_channel {
+        return l_channel > c_channel;
+    }
+
+    // Same base version AND same channel — compare the trailing counter
+    // (e.g. alpha.37 vs alpha.38).
+    extract_prerelease_counter(latest) > extract_prerelease_counter(current)
 }
 
 // ============================================================
@@ -1586,8 +1659,12 @@ mod tests {
         assert!(!UpdateChannel::Stable.requires_dev_access());
     }
 
-    /// Tests that is_newer() correctly handles all semver comparison cases:
-    /// patch bumps, minor bumps, major bumps, equal versions, and downgrades.
+    /// Tests that is_newer() correctly handles all plain-semver comparison
+    /// cases: patch bumps, minor bumps, major bumps, equal versions, and
+    /// downgrades. These are the pre-existing cases from before the
+    /// pre-release-aware rework — they MUST behave identically afterward,
+    /// since this comparator is shared with GAMDL, Python, pip engines, and
+    /// binary tool version checks, none of which use pre-release suffixes.
     #[test]
     fn test_is_newer() {
         // Patch bump: 1.0.1 is newer than 1.0.0
@@ -1600,6 +1677,54 @@ mod tests {
         assert!(!is_newer("1.0.0", "1.0.0"));
         // Downgrade: 1.0.0 is not newer than 2.0.0
         assert!(!is_newer("2.0.0", "1.0.0"));
+    }
+
+    /// Regression coverage for the core bug this rework fixes: consecutive
+    /// pre-releases of the SAME base version must compare correctly.
+    ///
+    /// Before the fix, `is_newer()` split naively on '.', so
+    /// "1.12.0-alpha.38".split('.') -> ["1", "12", "0-alpha", "38"] and the
+    /// patch segment ("0-alpha") failed to parse and silently defaulted to
+    /// 0. Every alpha/beta/rc build of a given base version therefore
+    /// compared as exactly equal to every other — in-app updates between
+    /// pre-releases were completely broken for every user on a pre-release
+    /// channel, not just on first run.
+    #[test]
+    fn test_is_newer_prerelease_counter_bump() {
+        // alpha.37 -> alpha.38 (same base, same channel, higher counter)
+        assert!(is_newer("1.12.0-alpha.37", "1.12.0-alpha.38"));
+        // The reverse must NOT be newer.
+        assert!(!is_newer("1.12.0-alpha.38", "1.12.0-alpha.37"));
+        // Equal pre-releases are not newer than themselves.
+        assert!(!is_newer("1.12.0-alpha.38", "1.12.0-alpha.38"));
+        // Same shape, beta channel — not just an alpha-specific fix.
+        assert!(is_newer("1.12.0-beta.1", "1.12.0-beta.2"));
+    }
+
+    /// A stable release of the same base version IS newer than any of its
+    /// own pre-releases — the channel tier (Alpha < Beta < Rc < Stable)
+    /// outranks the pre-release counter once the base versions match.
+    #[test]
+    fn test_is_newer_stable_outranks_own_prereleases() {
+        assert!(is_newer("1.12.0-alpha.38", "1.12.0"));
+        // A higher-ranked channel of the same base is also newer, even with
+        // a "lower" counter than a lesser channel would have.
+        assert!(is_newer("1.12.0-alpha.99", "1.12.0-beta.1"));
+        assert!(is_newer("1.12.0-beta.5", "1.12.0-rc.1"));
+        assert!(is_newer("1.12.0-rc.3", "1.12.0"));
+        // And the reverse (stable is never "older" than its own prereleases).
+        assert!(!is_newer("1.12.0", "1.12.0-alpha.38"));
+    }
+
+    /// A stable (or pre-release) build of a strictly NEWER base version
+    /// outranks pre-releases of an OLDER base, regardless of channel or
+    /// counter — the base-version tuple is always compared first.
+    #[test]
+    fn test_is_newer_base_version_takes_priority_over_channel() {
+        assert!(is_newer("1.12.0", "1.13.0-alpha.1"));
+        // Even a "lowly" alpha.1 of a newer base beats a "highly" rc.9 of
+        // an older base — base version is tier 1, channel is only tier 2.
+        assert!(is_newer("1.12.0-rc.9", "1.13.0-alpha.1"));
     }
 
     /// `derive_cpython_tag` splits a dotted Python version string into

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,9 +24,16 @@
  * 1. Platform detection via usePlatform() hook (async, detects OS)
  * 2. Platform-specific CSS theme loaded dynamically
  * 3. Settings loaded from Rust backend via IPC
- * 4. Update check (unconditional, before setup wizard decision)
+ * 4. Update check (unconditional, before setup wizard decision; bounded by
+ *    an ~8s timeout so a slow/unreachable network can't delay first launch)
  * 5. Dependency checks run in parallel (Python, GAMDL, tools)
- * 6. Setup wizard shown if dependencies are missing AND no app update pending
+ * 6. If dependencies are missing and setup was never completed: either the
+ *    setup wizard is shown directly, OR -- if a compatible app update is
+ *    available -- the first-run update prompt is shown first, letting the
+ *    user choose "Update now" (then relaunch into the wizard on the new
+ *    version) or "Continue setup on this version" (shows the wizard
+ *    immediately). Exactly one of the two always ends up on screen; a user
+ *    is never left with neither.
  * 7. Periodic update timer and tray listener registered
  * 8. Event listeners registered for progress, download lifecycle, and tray
  *
@@ -236,7 +243,10 @@ import type { GamdlProgress, ActivityLogEntry, ComponentUpdate } from './types';
  * 2. Loads the appropriate platform theme CSS
  * 3. Loads settings from the backend
  * 4. Checks if dependencies are installed (Python, GAMDL)
- * 5. Shows the setup wizard if dependencies are missing, or the main UI if ready
+ * 5. Shows the setup wizard if dependencies are missing and setup was never
+ *    completed -- unless a compatible app update is available, in which case
+ *    the first-run update prompt is shown first so the user can choose
+ *    between updating immediately or continuing setup on the current version
  * 6. Auto-checks for updates if enabled in settings
  * 7. Listens for GAMDL progress events from the backend
  * 8. Listens for system tray events (update check trigger)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,7 @@ import { useDependencyStore } from './stores/dependencyStore';
 import { useDownloadStore } from './stores/downloadStore';
 
 /** Update checker: polls for new versions of app components */
-import { useUpdateStore } from './stores/updateStore';
+import { useUpdateStore, findAppComponentUpdate } from './stores/updateStore';
 
 /** Activity log: accumulates raw subprocess output lines */
 import { useActivityStore } from './stores/activityStore';
@@ -465,9 +465,7 @@ function App() {
       let appUpdateAvailable = false;
       try {
         const updateResult = await checkForUpdates();
-        appUpdateAvailable = updateResult.components.some(
-          (c) => c.name === 'app' && c.update_available && c.is_compatible
-        );
+        appUpdateAvailable = !!findAppComponentUpdate(updateResult.components);
       } catch {
         /* Non-fatal: network may be unavailable on first launch */
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,6 +175,14 @@ import SpotifyConsentModal from './components/common/SpotifyConsentModal';
  * @see ./components/common/AppRelocationModal.tsx
  */
 import AppRelocationModal from './components/common/AppRelocationModal';
+/**
+ * FirstRunUpdatePrompt: first-run "an app update is available" prompt.
+ * Takes precedence over the setup wizard on a fresh install/launch when a
+ * compatible app update is available, offering "Update now" or "Continue
+ * setup on this version" -- always resolving to one of the two.
+ * @see ./components/common/FirstRunUpdatePrompt.tsx
+ */
+import FirstRunUpdatePrompt from './components/common/FirstRunUpdatePrompt';
 
 /* ─── Styles ─────────────────────────────────────────────────────────── */
 
@@ -218,7 +226,7 @@ import i18next from 'i18next';
  * Mirrors the Rust struct `GamdlProgress` serialized via serde.
  * @see ./types/index.ts for the full type definition
  */
-import type { GamdlProgress, ActivityLogEntry } from './types';
+import type { GamdlProgress, ActivityLogEntry, ComponentUpdate } from './types';
 
 /**
  * The root component that serves as the entry point for the application UI.
@@ -305,6 +313,8 @@ function App() {
   const currentPage = useUiStore((s) => s.currentPage);
   /** Whether the setup wizard overlay is visible (first-run or missing deps) */
   const showSetupWizard = useUiStore((s) => s.showSetupWizard);
+  /** Whether the first-run "app update available" prompt is visible (takes precedence over the wizard) */
+  const showFirstRunUpdatePrompt = useUiStore((s) => s.showFirstRunUpdatePrompt);
   /** Action to show/hide the setup wizard */
   const setShowSetupWizard = useUiStore((s) => s.setShowSetupWizard);
 
@@ -457,15 +467,40 @@ function App() {
 
       /* Step 2: Check for app updates BEFORE dependency checks.
        * On first launch the installed version may already be outdated, so we
-       * check for updates early. If an app update is available we skip the
-       * setup wizard and let the user update first — the wizard will run on
-       * the new version after restart. The check is unconditional (ignores
-       * the auto_check_updates setting) because first-launch users haven't
-       * configured anything yet. Failures are non-fatal. */
-      let appUpdateAvailable = false;
+       * check for updates early. If a compatible app update is available and
+       * setup was never completed, Step 4 below shows the first-run update
+       * prompt instead of jumping straight to the wizard, letting the user
+       * choose to update first or continue setup on the current version. The
+       * check is unconditional (ignores the auto_check_updates setting)
+       * because first-launch users haven't configured anything yet.
+       *
+       * Bounded by an ~8s timeout via Promise.race: on a network that drops
+       * packets rather than refusing the connection, an unbounded await here
+       * would delay the entire startup sequence (and therefore the setup
+       * wizard) by however long the underlying HTTP client takes to give up.
+       * A late-arriving result after the timeout still reaches the user
+       * normally via the update banner in the main UI (checkForUpdates()
+       * itself isn't cancelled -- only this startup gate stops waiting on
+       * it). Failures (network unavailable, timeout) are non-fatal; the
+       * flow proceeds as if no update were available. */
+      let appComponent: ComponentUpdate | undefined;
       try {
-        const updateResult = await checkForUpdates();
-        appUpdateAvailable = !!findAppComponentUpdate(updateResult.components);
+        const STARTUP_UPDATE_CHECK_TIMEOUT_MS = 8000;
+        const updateResult = await Promise.race([
+          checkForUpdates(),
+          new Promise<null>((resolve) => {
+            setTimeout(() => resolve(null), STARTUP_UPDATE_CHECK_TIMEOUT_MS);
+          }),
+        ]);
+        if (updateResult) {
+          appComponent = findAppComponentUpdate(updateResult.components);
+        } else {
+          console.info(
+            '[startup] Update check did not complete within 8s — proceeding to dependency ' +
+              'checks/setup wizard without waiting. A late result will still surface via the ' +
+              'update banner once it arrives.'
+          );
+        }
       } catch {
         /* Non-fatal: network may be unavailable on first launch */
       }
@@ -474,20 +509,30 @@ function App() {
       await checkAll();
 
       /*
-       * Step 4: Show setup wizard if dependencies are missing AND setup
-       * has never been completed AND no app update is pending. If an app
-       * update is available, we skip the wizard so the user sees the
-       * update banner in the main UI and can update first. After updating
-       * and restarting, the wizard will run on the new version.
+       * Step 4: Decide between the setup wizard and the first-run update
+       * prompt when dependencies are missing AND setup has never been
+       * completed.
        *
        * If the user has completed setup before (`setup_completed: true`),
-       * skip the wizard even if some deps are missing — they may have been
+       * skip both overlays even if some deps are missing — they may have been
        * intentionally removed, or the app was updated and detection is
        * temporarily broken. The user can always re-run the wizard from Settings.
        *
        * We read the latest state imperatively via getState() rather than
        * using the reactive selectors, because at this point the async
        * `checkAll()` has just completed and we need the freshest snapshot.
+       *
+       * When a first-run wizard IS needed, a compatible app update changes
+       * which overlay appears first: the first-run update prompt (Step 4a)
+       * takes precedence over the wizard so the user can choose to update
+       * immediately (which relaunches into the wizard on the new version)
+       * or continue setup on the current version. Exactly one of the two
+       * is shown here — never neither, never both stacked. This deliberately
+       * does NOT consult `UpdateCheckResult.has_updates`: that aggregate
+       * flag also goes true whenever GAMDL is simply "not installed yet"
+       * (the normal state of a fresh install), which would suppress the
+       * wizard on essentially every first launch. `appComponent` from
+       * Step 2 already narrows this to the app's own update specifically.
        */
       const depState = useDependencyStore.getState();
       const settingsState = useSettingsStore.getState();
@@ -499,8 +544,17 @@ function App() {
         depState.gamdl?.installed &&
         requiredToolsReady
       );
-      if (!depsReady && !settingsState.settings.setup_completed && !appUpdateAvailable) {
-        setShowSetupWizard(true);
+      const needsFirstRunWizard = !depsReady && !settingsState.settings.setup_completed;
+      if (needsFirstRunWizard) {
+        if (appComponent?.tag_name) {
+          // Step 4a: first-run update prompt takes precedence over the wizard.
+          useUiStore.getState().setShowFirstRunUpdatePrompt(true, {
+            tagName: appComponent.tag_name,
+            latestVersion: appComponent.latest_version,
+          });
+        } else {
+          setShowSetupWizard(true);
+        }
       }
 
       /*
@@ -512,16 +566,23 @@ function App() {
        * by comparing the current app version against `last_seen_version`
        * (which the Rust backend updates in load_settings()).
        *
-       * The notice is suppressed if the setup wizard is shown (to avoid
-       * modal stacking) — it will appear on the next launch after setup.
+       * The notice is suppressed if the setup wizard or the first-run update
+       * prompt is shown (to avoid modal stacking) — it will appear on the
+       * next launch after setup.
        */
       try {
         const currentVersion = await getVersion();
         const isPrerelease = currentVersion.startsWith('0.');
         const previousVersion = settingsState.settings.last_seen_version;
         const versionChanged = previousVersion !== '' && previousVersion !== currentVersion;
+        const uiStateForNotice = useUiStore.getState();
 
-        if (isPrerelease && versionChanged && !useUiStore.getState().showSetupWizard) {
+        if (
+          isPrerelease &&
+          versionChanged &&
+          !uiStateForNotice.showSetupWizard &&
+          !uiStateForNotice.showFirstRunUpdatePrompt
+        ) {
           useUiStore.getState().setShowPrereleaseNotice(true);
         }
 
@@ -529,7 +590,8 @@ function App() {
         if (
           !settingsState.settings.crash_report_prompt_shown &&
           settingsState.settings.setup_completed &&
-          !useUiStore.getState().showSetupWizard
+          !uiStateForNotice.showSetupWizard &&
+          !uiStateForNotice.showFirstRunUpdatePrompt
         ) {
           useUiStore.getState().setShowCrashReportPrompt(true);
         }
@@ -1067,6 +1129,21 @@ function App() {
         <LoadingSpinner size="lg" label="Loading MeedyaDL..." />
       </div>
     );
+  }
+
+  /*
+   * ─── Render: First-Run Update Prompt ────────────────────────────────
+   * Takes precedence over the setup wizard when both would otherwise be
+   * eligible (see Step 4 in the initialization effect). Rendered as a
+   * full-screen early return, matching the setup wizard's own pattern,
+   * so no other overlay can stack on top of it. Resolves to either the
+   * updater (relaunches into the wizard on the new version) or the
+   * setup wizard on the current version -- it never leaves the user on
+   * this screen with no way forward.
+   * @see ./components/common/FirstRunUpdatePrompt.tsx
+   */
+  if (showFirstRunUpdatePrompt) {
+    return <FirstRunUpdatePrompt />;
   }
 
   /*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,18 +609,26 @@ function App() {
        * user hasn't already said "Not now", offer to move it in.
        * Suppressed while the setup wizard or another first-launch modal
        * is about to show, to avoid stacking overlays on top of each
-       * other. Failures are non-fatal — the offer is entirely optional.
+       * other. Also suppressed while an app update is pending a restart
+       * or actively downloading -- relocation relaunches the app in
+       * place, and doing that with an update still in flight would cost
+       * the user a second restart without either updating or completing
+       * setup. Failures are non-fatal — the offer is entirely optional.
        */
       try {
         const offer = await checkAppRelocation();
         const uiState = useUiStore.getState();
+        const updateState = useUpdateStore.getState();
         if (
           offer.eligible &&
           offer.destination &&
           !settingsState.settings.relocation_declined &&
           !uiState.showSetupWizard &&
           !uiState.showPrereleaseNotice &&
-          !uiState.showCrashReportPrompt
+          !uiState.showCrashReportPrompt &&
+          !uiState.showFirstRunUpdatePrompt &&
+          !updateState.isDownloadingUpdate &&
+          !updateState.updateInstalled
         ) {
           uiState.setShowAppRelocationPrompt(true, offer.destination);
         }

--- a/src/components/common/FirstRunUpdatePrompt.tsx
+++ b/src/components/common/FirstRunUpdatePrompt.tsx
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 MeedyaSuite
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * @file FirstRunUpdatePrompt.tsx -- First-run "an app update is available" prompt.
+ *
+ * Shown instead of the setup wizard when BOTH of these are true on a fresh
+ * install/launch:
+ *   1. `settings.setup_completed` is false (the user hasn't finished the
+ *      setup wizard yet), AND
+ *   2. A compatible MeedyaDL app update is available (per
+ *      `findAppComponentUpdate()` in `updateStore.ts`).
+ *
+ * ## Why this exists
+ *
+ * Previously, `<App>` silently suppressed the setup wizard whenever an app
+ * update was pending, on the theory that the user should update first and
+ * let the wizard run on the new version after restart. But the gate that
+ * detected "update available" was broken (see #935-era audit — it compared
+ * against a component name the backend never emits), so this path was
+ * effectively dead in practice. Fixing that gate on its own would have
+ * reintroduced a real dead end: a fresh install with no dependencies
+ * installed, and no setup wizard shown because an update is "pending" --
+ * the user would be stuck looking at a loading screen with no way forward
+ * if they didn't want to update immediately (offline, slow network,
+ * deliberately testing a specific version, etc).
+ *
+ * This component replaces silent suppression with an explicit choice that
+ * ALWAYS terminates in one of two places:
+ *   - **Update now**: downloads and installs the update, then relaunches.
+ *     Errors are shown inline and the prompt stays open so the user can
+ *     retry or fall back to continuing setup.
+ *   - **Continue setup on this version**: dismisses the prompt and shows
+ *     the setup wizard immediately, on the currently-installed version.
+ *
+ * @see ../../stores/uiStore.ts -- showFirstRunUpdatePrompt / firstRunUpdatePromptInfo
+ * @see ../../App.tsx -- the startup effect that decides whether to show this
+ */
+
+import { useCallback } from 'react';
+import { Download, RotateCcw } from 'lucide-react';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { useUiStore } from '@/stores/uiStore';
+import { useUpdateStore } from '@/stores/updateStore';
+import { Button } from './Button';
+import { Modal } from './Modal';
+
+export default function FirstRunUpdatePrompt() {
+  const show = useUiStore((s) => s.showFirstRunUpdatePrompt);
+  const info = useUiStore((s) => s.firstRunUpdatePromptInfo);
+  const setShowFirstRunUpdatePrompt = useUiStore((s) => s.setShowFirstRunUpdatePrompt);
+  const setFirstRunUpdateDeferred = useUiStore((s) => s.setFirstRunUpdateDeferred);
+  const setShowSetupWizard = useUiStore((s) => s.setShowSetupWizard);
+  const addToast = useUiStore((s) => s.addToast);
+
+  const downloadAndInstallAppUpdate = useUpdateStore((s) => s.downloadAndInstallAppUpdate);
+  const isDownloadingUpdate = useUpdateStore((s) => s.isDownloadingUpdate);
+  const downloadProgress = useUpdateStore((s) => s.downloadProgress);
+  const updateInstalled = useUpdateStore((s) => s.updateInstalled);
+  const downloadError = useUpdateStore((s) => s.downloadError);
+
+  /**
+   * Move on to the setup wizard on the currently-installed version.
+   * Records the session-local "deferred" flag so this prompt never
+   * resurfaces on top of the wizard it just opened, then flips the two
+   * visibility flags together so there is never a render with neither
+   * overlay showing.
+   */
+  const handleContinueSetup = useCallback(() => {
+    setFirstRunUpdateDeferred(true);
+    setShowFirstRunUpdatePrompt(false);
+    setShowSetupWizard(true);
+  }, [setFirstRunUpdateDeferred, setShowFirstRunUpdatePrompt, setShowSetupWizard]);
+
+  /**
+   * Download, install, and relaunch into the update. On failure the
+   * prompt intentionally stays open (with the error surfaced inline via
+   * `downloadError` from the store) so the user can either retry or fall
+   * back to "Continue setup on this version" -- never a dead end.
+   */
+  const handleUpdateNow = useCallback(async () => {
+    if (!info) return;
+    try {
+      await downloadAndInstallAppUpdate(info.tagName);
+      await relaunch();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      addToast(message || 'Failed to download and install update', 'error');
+    }
+  }, [info, downloadAndInstallAppUpdate, addToast]);
+
+  const handleRestart = useCallback(async () => {
+    try {
+      await relaunch();
+    } catch {
+      addToast('Failed to restart. Please restart manually.', 'error');
+    }
+  }, [addToast]);
+
+  if (!show || !info) return null;
+
+  return (
+    <Modal
+      // Escape / backdrop-click must not strand the user with neither
+      // overlay visible -- treat dismissal the same as the explicit
+      // "Continue setup" choice, which is the safe (non-destructive)
+      // default of the two paths.
+      open={show}
+      onClose={handleContinueSetup}
+      title="Update Available"
+      maxWidth="max-w-lg"
+    >
+      <div className="space-y-4 text-sm text-content-secondary">
+        <p>
+          A newer version of MeedyaDL{' '}
+          {info.latestVersion && (
+            <>
+              (<span className="text-content-primary font-medium">v{info.latestVersion}</span>)
+            </>
+          )}{' '}
+          is available. You can install it now before setting up MeedyaDL, or continue setup on
+          the version you already have and update later.
+        </p>
+
+        {downloadError && (
+          <div className="rounded-platform border border-status-error/30 bg-status-error/5 p-3">
+            <p className="text-xs text-status-error">{downloadError}</p>
+          </div>
+        )}
+
+        {isDownloadingUpdate && (
+          <div className="flex items-center gap-2">
+            <div className="flex-1 h-1.5 bg-surface-secondary rounded-full overflow-hidden">
+              <div
+                className="h-full bg-accent rounded-full transition-all duration-300"
+                style={{ width: `${downloadProgress ?? 0}%` }}
+              />
+            </div>
+            <span className="text-xs text-content-tertiary tabular-nums">
+              {downloadProgress != null ? `${downloadProgress}%` : '...'}
+            </span>
+          </div>
+        )}
+
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3 pt-2">
+          <Button variant="ghost" onClick={handleContinueSetup} disabled={isDownloadingUpdate}>
+            Continue Setup on This Version
+          </Button>
+          {updateInstalled ? (
+            <Button variant="primary" icon={<RotateCcw size={14} />} onClick={handleRestart}>
+              Restart Now
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              icon={<Download size={14} />}
+              loading={isDownloadingUpdate}
+              onClick={handleUpdateNow}
+            >
+              {downloadError ? 'Retry Update' : 'Update Now'}
+            </Button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/common/PrereleaseNoticeModal.tsx
+++ b/src/components/common/PrereleaseNoticeModal.tsx
@@ -34,7 +34,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 import { useUiStore } from '../../stores/uiStore';
-import { useUpdateStore } from '../../stores/updateStore';
+import { useUpdateStore, APP_COMPONENT_NAME } from '../../stores/updateStore';
 import type { ComponentUpdate } from '../../types';
 import { Modal } from './Modal';
 
@@ -54,7 +54,8 @@ export default function PrereleaseNoticeModal() {
   // Check if there's a stable (non-prerelease) update available
   const latestUpdate = useUpdateStore((s): ComponentUpdate | undefined =>
     s.lastResult?.components.find(
-      (c: ComponentUpdate) => c.name === 'app' && c.update_available && c.is_compatible && !c.is_prerelease
+      (c: ComponentUpdate) =>
+        c.name === APP_COMPONENT_NAME && c.update_available && c.is_compatible && !c.is_prerelease
     )
   );
 

--- a/src/components/common/UpdateBanner.tsx
+++ b/src/components/common/UpdateBanner.tsx
@@ -53,7 +53,7 @@ import { useMemo } from 'react';
 import { relaunch } from '@tauri-apps/plugin-process';
 
 /** Zustand store for update state (available updates, dismiss, upgrade actions) */
-import { useUpdateStore } from '@/stores/updateStore';
+import { useUpdateStore, APP_COMPONENT_NAME } from '@/stores/updateStore';
 
 /** Zustand store for general UI state (toast notifications) */
 import { useUiStore } from '@/stores/uiStore';
@@ -74,7 +74,7 @@ import { Button } from './Button';
  * space in the layout when there is nothing to show.
  */
 // Core components shown with full detail; engine updates shown generically.
-const CORE_COMPONENTS = ['MeedyaDL', 'GAMDL', 'Python Runtime'];
+const CORE_COMPONENTS = [APP_COMPONENT_NAME, 'GAMDL', 'Python Runtime'];
 
 export function UpdateBanner() {
   /*
@@ -343,7 +343,7 @@ export function UpdateBanner() {
                    * 2. isDownloadingUpdate: progress bar with percentage
                    * 3. Default: "Download & Install" button (requires tag_name)
                    */}
-                  {update.name === 'MeedyaDL' && (
+                  {update.name === APP_COMPONENT_NAME && (
                     <>
                       {updateInstalled ? (
                         <Button

--- a/src/components/updates/UpdatesPage.tsx
+++ b/src/components/updates/UpdatesPage.tsx
@@ -25,7 +25,7 @@ import {
 } from 'lucide-react';
 import { relaunch } from '@tauri-apps/plugin-process';
 
-import { useUpdateStore } from '@/stores/updateStore';
+import { useUpdateStore, APP_COMPONENT_NAME } from '@/stores/updateStore';
 import { useUiStore } from '@/stores/uiStore';
 import { PageHeader } from '@/components/layout';
 import { Button } from '@/components/common';
@@ -45,7 +45,7 @@ function stripDownloadSection(body: string): string {
 
 // Core components shown individually with full detail in the Updates page.
 // Engine updates (everything else) are aggregated into a single generic card.
-const CORE_COMPONENTS = ['MeedyaDL', 'GAMDL', 'Python Runtime'];
+const CORE_COMPONENTS = [APP_COMPONENT_NAME, 'GAMDL', 'Python Runtime'];
 
 export function UpdatesPage() {
   const lastResult = useUpdateStore((s) => s.lastResult);
@@ -82,7 +82,7 @@ export function UpdatesPage() {
   // Current app version from the last check result
   const currentVersion = useMemo(() => {
     if (!lastResult) return null;
-    const app = lastResult.components.find((c) => c.name === 'MeedyaDL');
+    const app = lastResult.components.find((c) => c.name === APP_COMPONENT_NAME);
     return app?.current_version ?? null;
   }, [lastResult]);
 
@@ -346,7 +346,7 @@ export function UpdatesPage() {
                     )}
 
                     {/* MeedyaDL app update */}
-                    {update.name === 'MeedyaDL' && (
+                    {update.name === APP_COMPONENT_NAME && (
                       <>
                         {updateInstalled ? (
                           <Button
@@ -448,7 +448,7 @@ export function UpdatesPage() {
                 )}
 
                 {/* Download error with manual fallback */}
-                {update.name === 'MeedyaDL' && downloadError && !updateInstalled && (
+                {update.name === APP_COMPONENT_NAME && downloadError && !updateInstalled && (
                   <div className="rounded-platform border border-status-error/30 bg-status-error/5 p-3 mb-3">
                     <p className="text-xs text-status-error mb-2">{downloadError}</p>
                     {update.release_url && (
@@ -464,7 +464,7 @@ export function UpdatesPage() {
                 )}
 
                 {/* Full release notes (markdown) for MeedyaDL */}
-                {update.name === 'MeedyaDL' && update.release_body && (
+                {update.name === APP_COMPONENT_NAME && update.release_body && (
                   <div className="mt-4 pt-4 border-t border-border-light">
                     <h4 className="text-xs font-semibold text-content-secondary uppercase tracking-wider mb-3">
                       Release Notes
@@ -498,7 +498,7 @@ export function UpdatesPage() {
                 )}
 
                 {/* Description for non-MeedyaDL components */}
-                {update.name !== 'MeedyaDL' && update.description && (
+                {update.name !== APP_COMPONENT_NAME && update.description && (
                   <p className="text-sm text-content-secondary">{update.description}</p>
                 )}
               </div>

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -154,6 +154,48 @@ interface UiState {
   setShowCrashReportPrompt: (show: boolean) => void;
 
   /**
+   * Whether the first-run "an app update is available" prompt is shown.
+   *
+   * Flipped by `<App>`'s startup effect when BOTH `setup_completed` is
+   * false AND a compatible app update is available. Supersedes the old
+   * behaviour of silently skipping the setup wizard whenever an update
+   * was pending -- that left first-run users on an old version stranded
+   * with no dependencies installed and no visible path forward. The
+   * prompt always resolves to exactly one of two destinations: the
+   * in-app updater (`downloadAndInstallAppUpdate` + relaunch) or the
+   * setup wizard (`showSetupWizard`) -- see `FirstRunUpdatePrompt.tsx`.
+   */
+  showFirstRunUpdatePrompt: boolean;
+
+  /**
+   * The release the first-run update prompt would install, captured at
+   * the moment `<App>`'s startup effect detects it. `null` when the
+   * prompt is hidden.
+   */
+  firstRunUpdatePromptInfo: { tagName: string; latestVersion: string | null } | null;
+
+  /**
+   * Show or hide the first-run update prompt. Pass `info` when showing it;
+   * omitted (or the prompt being hidden) clears it.
+   */
+  setShowFirstRunUpdatePrompt: (
+    show: boolean,
+    info?: { tagName: string; latestVersion: string | null } | null
+  ) => void;
+
+  /**
+   * Session-local flag set when the user explicitly chooses "Continue
+   * setup on this version" from the first-run update prompt. Not
+   * persisted -- it exists only to record, for the remainder of this
+   * process's lifetime, that the user has already made this decision so
+   * the prompt is never re-shown on top of the wizard it just opened.
+   */
+  firstRunUpdateDeferred: boolean;
+
+  /** Set the first-run "continue on this version" deferred flag. */
+  setFirstRunUpdateDeferred: (deferred: boolean) => void;
+
+  /**
    * Whether the Spotify first-run consent modal is visible (M9-UI).
    * Flipped by `DownloadForm.runPreflightAndSubmit` when it detects
    * a Spotify URL and `spotify_consent_acknowledged` is still false.
@@ -323,6 +365,9 @@ export const useUiStore = create<UiState>((set, get) => ({
   showSetupWizard: false, // Setup wizard hidden until <App> decides to show it
   showPrereleaseNotice: false, // Pre-release notice hidden until version change detected
   showCrashReportPrompt: false, // Crash report opt-in prompt (first launch only)
+  showFirstRunUpdatePrompt: false, // First-run "app update available" prompt hidden until <App> decides to show it
+  firstRunUpdatePromptInfo: null, // No pending release info until the prompt is shown
+  firstRunUpdateDeferred: false, // User hasn't chosen "Continue setup on this version" yet
   showSpotifyConsent: false, // M9-UI: Spotify first-run consent modal
   pendingSpotifyConsentCallback: null, // M9-UI: callback to invoke on consent accept
   showAppRelocationPrompt: false, // #1057: macOS self-relocation offer modal
@@ -360,6 +405,16 @@ export const useUiStore = create<UiState>((set, get) => ({
   /** Show or hide the pre-release first-load notice modal. */
   setShowPrereleaseNotice: (show) => set({ showPrereleaseNotice: show }),
   setShowCrashReportPrompt: (show: boolean) => set({ showCrashReportPrompt: show }),
+
+  /** Show or hide the first-run update prompt, capturing the target release when shown. */
+  setShowFirstRunUpdatePrompt: (show, info = null) =>
+    set({
+      showFirstRunUpdatePrompt: show,
+      firstRunUpdatePromptInfo: show ? info : null,
+    }),
+
+  /** Record (or clear) the user's "continue setup on this version" choice. */
+  setFirstRunUpdateDeferred: (deferred) => set({ firstRunUpdateDeferred: deferred }),
 
   /** Show or hide the macOS self-relocation offer modal (#1057). */
   setShowAppRelocationPrompt: (show, destination = null) =>

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 MeedyaSuite
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * @file src/stores/updateStore.test.ts - Unit tests for the app-component
+ * update gate.
+ *
+ * Regression coverage for a bug where the frontend compared
+ * `ComponentUpdate.name` against the string `'app'`, but the Rust backend
+ * always emits the app component as `name: "MeedyaDL"`
+ * (`update_checker.rs::parse_release_from_response` and its two early-return
+ * paths). The mismatch meant `findAppComponentUpdate()` — and every gate
+ * built on top of it (the first-run update prompt, the pre-release notice's
+ * stable-release offer) — was permanently dead: it always returned
+ * `undefined` even when a genuine app update was available.
+ *
+ * @see src/stores/updateStore.ts - `APP_COMPONENT_NAME` + `findAppComponentUpdate`
+ */
+
+import { describe, expect, it } from 'vitest';
+import { APP_COMPONENT_NAME, findAppComponentUpdate } from './updateStore';
+import type { ComponentUpdate } from '@/types';
+
+/** Minimal valid `ComponentUpdate` fixture; tests override only what they need. */
+function makeComponent(overrides: Partial<ComponentUpdate>): ComponentUpdate {
+  return {
+    name: 'GAMDL',
+    current_version: '1.0.0',
+    latest_version: '1.0.0',
+    update_available: false,
+    is_compatible: true,
+    is_untested: false,
+    no_compatible_wheel: false,
+    description: null,
+    release_url: null,
+    release_body: null,
+    is_prerelease: false,
+    tag_name: null,
+    pip_package: null,
+    tool_id: null,
+    ...overrides,
+  };
+}
+
+describe('findAppComponentUpdate', () => {
+  it('finds an actionable MeedyaDL app update', () => {
+    const components = [
+      makeComponent({ name: APP_COMPONENT_NAME, update_available: true, is_compatible: true }),
+    ];
+
+    const result = findAppComponentUpdate(components);
+
+    expect(result).toBeDefined();
+    expect(result?.name).toBe('MeedyaDL');
+  });
+
+  it('does NOT trigger on a GAMDL-only update result', () => {
+    const components = [
+      makeComponent({ name: 'GAMDL', update_available: true, is_compatible: true }),
+    ];
+
+    expect(findAppComponentUpdate(components)).toBeUndefined();
+  });
+
+  it('does not match the old (incorrect) "app" name string', () => {
+    // Regression guard: the bug compared against the literal string 'app',
+    // which the backend never emits. If someone reintroduces that literal
+    // this fixture (using the real backend name) would still fail to match
+    // it, proving the comparison uses APP_COMPONENT_NAME and not 'app'.
+    const components = [
+      makeComponent({ name: 'app', update_available: true, is_compatible: true }),
+    ];
+
+    expect(findAppComponentUpdate(components)).toBeUndefined();
+  });
+
+  it('ignores a MeedyaDL entry that is not actually available or compatible', () => {
+    expect(
+      findAppComponentUpdate([
+        makeComponent({ name: APP_COMPONENT_NAME, update_available: false, is_compatible: true }),
+      ])
+    ).toBeUndefined();
+
+    expect(
+      findAppComponentUpdate([
+        makeComponent({ name: APP_COMPONENT_NAME, update_available: true, is_compatible: false }),
+      ])
+    ).toBeUndefined();
+  });
+});

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -56,6 +56,49 @@ import type { ComponentUpdate, UpdateCheckResult } from '@/types';
 import * as commands from '@/lib/tauri-commands';
 
 /**
+ * The `ComponentUpdate.name` value the Rust backend uses for the MeedyaDL
+ * app itself (see `parse_release_from_response()` /
+ * `check_app_update()`'s early-return paths in
+ * `src-tauri/src/services/update_checker.rs`).
+ *
+ * Every frontend call site that needs to pick the app's own entry out of
+ * an `UpdateCheckResult.components[]` array MUST compare against this
+ * constant rather than a hardcoded string literal. A prior mismatch
+ * (comparing against the string `'app'`, which the backend never emits)
+ * silently broke the first-run "app update available" gate in `App.tsx`
+ * and the stable-release offer in `PrereleaseNoticeModal.tsx` — the
+ * comparison always evaluated to false, so those code paths simply never
+ * fired. Centralising the string here means a future rename only needs
+ * to change one place.
+ */
+export const APP_COMPONENT_NAME = 'MeedyaDL';
+
+/**
+ * Finds the app's own `ComponentUpdate` entry in a components array,
+ * gated to a genuinely actionable state: the entry must be named
+ * {@link APP_COMPONENT_NAME}, report `update_available`, and be
+ * `is_compatible`. Shared by every call site that needs to answer
+ * "is there an app update the user could install right now?" — the
+ * first-run update gate in `App.tsx` being the primary consumer.
+ *
+ * Deliberately does NOT filter on `is_prerelease` — callers that care
+ * about that additional axis (e.g. `PrereleaseNoticeModal`'s "offer a
+ * stable release instead" banner) apply their own extra filter on top
+ * of this base predicate.
+ *
+ * @param components - The `components[]` array from an `UpdateCheckResult`
+ * @returns The app's `ComponentUpdate`, or `undefined` if no actionable
+ *   app update is present
+ */
+export function findAppComponentUpdate(
+  components: ComponentUpdate[]
+): ComponentUpdate | undefined {
+  return components.find(
+    (c) => c.name === APP_COMPONENT_NAME && c.update_available && c.is_compatible
+  );
+}
+
+/**
  * Combined state + actions interface for the update store.
  *
  * State tracks:


### PR DESCRIPTION
## Summary

In-app updates **between pre-releases have been silently broken** — every tester sitting on an older alpha has never been offered a newer one. This fixes that, plus two related bugs in the same area and a first-run dead end.

Found while investigating a narrower question: *does MeedyaDL check for updates before the first-run setup wizard?* The intended gate already existed in `App.tsx` — but it was dead code on three independent grounds.

## The three bugs

**1. Pre-release-blind version comparison — highest impact.** `is_newer()` split the version on `.` and parsed `(major, minor, patch)` with `unwrap_or(0)`. For `1.12.0-alpha.38`, `"0-alpha"` fails to parse, giving `(1,12,0)`. Every alpha in a series collapses to the same tuple, so `alpha.37 → alpha.38` was never "newer". **This affected all pre-release users on every launch, not just first run.**

**2. Dead first-run gate.** The wizard suppression matched the component named `'app'`, but the backend emits `"MeedyaDL"`. `appUpdateAvailable` has been permanently `false` since the feature landed. Other call sites already used the correct name — so this fix introduces a **single shared constant** rather than a fourth hardcoded string.

**3. No timeout on the GAMDL version lookup.** A bare `reqwest::get` with no client timeout meant a packet-dropping network could stall startup for minutes before the wizard appeared. Now uses the house `build_simple(10)` pattern.

## The first-run dead end

Had bug 2 been fixed as originally designed, declining an update would have suppressed the setup wizard **permanently** — including via Settings → "Re-run Setup Wizard", which reloads and re-triggers the same suppression. The user would be left with no dependencies and no route back.

Replaced with an explicit prompt offering **Update now** or **Continue setup on this version**, which always terminates in either the updater or the wizard.

The macOS relocation offer is now also gated on update state — previously a user could relocate (which relaunches) with an update still pending, restarting twice without either updating or setting up.

## Deliberately NOT changed

**Fresh installs still default to the Stable channel** (owner decision). Consequence, stated plainly: someone installing an alpha build still won't see alpha updates until they switch channel in Settings. This PR fixes detection for everyone already on a pre-release channel — which is the population that matters for the alpha cycle.

Also avoided: gating on the aggregate `has_updates`. That includes GAMDL, and a fresh install reports GAMDL "not installed" as an available update — which would have suppressed the wizard on essentially every first launch.

## Scope of changes

- [x] Rust backend (`update_checker.rs`, `gamdl_service.rs`)
- [x] React / TypeScript frontend (`App.tsx`, update store, prompt component)
- [ ] IPC surface / settings schema — unchanged
- [x] Documentation — corrected the stale startup-sequence comments

## Test plan

- [x] `cargo test` — 18 pass, including four new comparison cases: consecutive alphas order correctly; a stable release outranks its own pre-releases; base version takes priority over channel; plain semver behaves exactly as before
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `npm run type-check` clean; `npm run test` — 564 tests across 37 files pass
- [x] `check_ipc_commands.py` consistent (125 invoke targets)
- [x] Grepped the tree: no stray `'app'` component comparisons remain
- [ ] **Not verified on real hardware** — the actual update round-trip needs a VM with two published pre-releases, and Windows relaunch semantics differ

## Why the plain-semver regression test matters

`is_newer()` is shared with the GAMDL and tool version checks. A change that only considered app versions could silently break tool update detection, so the existing plain-semver cases are asserted unchanged.

## Related

Follows the first-run analysis. The remaining open question — whether fresh pre-release installs should infer their channel — was decided as **no**, and is deliberately out of scope here.

Release-Note: MeedyaDL now correctly spots newer test releases, so updates between preview versions arrive as they should.
Release-Note: If an update is waiting the first time you open MeedyaDL, you can now choose to install it first or carry on setting up — whichever you pick, setup always completes.
Release-Note: MeedyaDL starts up promptly even when your connection is slow or unreliable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC

---
_Generated by [Claude Code](https://claude.ai/code/session_012UxJQgvDRJNpJQgBmA8xEC)_