### PR TITLE
fix(rc): pin meedya-core to SHA rev instead of deleted branch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "meedya-codecs"
 version = "0.1.0"
-source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?branch=claude%2Finteresting-mirzakhani#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=0a4654ff4db30d27fc0e29699f342a93ebc86d94#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
 dependencies = [
  "meedya-metadata",
  "serde",
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "meedya-core"
 version = "0.1.0"
-source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?branch=claude%2Finteresting-mirzakhani#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=0a4654ff4db30d27fc0e29699f342a93ebc86d94#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
 dependencies = [
  "meedya-codecs",
  "meedya-fingerprint",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "meedya-fingerprint"
 version = "0.1.0"
-source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?branch=claude%2Finteresting-mirzakhani#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=0a4654ff4db30d27fc0e29699f342a93ebc86d94#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
 dependencies = [
  "reqwest 0.12.28",
  "rusty-chromaprint 0.2.0",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "meedya-metadata"
 version = "0.1.0"
-source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?branch=claude%2Finteresting-mirzakhani#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=0a4654ff4db30d27fc0e29699f342a93ebc86d94#0a4654ff4db30d27fc0e29699f342a93ebc86d94"
 dependencies = [
  "async-trait",
  "fuzzy-matcher",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ tauri-build = { version = "2", features = [] }
 # ---- MeedyaSuite-core ----
 # Shared core library providing metadata providers, codec detection, and fingerprinting.
 # @see https://github.com/MWBMPartners/MeedyaSuite-core
-meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core", branch = "claude/interesting-mirzakhani", features = ["full"] }
+meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core", rev = "0a4654ff4db30d27fc0e29699f342a93ebc86d94", features = ["full"] }
 
 # ---- Tauri Framework & Plugins ----
 # These provide the core application framework and platform-specific capabilities.


### PR DESCRIPTION
## Summary

Fixes the **Release-Candidate Release #23** deploy failure. The `release-candidate` branch pinned `meedya-core` (and its MeedyaSuite-core sibling crates) to the git branch `claude/interesting-mirzakhani`, which has since been **deleted**. `cargo generate-lockfile` in the rc release workflow therefore failed:

```
error: failed to get `meedya-core` as a dependency of package `meedyadl` …
  unable to update https://github.com/MWBMPartners/MeedyaSuite-core?branch=claude/interesting-mirzakhani
  failed to find branch `claude/interesting-mirzakhani`
```

Release-Note: none

## Root cause

`main`, `alpha`, and `beta` already pin the same commit via `rev = "0a4654ff4db30d27fc0e29699f342a93ebc86d94"`. `release-candidate` was left behind on the old **branch** reference (it never received the SHA-pin update its upstream `beta` and downstream `main` both have). When #1095 (the extract-zip fix) merged, it was the first push to `release-candidate` since May, so it was the first to run the release workflow — which surfaced this pre-existing breakage. **Not caused by the extract-zip change** (that touched only the JS side).

## Change

- `src-tauri/Cargo.toml`: `meedya-core` `branch = "claude/interesting-mirzakhani"` → `rev = "0a4654ff…"` (exact match to main/alpha/beta).
- `src-tauri/Cargo.lock`: the source line for all **4** MeedyaSuite-core crates (`meedya-core`, `meedya-codecs`, `meedya-fingerprint`, `meedya-metadata`) swapped `?branch=…` → `?rev=…`.

**Zero code change:** the resolved commit (`#0a4654ff…`) is identical before and after — this only makes the reference resolvable again. The `git grep` for `interesting-mirzakhani` is now empty, and rc's 4 MeedyaSuite-core source lines match main's byte-for-byte.

## Scope

- [x] Build config (`Cargo.toml` / `Cargo.lock`) — dependency reference only
- [ ] No Rust/TS/settings/IPC source changes

## Note

PRs to `release-candidate` currently run **no CI** (a separate config gap — rc's `ci.yml` only triggers on PRs to `main`), so this can't be validated by a PR check. It's validated by construction: byte-identical `meedya-core` reference to the main/alpha/beta channels that build successfully. The authoritative check is the rc **release workflow** re-running green after merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_