### PR TITLE
ci: promote alpha's ci.yml + release-note-gate to release-candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 MeedyaDL
+# Copyright (c) 2026 MeedyaSuite
 # Licensed under the MIT License. See LICENSE file in the project root.
 #
 # Continuous Integration (CI) Workflow for MeedyaDL
@@ -47,12 +47,22 @@ name: CI
 # ============================================================
 # @see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
-  # Run on pushes to main and develop branches (direct commits and merged PRs)
+  # Run on pushes to main and the long-lived channel branches (direct commits
+  # and merged PRs). "develop" never existed in this repo and was dead
+  # config; the real gap it was masking was `alpha` -- direct pushes there
+  # got ZERO CI even though `alpha-release.yml` immediately cuts a release
+  # from every push to that branch. beta/release-candidate get the same
+  # treatment for the same reason: each has its own push-triggered release
+  # workflow that would otherwise ship an unvalidated build straight to a
+  # channel users can opt into.
   push:
-    branches: [main, develop]
-  # Run on pull requests targeting main (validates PR code before merge)
+    branches: [main, alpha, beta, release-candidate]
+  # Run on pull requests targeting main and the long-lived channel branches
+  # (validates PR code before merge). alpha is where active development lands,
+  # so it needs the full Backend/Frontend + clippy matrix too — previously
+  # only main did, leaving every alpha PR ungated (#1040 roadmap finding).
   pull_request:
-    branches: [main]
+    branches: [main, alpha, beta, release-candidate]
   # Allow manual trigger from GitHub UI or CLI (gh workflow run "CI")
   # Useful for conserving Actions minutes during rapid development:
   #   1. Push commits with "[skip ci]" in the message to skip auto-triggers
@@ -128,8 +138,22 @@ jobs:
       #   - It uses the exact versions from package-lock.json (no version drift)
       #   - It deletes node_modules/ first for a deterministic install
       #   - It fails if package-lock.json is out of sync with package.json
+      #
+      # `shell: bash` + quiet flags (closes #823):
+      # - `shell: bash` sidesteps the GitHub-Actions-default pwsh
+      #   dot-source pattern (`pwsh -command ". '{0}'"`) on Windows
+      #   runners, which has a known failure mode of silently
+      #   swallowing a child process's stdout/stderr when the process
+      #   exits mid-output-flush. The 2026-05-18 #823 flake reproduced
+      #   exactly that: `npm ci` exited 1 in 19 s with zero output.
+      # - `--no-progress` removes the progress-bar TTY interaction
+      #   that interacts badly with pwsh.
+      # - `--no-audit` because the dedicated "Security audit" step
+      #   below already runs `npm audit --audit-level=high`.
+      # - `--no-fund` skips an unnecessary informational network call.
       - name: Install dependencies
-        run: npm ci
+        shell: bash
+        run: npm ci --no-audit --no-fund --no-progress
 
       # Step 3.5: Check for known vulnerabilities in npm dependencies.
       # 'npm audit' checks installed packages against the npm advisory database.
@@ -166,10 +190,29 @@ jobs:
   backend:
     name: Backend (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Suppress Node's DEP0040 punycode deprecation warning emitted by
+    # `@actions/cache`'s bundled dependencies, which the Swatinem/rust-cache
+    # post step invokes. The warning is cosmetic — neither MeedyaDL nor the
+    # action's hot path call `require('punycode')` — but it clutters CI logs
+    # on every cache save. Job-level env propagates to both the main and post
+    # steps of every action in this job. Targeted (`--disable-warning=DEP0040`
+    # rather than `--no-deprecation`) so other deprecations remain visible.
+    # @see https://github.com/MWBMPartners/MeedyaDL/issues — punycode audit 2026-05-17
+    env:
+      NODE_OPTIONS: --disable-warning=DEP0040
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-14 pinned (not macos-latest) because the macos-15 runner image
+        # rotated in mid-2026 ships a Homebrew `cargo` shim at
+        # `/opt/homebrew/bin/cargo` that proxies to `rustup-init` when rustup
+        # isn't fully initialised. With the current `dtolnay/rust-toolchain`
+        # pin, that shim wins the PATH race and `cargo check` resolves to
+        # `rustup-init`, failing with `error: unexpected argument 'check'
+        # found`. Pinning the previous LTS image bypasses the shim.
+        # Revisit when `dtolnay/rust-toolchain` (or a successor action) ships
+        # a version that handles the new image layout.
+        os: [ubuntu-latest, macos-14, windows-latest]
 
     steps:
       # Step 1: Check out the repository code.
@@ -199,21 +242,136 @@ jobs:
             libssl-dev \
             libgtk-3-dev
 
+      # Step 2.5: Scrub Homebrew rustup-init shims on macOS runners.
+      # GitHub macOS runner images ship Homebrew-installed `rustup-init` plus
+      # symlinks at `/opt/homebrew/bin/{cargo,rustc,rustdoc,rustup,rustup-init}`
+      # (and the older `/usr/local/bin/` Intel paths). When rustup isn't fully
+      # initialised the shim falls back to running `rustup-init`, so any later
+      # `cargo check` resolves to the installer and fails with
+      # `error: unexpected argument 'check' found`. The first attempt at fixing
+      # this just pinned `macos-14` — same shim layout, same failure.
+      # Removing the shims here, BEFORE `dtolnay/rust-toolchain` runs, lets
+      # the rustup install put `~/.cargo/bin/cargo` on PATH unopposed.
+      - name: Remove Homebrew rustup shims (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Scrubbing Homebrew rustup shims AND stale ~/.cargo/bin/ symlinks..."
+          # /opt/homebrew/bin/ + /usr/local/bin/ — Homebrew install paths.
+          for bindir in /opt/homebrew/bin /usr/local/bin; do
+            for binname in cargo rustc rustdoc rustup rustup-init; do
+              target="$bindir/$binname"
+              if [ -e "$target" ] || [ -L "$target" ]; then
+                echo "  removing $target"
+                sudo rm -f "$target"
+              fi
+            done
+          done
+          # ~/.cargo/bin/ — runner image bakes this in pre-symlinked to
+          # the Homebrew rustup-init we just removed (PR #770 v3 root
+          # cause). Wipe it too so the upstream installer rebuilds clean
+          # links to ~/.cargo/bin/rustup (the actual proxy, not
+          # rustup-init).
+          if [ -d "${HOME}/.cargo/bin" ]; then
+            for binname in cargo rustc rustdoc rustup rustup-init; do
+              target="${HOME}/.cargo/bin/${binname}"
+              if [ -e "$target" ] || [ -L "$target" ]; then
+                echo "  removing $target"
+                rm -f "$target"
+              fi
+            done
+          fi
+          # ~/.rustup/ — pre-installed on the runner image; without
+          # removing it, `rustup-init.sh` short-circuits with
+          # "Updating existing toolchain" and never re-populates
+          # ~/.cargo/bin/. Wipe so the installer takes the fresh path.
+          if [ -d "${HOME}/.rustup" ]; then
+            echo "  removing ${HOME}/.rustup (forces fresh install)"
+            rm -rf "${HOME}/.rustup"
+          fi
+          echo "Done. Remaining cargo on PATH (should be empty until Setup Rust runs):"
+          command -v cargo || echo "  (none — good, Setup Rust will install a clean one)"
+
       # Step 3: Set up the Rust stable toolchain with clippy.
-      # dtolnay/rust-toolchain@stable installs the latest stable Rust compiler.
-      # The 'clippy' component is the Rust linter, added for the clippy step below.
+      #
+      # On Linux/Windows, dtolnay/rust-toolchain places real binaries at
+      # ~/.cargo/bin/ via upstream rustup-init.sh and just works.
+      #
+      # On macOS, dtolnay re-creates `/opt/homebrew/bin/rustup-init` (the
+      # very shim that Step 2.5 just scrubbed) and symlinks
+      # ~/.cargo/bin/cargo back to it, perpetuating the original shim
+      # bug — `cargo check` resolves to `rustup-init check` which exits
+      # 1 with `unexpected argument 'check' found`. The PR #770 v2
+      # diagnostic step caught this happening at 20:38:09 UTC on
+      # commit 27b7000.
+      #
+      # Bypass the action entirely on macOS — run upstream rustup-init.sh
+      # ourselves. The official installer places REAL binaries at
+      # ~/.cargo/bin/{cargo,rustc,rustup,...} (proxied through rustup,
+      # not rustup-init), which is what every subsequent step expects.
       # @see https://github.com/dtolnay/rust-toolchain
-      - name: Setup Rust
+      # @see https://rustup.rs (upstream rustup installer source)
+      - name: Setup Rust (Linux/Windows)
+        if: runner.os != 'macOS'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
+
+      - name: Setup Rust (macOS — upstream rustup, bypasses Homebrew shim)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `--default-toolchain stable` matches dtolnay/rust-toolchain@stable.
+          # `--profile minimal` skips docs/tests we don't need on CI.
+          # `--component clippy` matches the dtolnay step's `with: components: clippy`.
+          # `-y` accepts all defaults non-interactively.
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y \
+                --default-toolchain stable \
+                --profile minimal \
+                --component clippy
+          echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
+
+      # Step 3.5: Diagnostic + sanity check — confirm cargo on PATH is the
+      # rustup-managed binary, not a Homebrew rustup-init shim. Same step
+      # runs again right before `cargo check` (the actual failure point on
+      # the v1 fix) so we can pinpoint whether state degrades between steps.
+      # The realpath check is stronger than the earlier `cargo --version |
+      # grep rustup-init` approach which falsely passed in the v1 fix run.
+      - name: Verify cargo is rustup-managed (post-setup)
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== Rust toolchain diagnostic (post-setup) ==="
+          echo "PATH=$PATH"
+          echo "CARGO_HOME=${CARGO_HOME:-<unset>}"
+          echo "RUSTUP_HOME=${RUSTUP_HOME:-<unset>}"
+          cargo_path="$(command -v cargo)" || { echo "::error::cargo not on PATH"; exit 1; }
+          echo "command -v cargo => $cargo_path"
+          if command -v realpath >/dev/null 2>&1; then
+            echo "realpath           => $(realpath "$cargo_path")"
+          fi
+          case "$cargo_path" in
+            */.cargo/bin/cargo|*/cargo/bin/cargo) ;;
+            *)
+              echo "::error::cargo on PATH ($cargo_path) is NOT in ~/.cargo/bin — likely a Homebrew/system shim."
+              exit 1 ;;
+          esac
+          if [ "$(basename "$cargo_path")" = "rustup-init" ] || \
+             (command -v realpath >/dev/null 2>&1 && [ "$(basename "$(realpath "$cargo_path")")" = "rustup-init" ]); then
+            echo "::error::cargo resolves to rustup-init."
+            exit 1
+          fi
+          cargo --version
 
       # Step 4: Cache Rust compilation artifacts for faster builds.
       # Caches the target/ directory within src-tauri/ (the Cargo workspace).
       # This can save 5-15 minutes on subsequent runs by reusing compiled dependencies.
       # @see https://github.com/Swatinem/rust-cache
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: src-tauri
 
@@ -228,8 +386,13 @@ jobs:
 
       # Step 6: Install npm dependencies.
       # Needed for step 7 (building the frontend).
+      # `shell: bash` + quiet flags applied here for the same reason
+      # as the Frontend job's step 3 — closes #823. The Backend job
+      # didn't reproduce the flake on 2026-05-18 but uses identical
+      # tooling, so the same hardening applies as defence-in-depth.
       - name: Install npm dependencies
-        run: npm ci
+        shell: bash
+        run: npm ci --no-audit --no-fund --no-progress
 
       # Step 7: Build the frontend.
       # Runs 'vite build' to generate the dist/ directory with compiled HTML/JS/CSS.
@@ -237,6 +400,33 @@ jobs:
       # and cargo check would fail without it.
       - name: Build frontend
         run: npm run build
+
+      # Step 7.5: Re-run the cargo-shim diagnostic from the working dir that
+      # `cargo check` will actually use. If cargo state changed between
+      # Setup Rust and now (cache restore, Node.js setup, npm install, etc.),
+      # this is where we'll see it — with full PATH dump for forensic context.
+      - name: Verify cargo is rustup-managed (pre-cargo-check)
+        working-directory: src-tauri
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== Rust toolchain diagnostic (pre-cargo-check) ==="
+          echo "PWD=$(pwd)"
+          echo "PATH=$PATH"
+          echo "CARGO_HOME=${CARGO_HOME:-<unset>}"
+          echo "RUSTUP_HOME=${RUSTUP_HOME:-<unset>}"
+          cargo_path="$(command -v cargo)" || { echo "::error::cargo not on PATH"; exit 1; }
+          echo "command -v cargo => $cargo_path"
+          if command -v realpath >/dev/null 2>&1; then
+            echo "realpath           => $(realpath "$cargo_path")"
+          fi
+          case "$cargo_path" in
+            */.cargo/bin/cargo|*/cargo/bin/cargo) ;;
+            *)
+              echo "::error::cargo on PATH ($cargo_path) is NOT in ~/.cargo/bin at cargo-check time."
+              exit 1 ;;
+          esac
+          cargo --version
 
       # Step 8: Verify Rust compilation.
       # 'cargo check' runs the compiler without producing a binary -- much faster than

--- a/.github/workflows/release-note-gate.yml
+++ b/.github/workflows/release-note-gate.yml
@@ -1,0 +1,325 @@
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Release Note Gate (#1028)
+# ==========================
+#
+# A cheap PR gate for MeedyaDL's ELI5 release-notes pipeline. No build step
+# -- this workflow only reads PR metadata and (for the release-please job)
+# checks a file's presence/shape, so it stays fast on every PR.
+#
+# Four independent jobs:
+#
+#   1. pr-trailer
+#      Every user-facing PR (title starts with `feat`/`fix`/`perf`) must
+#      end its body with a `Release-Note: <plain English line>` trailer
+#      (or `Release-Note: none`). That trailer becomes a commit footer at
+#      squash-merge time (repo squash settings = PR_TITLE + PR_BODY) and
+#      is what `.github/cliff-eli5-body.tera` / `cliff-cumulative-body.tera`
+#      read to render ELI5 release notes. See
+#      .github/release-notes/STYLE_GUIDE.md for the writing rules. Also
+#      content-lints the trailer via scripts/release-notes/lint-notes.py
+#      (closes leak L1 -- see .github/audits/release-notes-policy-audit-
+#      2026-07-24.md §3.2/§4.3).
+#
+#   2. release-pr-notes-file
+#      Gates the release-please PR itself (branch prefix
+#      `release-please--`). Stable cuts require a hand-polished tier-1
+#      file at `.github/release-notes/v<version>.md` (see
+#      .github/release-notes/README.md) to already be merged to main
+#      before the release-please PR can merge. `scripts/release-notes/
+#      draft-notes.sh` bootstraps that file from any Release-Note:
+#      trailers already on main. Also content-lints that file (part of
+#      closing leak L6).
+#
+#   3. push-trailer-advisory (#1046)
+#      job 1 only fires on `pull_request` -- but CLAUDE.md's documented
+#      convention is "push fix:/feat: commits directly to main", which
+#      never opens a PR and so never sees job 1. This job scans commits
+#      pushed directly to main/alpha/beta/release-candidate and warns
+#      (advisory only -- a push can't be un-pushed) on any feat/fix/perf
+#      commit missing a Release-Note: trailer, while the author is still
+#      likely to be looking at the Actions tab.
+#
+#   4. notes-file-lint
+#      Lints every `.github/release-notes/*.md` file touched by a PR
+#      (excluding STYLE_GUIDE.md / README.md), regardless of whether the
+#      PR is release-please's own branch. Closes leak L6 for curated
+#      files that never transit job 2 -- prerelease backfills, retro
+#      scrubs, and any future notes file staged ahead of a release-please
+#      cut.
+#
+# All jobs that read untrusted PR/commit title and body strings use
+# `env:` to pass them into `run:` blocks -- never direct `${{ }}`
+# interpolation in a shell command, which would let a crafted title/body
+# break out of the script (the same injection-hardening pattern used by
+# version-bump.yml and release.yml's workflow_dispatch inputs).
+
+name: Release Note Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, alpha, beta, release-candidate]
+  push:
+    branches: [main, alpha, beta, release-candidate]
+
+permissions:
+  contents: read
+
+# Cancel a stale run when the PR is updated again -- these are cheap
+# metadata checks, no point letting an old run finish after a new push.
+# Push events have no PR number, so fall back to the commit SHA (still
+# unique per push, just doesn't dedupe against other events).
+concurrency:
+  group: release-note-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # ------------------------------------------------------------------
+  # Job 1: require a Release-Note: trailer on every user-facing PR body.
+  # ------------------------------------------------------------------
+  pr-trailer:
+    name: Release-Note trailer present
+    runs-on: ubuntu-latest
+    # Skip release-please's own PR (fixed template body, not authored by
+    # a human, nothing to gate) and dependabot PRs (never user-facing in
+    # the ELI5 sense -- dependency bumps are covered by the "deps-only"
+    # release-notes shape, not per-PR trailers).
+    if: >-
+      !startsWith(github.event.pull_request.head.ref, 'release-please--') &&
+      github.actor != 'dependabot[bot]'
+    steps:
+      # Needed to reach scripts/release-notes/lint-notes.py for the
+      # content-lint step below (audit §4.3 point 1).
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check for a Release-Note trailer on user-facing PRs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Only feat/fix/perf PRs are user-facing in the changelog sense.
+          # Matches the conventional-commit type followed by "(", "!", or
+          # ":" -- e.g. "feat:", "feat(wrapper):", "fix!:".
+          if ! printf '%s' "$PR_TITLE" | grep -qE '^(feat|fix|perf)(\(|!|:)'; then
+            echo "PR title '${PR_TITLE}' is not feat/fix/perf -- no Release-Note trailer required."
+            exit 0
+          fi
+
+          # Require a line starting with "Release-Note: " followed by at
+          # least one non-whitespace character (so a bare "Release-Note:"
+          # with nothing after it still fails the check).
+          if ! printf '%s' "$PR_BODY" | grep -qE '^Release-Note: \S'; then
+            echo "::error::This PR has no 'Release-Note:' line in its body. Add one plain-English line per user-visible change (see .github/release-notes/STYLE_GUIDE.md), or 'Release-Note: none' if nothing is user-visible."
+            exit 1
+          fi
+
+          echo "Release-Note trailer found."
+
+      # Content lint (audit §4.3 point 1, closes leak L1 -- "verbatim
+      # trailers, unlinted"): the presence check above only confirms a
+      # Release-Note: line exists, not that its content is safe to render
+      # verbatim. Every trailer line is piped through lint-notes.py
+      # --trailer, which enforces both plain-English (STYLE_GUIDE.md
+      # "Hard bans") and mechanism-confidentiality ("Never reveal how a
+      # feature is delivered"). Blocking.
+      - name: Lint Release-Note trailer content
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "$PR_TITLE" | grep -qE '^(feat|fix|perf)(\(|!|:)'; then
+            echo "PR title '${PR_TITLE}' is not feat/fix/perf -- no Release-Note trailer to lint."
+            exit 0
+          fi
+
+          printf '%s\n' "$PR_BODY" \
+            | grep -E '^Release-Note: ' \
+            | sed 's/^Release-Note: //' \
+            | python3 scripts/release-notes/lint-notes.py --trailer
+
+  # ------------------------------------------------------------------
+  # Job 2: the release-please PR must carry a merged tier-1 notes file.
+  # ------------------------------------------------------------------
+  release-pr-notes-file:
+    name: Tier-1 release-notes file present
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref, 'release-please--')
+    steps:
+      # Default checkout on a pull_request event resolves to the PR's
+      # merge ref (base + head merged) -- so a tier-1 file merged to main
+      # via a separate PR shows up here even though release-please's own
+      # branch never touches .github/release-notes/.
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Require a populated tier-1 notes file for this version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Release-please PR titles look like "chore(main): release 1.11.0".
+          VER=$(printf '%s' "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$VER" ]; then
+            echo "::error::Could not parse a version number out of the PR title '${PR_TITLE}'."
+            exit 1
+          fi
+
+          NOTES_FILE=".github/release-notes/v${VER}.md"
+          echo "Checking for: ${NOTES_FILE}"
+
+          if [ ! -f "$NOTES_FILE" ]; then
+            echo "::error::${NOTES_FILE} is missing. Run 'scripts/release-notes/draft-notes.sh v${VER}', polish the draft per .github/release-notes/STYLE_GUIDE.md, merge it to main, then re-run this check."
+            exit 1
+          fi
+
+          if ! grep -qE '^### ' "$NOTES_FILE"; then
+            echo "::error::${NOTES_FILE} exists but has no populated '### ' sections (What's new / What's fixed / Performance / Notes). Run 'scripts/release-notes/draft-notes.sh v${VER}', polish the draft per .github/release-notes/STYLE_GUIDE.md, merge it to main, then re-run this check."
+            exit 1
+          fi
+
+          echo "${NOTES_FILE} is present and populated."
+
+          # Content lint (audit §4.3 point 2, part of closing leak L6 --
+          # "curated files & splices are applied verbatim"): the shape
+          # check above only confirms populated sections exist, not that
+          # their content is safe to publish. Blocking.
+          if ! python3 scripts/release-notes/lint-notes.py "$NOTES_FILE"; then
+            echo "::error::${NOTES_FILE} failed the release-notes content lint (mechanism disclosure or commit-speak -- see findings above). Fix per .github/release-notes/STYLE_GUIDE.md and re-run this check."
+            exit 1
+          fi
+
+  # ------------------------------------------------------------------
+  # Job 3: advisory-only trailer check for commits pushed directly to a
+  # channel branch (#1046) -- closes the gap where job 1 (pull_request-
+  # only) never sees this repo's documented "push fix:/feat: commits
+  # directly to main" workflow.
+  # ------------------------------------------------------------------
+  push-trailer-advisory:
+    name: Release-Note trailer present (direct push, advisory)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+    steps:
+      # fetch-depth: 0 so `git rev-list before..after` can walk the
+      # actual pushed range -- a shallow checkout would only have the
+      # tip commit and every earlier SHA would be "missing".
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan pushed commits for missing Release-Note trailers
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # A branch's first-ever push sets BEFORE to the all-zeroes SHA;
+          # a force-push / history rewrite can also leave BEFORE
+          # unreachable from this checkout. Neither has a meaningful
+          # "newly pushed commits" range, so skip rather than false-
+          # positive on unrelated pre-existing history.
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+            echo "No usable commit range for this push (new branch or rewritten history) -- skipping."
+            exit 0
+          fi
+
+          MISSING=0
+          for SHA in $(git rev-list "${BEFORE_SHA}..${AFTER_SHA}"); do
+            SUBJECT=$(git log -1 --format='%s' "$SHA")
+            # Same feat/fix/perf gate as job 1 (pr-trailer).
+            if ! printf '%s' "$SUBJECT" | grep -qE '^(feat|fix|perf)(\(|!|:)'; then
+              continue
+            fi
+            BODY=$(git log -1 --format='%b' "$SHA")
+            if ! printf '%s' "$BODY" | grep -qE '^Release-Note: \S'; then
+              echo "::warning::Commit ${SHA:0:9} ('${SUBJECT}') is feat/fix/perf but has no 'Release-Note:' trailer. Direct-pushed commits should carry one too, same as PR bodies (see .claude/CLAUDE.md Conventions and .github/release-notes/STYLE_GUIDE.md). It can still be added via 'git commit --amend' before anything else builds on top of this commit."
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          if [ "$MISSING" -gt 0 ]; then
+            {
+              echo "### Release-Note trailer check (advisory)"
+              echo
+              echo "${MISSING} direct-pushed \`feat\`/\`fix\`/\`perf\` commit(s) in this push have no \`Release-Note:\` trailer. See the warnings above for which commits."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "All feat/fix/perf commits in this push carry a Release-Note trailer (or there were none)."
+          fi
+
+          # Advisory only -- a push already happened; never fail the job.
+          exit 0
+
+  # ------------------------------------------------------------------
+  # Job 4: content-lint every release-notes file touched by this PR
+  # (audit §4.3 point 3, closes leak L6 -- "curated files & splices are
+  # applied verbatim"). Runs independently of job 2's release-please
+  # branch filter, so it also covers prerelease backfills and retro
+  # scrubs staged on ordinary feature PRs (e.g. the alpha.30/.31 repair
+  # files, or a future v1.10.0-alpha.15-style scrub) that never touch a
+  # `release-please--` branch.
+  # ------------------------------------------------------------------
+  notes-file-lint:
+    name: Lint changed release-notes files
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      # fetch-depth: 0 -- the pull_request event checks out the PR's
+      # merge ref (two parents: base + head), and we need both endpoints
+      # reachable locally to diff exactly the files this PR changed.
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Find changed release-notes files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # STYLE_GUIDE.md / README.md are policy documents, not curated
+          # release notes -- they legitimately quote denylisted terms as
+          # examples of what NOT to write, so linting them would be all
+          # false positives. --diff-filter=d excludes deleted files (a
+          # notes file removed in this PR obviously can't be lint-opened).
+          FILES=$(git diff --name-only --diff-filter=d "${BASE_SHA}" "${HEAD_SHA}" -- '.github/release-notes/*.md' \
+            | grep -vE '/(STYLE_GUIDE|README)\.md$' || true)
+
+          {
+            echo "files<<GATE_EOF"
+            echo "$FILES"
+            echo "GATE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Lint changed notes files
+        if: steps.changed.outputs.files != ''
+        env:
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -euo pipefail
+
+          STATUS=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "Linting: $f"
+            python3 scripts/release-notes/lint-notes.py "$f" || STATUS=1
+          done <<< "$FILES"
+
+          exit "$STATUS"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meedyadl",
-  "version": "1.0.0-rc.21",
+  "version": "1.0.0-rc.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meedyadl",
-      "version": "1.0.0-rc.21",
+      "version": "1.0.0-rc.34",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -57,14 +57,14 @@
         "jsdom": "^29.1.1",
         "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.13",
+        "postcss": "^8.5.26",
         "prettier": "^3.8.3",
         "puppeteer": "^25.6.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
         "tailwindcss": "^4.2.2",
         "terser": "^5.46.2",
         "typescript": "^6.0.3",
-        "vite": "^8.0.10",
+        "vite": "^8.2.1",
         "vitest": "^4.1.5"
       }
     },
@@ -140,12 +140,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -164,21 +164,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -205,14 +205,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -222,14 +222,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -259,29 +259,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -301,18 +301,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -320,27 +320,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -359,33 +359,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -393,14 +393,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -891,33 +891,10 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1121,9 +1098,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1134,19 +1111,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1157,19 +1134,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1184,9 +1181,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1201,9 +1198,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1218,9 +1215,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1235,9 +1232,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1252,9 +1249,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1269,9 +1266,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1286,9 +1283,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1303,9 +1300,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1320,9 +1317,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1337,9 +1334,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1350,19 +1347,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1373,19 +1370,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1396,19 +1393,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1419,19 +1416,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1442,19 +1439,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1465,19 +1462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1488,19 +1485,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1511,39 +1508,56 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1554,16 +1568,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1574,16 +1588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1594,7 +1608,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1661,29 +1675,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1883,9 +1878,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -1900,9 +1895,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -1917,9 +1912,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -1934,9 +1929,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -1951,9 +1946,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -1968,9 +1963,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
@@ -1985,9 +1980,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
@@ -2002,9 +1997,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2019,9 +2014,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
@@ -2036,9 +2031,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
@@ -2053,9 +2048,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
@@ -2070,9 +2065,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -2086,29 +2081,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -2123,9 +2099,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -3014,17 +2990,6 @@
         }
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3634,9 +3599,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.11.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3657,22 +3622,22 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -3690,11 +3655,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3721,9 +3686,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -4159,9 +4124,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.406",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
+      "integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4559,9 +4524,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5223,10 +5188,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6644,9 +6619,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6670,11 +6645,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -6854,9 +6832,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6890,9 +6868,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -6910,7 +6888,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7265,14 +7243,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7281,27 +7259,26 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7325,9 +7302,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7338,48 +7315,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -7605,9 +7587,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7751,9 +7733,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7848,9 +7830,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {
@@ -7947,17 +7929,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7973,7 +7955,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -8022,6 +8004,267 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -68,17 +68,22 @@
     "jsdom": "^29.1.1",
     "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0",
-    "postcss": "^8.5.13",
+    "postcss": "^8.5.26",
     "prettier": "^3.8.3",
     "puppeteer": "^25.6.0",
-    "sharp": "^0.34.5",
+    "sharp": "^0.35.3",
     "tailwindcss": "^4.2.2",
     "terser": "^5.46.2",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10",
+    "vite": "^8.2.1",
     "vitest": "^4.1.5"
   },
   "overrides": {
-    "basic-ftp": "^5.3.1"
+    "basic-ftp": "^5.3.1",
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.4.0",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17",
+    "undici": "^7.29.0"
   }
 }

--- a/scripts/release-notes/apply-notes.sh
+++ b/scripts/release-notes/apply-notes.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# scripts/release-notes/apply-notes.sh
+# =====================================
+#
+# Ships the tier-1 ELI5 release-notes file for a tag onto the matching
+# GitHub Release, PRESERVING the existing "Choose your download" footer
+# that release.yml appends once the per-platform builds finish.
+#
+# Part of #1028 -- this is the "also overwrites pre-created releases"
+# half of the pipeline: release-please and version-bump.yml both create
+# the release object ahead of (or without) a hand-written body, and this
+# script is the corrective pass that replaces everything ABOVE the
+# download-table footer with the polished tier-1 file, whenever it's run
+# -- before the platform builds finish, after, or as a later fix-up.
+#
+# USAGE:
+#   scripts/release-notes/apply-notes.sh <TAG> [REPO]
+#
+#   TAG   The release tag, e.g. v1.11.0. Must have a matching
+#         .github/release-notes/<TAG>.md file (see README.md in that
+#         directory and scripts/release-notes/draft-notes.sh).
+#   REPO  Optional. Defaults to MWBMPartners/MeedyaDL.
+#
+# IDEMPOTENT: if the release body already matches "notes file + existing
+# footer", this exits 0 without calling `gh release edit` again.
+
+set -euo pipefail
+
+TAG="${1:-}"
+REPO="${2:-MWBMPartners/MeedyaDL}"
+
+if [ -z "$TAG" ]; then
+  echo "Usage: $0 <TAG> [REPO]" >&2
+  echo "  e.g. $0 v1.11.0" >&2
+  echo "       $0 v1.11.0 MWBMPartners/MeedyaDL" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NOTES_FILE="$REPO_ROOT/.github/release-notes/${TAG}.md"
+
+if [ ! -f "$NOTES_FILE" ]; then
+  echo "ERROR: ${NOTES_FILE} not found." >&2
+  echo "Draft one with: scripts/release-notes/draft-notes.sh ${TAG}" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: the GitHub CLI ('gh') is required." >&2
+  exit 1
+fi
+
+# Use temp files (not env vars / command substitution) to pass the live
+# release body and the notes file into python -- release bodies can be
+# large once a few platform build tables are appended, and shell argv /
+# environment both have size limits that a growing changelog would
+# eventually hit.
+BODY_FILE="$(mktemp)"
+NEW_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$NEW_FILE"' EXIT
+
+echo "Fetching current release body for ${TAG} (repo: ${REPO})..."
+gh release view "$TAG" --repo "$REPO" --json body -q .body > "$BODY_FILE"
+
+# Footer-preserving splice: replace everything above the "## Choose your
+# download" table with $NOTES_FILE, keeping the table (and the "---"
+# divider above it) verbatim. Shared with release.yml's ensure-release
+# self-heal path (#1046) -- see splice-body.py for the exact regex.
+python3 "$REPO_ROOT/scripts/release-notes/splice-body.py" "$NOTES_FILE" "$BODY_FILE" "$NEW_FILE"
+
+if diff -q "$BODY_FILE" "$NEW_FILE" >/dev/null 2>&1; then
+  echo "Release ${TAG} is already current -- nothing to do."
+  exit 0
+fi
+
+echo "Updating release ${TAG} body from ${NOTES_FILE}..."
+gh release edit "$TAG" --repo "$REPO" --notes-file "$NEW_FILE"
+echo "Done."

--- a/scripts/release-notes/detect-commit-speak.py
+++ b/scripts/release-notes/detect-commit-speak.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# scripts/release-notes/detect-commit-speak.py
+# ==============================================
+#
+# Heuristic detector for #1046: is a GitHub Release body raw commit-speak
+# (an old-format git-cliff render, or bare "chore(alpha): X.Y.Z" version-
+# bump noise) rather than the #1027/#1028 ELI5 format?
+#
+# Used by .github/workflows/release.yml's "ensure-release" self-heal path
+# to decide whether a PRERELEASE whose GitHub Release already exists (and
+# has no tier-1 curated notes file staged) should be regenerated. Stables
+# are never auto-rewritten by that path -- they always require an
+# explicit curated file -- so this detector is only consulted for
+# prerelease tags.
+#
+# USAGE:
+#   detect-commit-speak.py < body.md
+#   echo "$BODY" | detect-commit-speak.py
+#
+# EXIT CODE:
+#   0  the body LOOKS LIKE commit-speak / bare noise -- should self-heal.
+#   1  the body already has ELI5-format markers -- leave it alone.
+#
+# HEURISTIC (mirrors the diagnosis report .github/audits/
+# release-notes-eli5-diagnosis-2026-07-24.md section 4, G1):
+#   Treat as commit-speak if the body matches an old-format signal
+#   (a raw git-cliff "## [x.y.z]" version header, or a bare
+#   "### Maintenance" bump-only section) AND lacks every one of the
+#   new-format markers that #1027/#1028 always emit for a real ELI5
+#   render (What's new / What's fixed / Notes / Under the hood / the
+#   honest "no user-facing changes" preamble).
+
+import re
+import sys
+
+# Old-format signals: a raw git-cliff version header, or the maintenance-only
+# bump noise that was the literal symptom reported in #1046.
+OLD_FORMAT_SIGNALS = (
+    re.compile(r"^## \[[0-9]", re.MULTILINE),
+    re.compile(r"###\s*(?:\U0001F9F9\s*)?Maintenance", re.IGNORECASE),
+)
+
+# New-format markers: any one of these means #1027/#1028 already ran and
+# produced a real ELI5 body -- never self-heal over it.
+NEW_FORMAT_MARKERS = (
+    "### What's new",
+    "### What's fixed",
+    "### Notes",
+    "### Under the hood",
+    "_No user-facing changes",
+)
+
+
+def is_commit_speak(body: str) -> bool:
+    if not body or not body.strip():
+        # An empty/missing body is not "commit-speak" in the literal
+        # sense, but it's certainly not a good ELI5 body either -- treat
+        # it the same way so a blank release also gets healed.
+        return True
+
+    has_new_format_marker = any(marker in body for marker in NEW_FORMAT_MARKERS)
+    if has_new_format_marker:
+        return False
+
+    has_old_format_signal = any(
+        pattern.search(body) for pattern in OLD_FORMAT_SIGNALS
+    )
+    return has_old_format_signal
+
+
+def main() -> int:
+    body = sys.stdin.read()
+    return 0 if is_commit_speak(body) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release-notes/draft-notes.sh
+++ b/scripts/release-notes/draft-notes.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# scripts/release-notes/draft-notes.sh
+# =====================================
+#
+# Drafts a tier-1 ELI5 release-notes skeleton for a version that is about
+# to ship. Part of #1028 -- the Release-Note-trailer ELI5 pipeline.
+#
+# USAGE:
+#   scripts/release-notes/draft-notes.sh <TAG> [PREV_TAG]
+#
+#   TAG       Version to draft, e.g. v1.11.0 or v1.11.0-alpha.29.
+#   PREV_TAG  Optional. Defaults to the previous tag of the same channel:
+#             the previous stable tag for a stable vX.Y.Z, or the
+#             previous same-base same-channel tag for a prerelease
+#             (e.g. v1.11.0-alpha.28 for v1.11.0-alpha.29).
+#
+# OUTPUT:
+#   .github/release-notes/<TAG>.md.draft
+#
+#   The .draft suffix is deliberate -- release-note-gate.yml's
+#   release-pr-notes-file job only looks for "<TAG>.md" (no suffix), so
+#   this file is inert until a human (or Claude) polishes it per
+#   .github/release-notes/STYLE_GUIDE.md and renames it (drop ".draft")
+#   before merging to main.
+#
+# WHAT IT DOES:
+#   1. Works out PREV_TAG if it wasn't supplied.
+#   2. Seeds the ELI5 sections from any Release-Note: trailers already
+#      merged since PREV_TAG (cliff-eli5-body.tera does the grouping
+#      into What's new / What's fixed / Performance / Notes).
+#   3. Appends the full technical git-cliff changelog for the same range,
+#      wrapped in an HTML comment, as raw source material for polishing.
+#
+# NOTE ON RANGES: TAG is normally NOT a real git tag yet when this script
+# runs -- the whole point is to satisfy release-note-gate.yml's
+# release-pr-notes-file check BEFORE the release-please PR merges and the
+# tag is cut. So the git-cliff range end falls back to HEAD unless TAG
+# already exists (e.g. re-drafting a prerelease after the fact).
+#
+# See also:
+#   scripts/release-notes/apply-notes.sh -- ships the polished file to a
+#   GitHub Release once <TAG>.md.draft has been renamed to <TAG>.md and
+#   merged to main.
+
+set -euo pipefail
+
+TAG="${1:-}"
+PREV_TAG_ARG="${2:-}"
+
+if [ -z "$TAG" ]; then
+  echo "Usage: $0 <TAG> [PREV_TAG]" >&2
+  echo "  e.g. $0 v1.11.0" >&2
+  echo "       $0 v1.11.0-alpha.29 v1.11.0-alpha.28" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+ELI5_TEMPLATE=".github/cliff-eli5-body.tera"
+OUT_FILE=".github/release-notes/${TAG}.md.draft"
+
+if [ ! -f "$ELI5_TEMPLATE" ]; then
+  echo "ERROR: ${ELI5_TEMPLATE} not found." >&2
+  exit 1
+fi
+
+if ! command -v git-cliff >/dev/null 2>&1; then
+  echo "ERROR: git-cliff is required (e.g. 'brew install git-cliff')." >&2
+  exit 1
+fi
+
+# --- Work out PREV_TAG --------------------------------------------------
+if [ -n "$PREV_TAG_ARG" ]; then
+  PREV_TAG="$PREV_TAG_ARG"
+else
+  if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # Stable release -- previous stable tag only (no prerelease suffix).
+    PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+$'
+  elif [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-([A-Za-z]+)\.[0-9]+$ ]]; then
+    # Prerelease -- previous tag with the same base version AND channel.
+    BASE="${BASH_REMATCH[1]}"
+    CHANNEL="${BASH_REMATCH[2]}"
+    ESCAPED_BASE="${BASE//./\\.}"
+    PATTERN="^v${ESCAPED_BASE}-${CHANNEL}\\.[0-9]+\$"
+  else
+    echo "ERROR: could not parse TAG '${TAG}' as vX.Y.Z or vX.Y.Z-channel.N -- pass PREV_TAG explicitly." >&2
+    exit 1
+  fi
+
+  # git's own version-aware tag sort (newest first) -- portable across
+  # macOS/Linux, unlike `sort -V` which BSD sort doesn't support. Exclude
+  # TAG itself in case it already exists (the backfill/re-draft case);
+  # the first survivor is the most recent tag before TAG.
+  PREV_TAG="$(git tag --sort=-version:refname \
+    | grep -E "$PATTERN" \
+    | grep -v -x "$TAG" \
+    | head -1 || true)"
+
+  if [ -z "$PREV_TAG" ]; then
+    echo "ERROR: could not find a previous tag matching '${PATTERN}'. Pass PREV_TAG explicitly." >&2
+    exit 1
+  fi
+fi
+
+echo "TAG:      $TAG"
+echo "PREV_TAG: $PREV_TAG"
+
+# --- Resolve the range end (see NOTE ON RANGES above) -------------------
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  RANGE_END="$TAG"
+else
+  RANGE_END="HEAD"
+  echo "Note: ${TAG} is not an existing git tag yet -- rendering ${PREV_TAG}..HEAD instead."
+fi
+
+RANGE="${PREV_TAG}..${RANGE_END}"
+VERSION_NO_V="${TAG#v}"
+
+mkdir -p "$(dirname "$OUT_FILE")"
+
+# --- ELI5 section, seeded from any Release-Note: trailers already merged ---
+ELI5_BODY="$(git-cliff --strip all --tag "$TAG" --body "$(cat "$ELI5_TEMPLATE")" "$RANGE" 2>/dev/null || true)"
+
+if ! printf '%s' "$ELI5_BODY" | grep -q '^### '; then
+  # No Release-Note: trailers found in range yet (typical when drafting
+  # right after the range opens) -- still scaffold all four headings so
+  # the human has the right shape to fill in from the technical source
+  # material below.
+  ELI5_BODY="$(cat <<'EOF'
+### What's new
+
+<!-- No Release-Note: trailers found in this range yet -- add bullets, or pull from the technical changelog below. -->
+
+### What's fixed
+
+<!-- ditto -->
+
+### Performance
+
+<!-- ditto -->
+
+### Notes
+
+<!-- ditto -->
+EOF
+)"
+fi
+
+# --- Full technical render, for reference while polishing ---------------
+TECH_BODY="$(git-cliff --strip all "$RANGE" 2>/dev/null || true)"
+
+{
+  echo "# MeedyaDL ${VERSION_NO_V}"
+  echo
+  echo "<!-- one-line summary here -->"
+  echo
+  printf '%s\n' "$ELI5_BODY"
+  echo
+  echo "<!-- SOURCE (delete before publishing): full technical changelog for ${RANGE}, kept here as reference material while polishing the sections above per .github/release-notes/STYLE_GUIDE.md."
+  echo
+  printf '%s\n' "$TECH_BODY"
+  echo "-->"
+} > "$OUT_FILE"
+
+echo
+echo "Wrote: ${OUT_FILE}"
+echo "Polish per .github/release-notes/STYLE_GUIDE.md, then rename to drop .draft and commit."

--- a/scripts/release-notes/lint-notes.py
+++ b/scripts/release-notes/lint-notes.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+"""
+scripts/release-notes/lint-notes.py
+====================================
+
+Denylist-driven content linter for MeedyaDL release notes, over BOTH
+authoring surfaces:
+
+  - `Release-Note:` trailer lines (one per PR — read from stdin with
+    --trailer)
+  - committed tier-1 curated notes files (`.github/release-notes/*.md`,
+    passed as FILE arguments)
+
+Enforces the two requirements in `.github/release-notes/STYLE_GUIDE.md`:
+
+  (a) plain English / no commit-speak ("Hard bans" section), and
+  (b) never disclose HOW a feature is delivered — credentials, acquisition
+      paths, protocol/stream internals, storage/crypto internals
+      ("Never reveal how a feature is delivered" section).
+
+Design + denylist seed: `.github/audits/release-notes-policy-audit-2026-07-24.md`
+section 4 ("Enforcement design"). Two deliberate refinements over the seed's
+literal regex text, made while calibrating this script to be zero-finding
+on the actual (post-rewrite) corpus, both noted inline below:
+
+  1. `mechanism-private-key` uses `private keys?` (not `private key`) so the
+     plural form is caught too — a bare `\\bprivate key\\b` cannot match
+     "...private keys..." because `\\b` requires a boundary immediately
+     after "key", and "s" is a word character.
+  2. `commit-speak-backticked-identifier` carves out bare UI template
+     placeholders (`` `{album}` ``, `` `{platform}` ``) — these are
+     legitimate, user-facing filename/folder template variables (Settings
+     > filename templates), not code identifiers, and the audit's own
+     grading (v1.9.0.md) treats the `{platform}` template chip as a clean
+     UI element.
+
+This is a pure-stdlib script (no third-party deps), matching the house
+style of `tools/audit-checks/*.py`: zero-finding on a clean tree; add a
+negative test / seed line when changing the denylist.
+
+USAGE
+  lint-notes.py [--trailer] [--strict] [FILE ...]
+  echo "$LINE" | lint-notes.py --trailer
+  gh release view "$TAG" --json body --jq .body | lint-notes.py --live --strict
+
+  --trailer   Read newline-separated `Release-Note:` trailer text from
+              stdin instead of linting FILE arguments. Each stdin line is
+              treated as one independent trailer (already stripped of the
+              leading "Release-Note: " prefix by the caller — see
+              `.github/workflows/release-note-gate.yml` wiring).
+  --live      Read a single published release body from stdin (e.g. the
+              output of `gh release view --json body --jq .body`) and lint
+              it as one document, with the workflow-appended "Choose your
+              download" footer stripped first (same `_strip_footer` used
+              for committed files) so the footer's own boilerplate never
+              trips the denylist. Used by
+              `.github/workflows/release-body-audit.yml` to check bodies
+              after they are already public, since nothing else inspects
+              a body post-publication.
+  --strict    Escalate warning-tier findings to blocking (exit 1 if any
+              warning-tier finding exists, even with zero errors). Not
+              passed by any PR-time caller today (deliberate — see
+              "Severity policy" below); `release-body-audit.yml` passes it
+              on every `--live` invocation.
+
+SEVERITY POLICY
+  Error-tier findings (mechanism disclosure, commit-speak) always block,
+  everywhere. Warning-tier findings (the noisy heuristics: bare "API",
+  "JSON", "database", CamelCase, etc.) are calibrated to have a real
+  false-positive rate and are advisory at PR-authoring time (trailer lint,
+  tier-1 file lint) so a legitimate plain-English bullet doesn't get
+  blocked over a heuristic guess — a human is looking at the same PR
+  either way. The published-body audit is a different situation: nothing
+  else reviews these bodies again, so it is the one caller that always
+  runs `--strict`, matching the design note in
+  `.github/audits/release-notes-policy-audit-2026-07-24.md` §4.2 ("Tier:
+  warning (human review, --strict in nightly/manual runs)").
+
+EXIT CODES
+  0  no error-tier findings (and, under --strict, no warning-tier findings)
+  1  at least one error-tier finding (or, under --strict, any finding)
+
+OUTPUT
+  "  • path:line — [tier] rule: matched 'text'" per finding — errors
+  before warnings, then file/line order within each tier.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Allowlist: product/brand names that would otherwise trip the noisy
+# CamelCase heuristic (warning tier). Extend in-repo, reviewed — audit §4.1.
+# ---------------------------------------------------------------------------
+ALLOWLIST = {
+    "MeedyaDL", "MeedyaSuite", "MeedyaConverter", "MeedyaManager", "GitHub",
+    "MusicKit", "LRCGET", "LRCLIB", "YouTube", "SoundCloud", "AppImage",
+    "ChromeOS", "VoiceOver", "NVDA", "MacBook", "iTunes", "iPlayer",
+    "MusicBrainz", "AcoustID", "ReplayGain", "Raspberry Pi", "Dolby", "PyPI",
+}
+
+# A backticked span that is exactly a bare `{identifier}` template
+# placeholder (filename/folder template variables users configure in
+# Settings, e.g. `{album}`, `{platform}`) — see refinement 2 in the module
+# docstring.
+_TEMPLATE_PLACEHOLDER_RE = re.compile(r"^\{[A-Za-z_]+\}$")
+
+# The workflow-appended "Choose your download" footer is not authored
+# content — never lint it when pointed at a live/spliced release body.
+_FOOTER_MARKER = "## Choose your download"
+
+# ---------------------------------------------------------------------------
+# Denylist. Each rule is (name, compiled_regex). Tiers are enforced
+# separately below (errors always block; warnings only block under
+# --strict). Ordering within a tier mirrors audit §4.2 for traceability.
+# ---------------------------------------------------------------------------
+
+ERROR_MECHANISM_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("mechanism-token-phrase", re.compile(r"(?i)\b(developer|web[- ]?player|user|bearer|access|auth)\s+token\b")),
+    ("mechanism-token-standalone", re.compile(r"(?i)\btoken\b")),
+    ("mechanism-music-user-token", re.compile(r"(?i)\bMusic-User-Token\b")),
+    ("mechanism-jwt", re.compile(r"\bJWT\b")),
+    # Plural-inclusive — see refinement 1 in the module docstring.
+    ("mechanism-private-key", re.compile(r"(?i)\bprivate keys?\b")),
+    ("mechanism-p8", re.compile(r"\.p8\b")),
+    ("mechanism-keychain", re.compile(r"(?i)\bkeychain\b")),
+    ("mechanism-endpoint", re.compile(r"(?i)\bendpoint\b")),
+    ("mechanism-api-version-path", re.compile(r"\b/v[0-9]+/")),
+    ("mechanism-amp-api", re.compile(r"amp-api")),
+    ("mechanism-api-music-apple", re.compile(r"api\.music\.apple")),
+    # Broadened beyond the hyphenated "syllable-lyrics" endpoint name to
+    # also catch the underlying data-shape vocabulary that discloses the
+    # same acquisition-path detail without naming the endpoint itself —
+    # e.g. v1.10.1.md's "the difference between syllable-level and
+    # word-level timing in Apple's ... data" leaks exactly what the
+    # endpoint call is for even though it never says "syllable-lyrics".
+    ("mechanism-syllable-lyrics", re.compile(r"(?i)\b(?:syllable[- ](?:lyrics|level|timing)|word-level timing)\b")),
+    ("mechanism-scraping", re.compile(r"(?i)\b(scrape[sd]?|scraping)\b")),
+    ("mechanism-extraction", re.compile(r"(?i)\bextract(s|ed|ing|ion)?\b.{0,40}\b(token|cookie|credential)s?\b")),
+    ("mechanism-m3u8", re.compile(r"\bm3u8\b")),
+    ("mechanism-hls", re.compile(r"\bHLS\b")),
+    ("mechanism-ttml", re.compile(r"\bTTML\b")),
+    # STYLE_GUIDE.md's "Never reveal how a feature is delivered" section
+    # explicitly bans "retry or fallback behaviour against a service" as
+    # an acquisition-path disclosure, but no rule enforced it. Scoped to
+    # the inflected verb forms (retries/retried/retrying) co-occurring
+    # with "without"/"fetch"/"timeout" — NOT bare "retry", which is also
+    # the literal, allowed UI button/pill label ("Retry", "Retry without
+    # Wrapper" pill) that must stay unflagged. Matches both v1.3.0.md
+    # ("MeedyaDL retries without cover art instead of ... failing") and
+    # v1.11.0-alpha.23.md ("adds a proper timeout and automatic retry
+    # when fetching artwork").
+    ("mechanism-retry-against-service", re.compile(
+        r"(?i)\b(?:retr(?:ies|ied|ying)|timeout)\b.{0,80}\b(?:fetch\w*|without)\b"
+        r"|\b(?:fetch\w*|without)\b.{0,80}\b(?:retr(?:ies|ied|ying)|timeout)\b"
+    )),
+    # "Apple-side" (e.g. v1.3.0.md's "A known Apple-side bug") names which
+    # party's system a bug/workaround targets — an acquisition-path-shaped
+    # disclosure even without naming a specific API. Hyphenated form only
+    # ("Apple Music-side" reads as a plain adjective, not this pattern).
+    ("mechanism-apple-side", re.compile(r"(?i)\bApple-side\b")),
+    # Reverse-DNS bundle/app identifiers (e.g. com.meedyasuite.meedyadl)
+    # are packaging internals, never user-facing vocabulary.
+    ("mechanism-bundle-identifier", re.compile(r"(?i)\bcom\.[a-z0-9]+(?:\.[a-z0-9]+)+\b")),
+    ("mechanism-cdn", re.compile(r"(?i)\bCDN\b")),
+    # Naming a specific third-party lookup/resolution service (e.g. "the
+    # iTunes Lookup API") discloses an acquisition path the same way
+    # amp-api / api.music.apple already do for the other Apple endpoint.
+    # Deliberately does NOT match plain "lookup"/"lookups" alone (that's
+    # allowed capability language — see v1.9.0.md "cross-platform
+    # lookups", and "MusicBrainz lookups" in v1.11.0-alpha.31.md, where
+    # MusicBrainz is itself allowlisted, literal Settings-toggle
+    # vocabulary) — only the specific named-service or api/service/
+    # endpoint-qualified shape.
+    ("mechanism-lookup-service", re.compile(
+        r"(?i)\biTunes Lookup\b|\b(?:lookup|resolution)\s+(?:api|service|endpoint)\b"
+    )),
+    # Negative lookahead allows the Settings label "decryption address".
+    ("mechanism-decrypt", re.compile(r"(?i)\bdecrypt(ion|ing|ed)?\b(?!.{0,20}address)")),
+    ("mechanism-aes", re.compile(r"(?i)\bAES-[0-9]+")),
+    ("mechanism-pbkdf", re.compile(r"\bPBKDF")),
+    ("mechanism-sha", re.compile(r"\bSHA-?[0-9]+")),
+    ("mechanism-iterations", re.compile(r"[0-9][0-9\s]*iterations")),
+    ("mechanism-sqlite", re.compile(r"(?i)\bSQLite\b")),
+    ("mechanism-webview", re.compile(r"\bWebView\b")),
+    ("mechanism-js-evaluation", re.compile(r"(?i)\bJavaScript evaluation\b")),
+]
+
+COMMIT_SPEAK_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("commit-speak-snake-case", re.compile(r"\b[a-z0-9]+_[a-z0-9]+_?[a-z0-9]*\b")),
+    ("commit-speak-cli-flag", re.compile(r"--[a-z][a-z0-9-]+\b")),
+    ("commit-speak-function-call", re.compile(r"\b\w+\(\)")),
+    ("commit-speak-backticked-identifier", re.compile(r"`[^`]*[_(){}]`")),
+    ("commit-speak-cliff-header", re.compile(r"^## \[[0-9]", re.MULTILINE)),
+    ("commit-speak-scope-prefix-bullet", re.compile(r"^\s*-\s*\*\*\([a-z-]+\)\*\*", re.MULTILINE)),
+    ("commit-speak-bare-issue-citation", re.compile(r"\(#[0-9]+(,\s*#[0-9]+)*\)$", re.MULTILINE)),
+    ("commit-speak-jargon", re.compile(r"(?i)\b(refactor|wire[- ]up|hoist)\b")),
+    ("commit-speak-draft-source-residue", re.compile(r"<!--\s*SOURCE")),
+]
+
+WARNING_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("warn-konami", re.compile(r"(?i)Konami")),
+    ("warn-api", re.compile(r"(?i)\bAPI\b")),
+    ("warn-json", re.compile(r"(?i)\bJSON\b")),
+    ("warn-database", re.compile(r"(?i)\bdatabase\b")),
+    ("warn-apples-x", re.compile(r"(?i)Apple's .{0,20}(data|format|service)")),
+    ("warn-commit-jargon-common", re.compile(r"(?i)\b(emit|guard|gate)\b")),
+    ("warn-camelcase", re.compile(r"\b[A-Z][a-z]+[A-Z]\w*\b")),
+]
+
+# (tier_label, rules) in severity order for both matching and reporting.
+_TIERED_RULESETS: list[tuple[str, list[tuple[str, re.Pattern[str]]]]] = [
+    ("error", ERROR_MECHANISM_RULES),
+    ("error", COMMIT_SPEAK_RULES),
+    ("warning", WARNING_RULES),
+]
+
+
+class Finding:
+    __slots__ = ("path", "line_no", "tier", "rule", "text")
+
+    def __init__(self, path: str, line_no: int, tier: str, rule: str, text: str) -> None:
+        self.path = path
+        self.line_no = line_no
+        self.tier = tier
+        self.rule = rule
+        self.text = text
+
+    def render(self) -> str:
+        return f"  • {self.path}:{self.line_no} — [{self.tier}] {self.rule}: matched '{self.text}'"
+
+
+def _strip_footer(lines: list[str]) -> list[str]:
+    """Drop the workflow-appended 'Choose your download' footer onward —
+    it is not authored content and must never trip the linter when this
+    script is pointed at a live/spliced release body."""
+    for i, line in enumerate(lines):
+        if line.strip() == _FOOTER_MARKER:
+            return lines[:i]
+    return lines
+
+
+def _is_allowlisted_camelcase(matched: str) -> bool:
+    return matched in ALLOWLIST
+
+
+def _is_allowlisted_backtick(matched: str) -> bool:
+    """True if a `commit-speak-backticked-identifier` match is actually a
+    bare UI template placeholder (refinement 2 in the module docstring)."""
+    inner = matched.strip("`")
+    return bool(_TEMPLATE_PLACEHOLDER_RE.match(inner))
+
+
+def lint_text(text: str, path: str, strip_footer: bool = False) -> list[Finding]:
+    """Run every rule against `text`, returning findings in
+    error-then-warning, file-order sequence. `path` is only used for
+    reporting — pass a synthetic label like "trailer" for stdin input."""
+    lines = text.splitlines()
+    if strip_footer:
+        lines = _strip_footer(lines)
+
+    findings: list[Finding] = []
+    for tier, ruleset in _TIERED_RULESETS:
+        for rule_name, pattern in ruleset:
+            for line_no, line in enumerate(lines, start=1):
+                for m in pattern.finditer(line):
+                    matched = m.group(0)
+                    if rule_name == "warn-camelcase" and _is_allowlisted_camelcase(matched):
+                        continue
+                    if rule_name == "commit-speak-backticked-identifier" and _is_allowlisted_backtick(matched):
+                        continue
+                    findings.append(Finding(path, line_no, tier, rule_name, matched))
+    return findings
+
+
+def lint_file(file_path: Path) -> list[Finding]:
+    text = file_path.read_text(encoding="utf-8", errors="ignore")
+    return lint_text(text, str(file_path), strip_footer=True)
+
+
+def lint_trailer_stream(stream: str) -> list[Finding]:
+    """Each stdin line is an independent trailer — line numbers in the
+    report therefore mean "the Nth trailer line on stdin", not a position
+    inside a file."""
+    findings: list[Finding] = []
+    for i, line in enumerate(stream.splitlines(), start=1):
+        if not line.strip():
+            continue
+        line_findings = lint_text(line, "trailer", strip_footer=False)
+        # Re-number: lint_text() reports the line's own internal position
+        # (always 1, since a trailer is single-line), but the report should
+        # identify *which* trailer on stdin tripped the rule.
+        findings.extend(Finding("trailer", i, f.tier, f.rule, f.text) for f in line_findings)
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    trailer_mode = "--trailer" in args
+    live_mode = "--live" in args
+    strict = "--strict" in args
+    file_args = [a for a in args if a not in ("--trailer", "--live", "--strict")]
+
+    if trailer_mode and live_mode:
+        print("lint-notes.py: --trailer and --live are mutually exclusive", file=sys.stderr)
+        return 2
+
+    all_findings: list[Finding] = []
+
+    if trailer_mode:
+        stdin_text = sys.stdin.read()
+        all_findings.extend(lint_trailer_stream(stdin_text))
+    elif live_mode:
+        # A single published release body, read whole off stdin (see
+        # `.github/workflows/release-body-audit.yml`). Footer-stripped
+        # the same way a committed file is — the workflow-appended
+        # "Choose your download" section is not authored content.
+        stdin_text = sys.stdin.read()
+        all_findings.extend(lint_text(stdin_text, "live", strip_footer=True))
+    else:
+        if not file_args:
+            print("lint-notes.py: no FILE arguments given (and --trailer/--live not set)", file=sys.stderr)
+            print(__doc__, file=sys.stderr)
+            return 2
+        for arg in file_args:
+            fp = Path(arg)
+            if not fp.is_file():
+                print(f"lint-notes.py: {arg}: not a file", file=sys.stderr)
+                return 2
+            all_findings.extend(lint_file(fp))
+
+    errors = [f for f in all_findings if f.tier == "error"]
+    warnings = [f for f in all_findings if f.tier == "warning"]
+
+    for f in errors:
+        print(f.render())
+    for f in warnings:
+        print(f"::warning::{f.render().strip()}")
+
+    total = len(errors) + len(warnings)
+    if total == 0:
+        print("OK — no mechanism-disclosure or commit-speak findings.")
+    else:
+        print(f"\n{len(errors)} error(s), {len(warnings)} warning(s).")
+
+    if errors:
+        return 1
+    if strict and warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release-notes/splice-body.py
+++ b/scripts/release-notes/splice-body.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# scripts/release-notes/splice-body.py
+# =====================================
+#
+# Shared footer-preserving splice for GitHub Release bodies. Replaces
+# everything ABOVE the "## Choose your download" footer (appended by
+# release.yml's finalize-release job once platform builds finish) with a
+# fresh notes file, while keeping the footer -- and the "---" divider
+# immediately above it -- byte-for-byte intact.
+#
+# Factored out of apply-notes.sh (#1028) so the exact same footer regex
+# is used by BOTH:
+#   - scripts/release-notes/apply-notes.sh (curated tier-1 notes, run by
+#     a maintainer / CI against a stable or a pre-staged prerelease file)
+#   - .github/workflows/release.yml's "ensure-release" self-heal path
+#     (#1046 -- regenerates + splices a commit-speak prerelease body
+#     automatically on re-run, no hand-editing required)
+#
+# USAGE:
+#   splice-body.py <notes_file> <body_file> <out_file>
+#
+#   notes_file  Path to the new notes content (Markdown, no footer).
+#   body_file   Path to the CURRENT release body (may or may not already
+#               have a "## Choose your download" footer appended).
+#   out_file    Where to write the spliced result.
+#
+# BEHAVIOUR:
+#   - If body_file contains "\n---\n\n## Choose your download" (the
+#     divider release.yml's finalize-release job inserts before the
+#     table), everything from that "---" onward is preserved verbatim
+#     and appended after notes_file + a blank line.
+#   - Else if body_file contains a bare "## Choose your download" heading
+#     with no divider (unlikely, but tolerated), everything from the
+#     heading onward is preserved.
+#   - Else (no footer yet -- builds haven't finished) the output is just
+#     notes_file with a trailing newline.
+#
+# Exits 0 always; this script never fails on "no footer found" since
+# that's a normal, expected state (pre-build-completion).
+
+import re
+import sys
+
+
+def splice(notes: str, body: str) -> str:
+    """Return notes + the preserved "Choose your download" footer (if any)
+    from body. notes is expected to already be stripped of trailing
+    newlines by the caller; this function re-normalises regardless."""
+    notes = notes.rstrip("\n")
+
+    # Primary: the "---" divider line immediately before the heading.
+    # Match starts at the newline before the dashes so we can step past
+    # it and land exactly on the first "-".
+    divider = re.search(r"\n-{3,}\s*\n+(?=## Choose your download)", body)
+    if divider:
+        footer = body[divider.start() + 1 :]
+    else:
+        # Fallback: no divider found (e.g. a release object with no build
+        # table appended yet, or a hand-edited body) -- footer starts at
+        # the heading itself, if present at all.
+        heading = re.search(r"^## Choose your download", body, re.MULTILINE)
+        footer = body[heading.start() :] if heading else ""
+
+    if footer:
+        return notes + "\n\n" + footer
+    return notes + "\n"
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "Usage: splice-body.py <notes_file> <body_file> <out_file>",
+            file=sys.stderr,
+        )
+        return 1
+
+    notes_path, body_path, out_path = sys.argv[1:4]
+
+    with open(notes_path, "r", encoding="utf-8") as f:
+        notes = f.read()
+
+    with open(body_path, "r", encoding="utf-8") as f:
+        body = f.read()
+
+    result = splice(notes, body)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(result)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release-notes/test_lint_notes.py
+++ b/scripts/release-notes/test_lint_notes.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+"""
+scripts/release-notes/test_lint_notes.py
+=========================================
+
+Negative-test fixtures for `scripts/release-notes/lint-notes.py`'s
+denylist, per the repo convention in `tools/audit-checks/README.md`
+("zero-finding on a clean tree; add a negative test when changing the
+denylist") — extended here into an actual runnable assertion set rather
+than a manual "inject the drift, confirm it's caught, revert" pass,
+since the denylist itself has no test coverage otherwise.
+
+Each case is (label, text, expected_rule). `expected_rule` is the rule
+name that MUST appear in the findings for that text (a positive/"catches"
+case), or `None` for a negative/"stays clean" case, where `expected_rule`
+is instead read as "this specific rule name must NOT appear" (the
+adjacent-phrasing false-positive check that matters most for a denylist
+this size — see the `assert_clean_of` cases below).
+
+Pure stdlib, no pytest — same house style as `tools/audit-checks/*.py`.
+Run directly: `python3 scripts/release-notes/test_lint_notes.py`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_LINT_NOTES_PATH = _SCRIPT_DIR / "lint-notes.py"
+
+# lint-notes.py has a hyphen in its filename (matches the repo's CLI-script
+# naming convention), so it can't be `import`ed normally — load it by path.
+_spec = importlib.util.spec_from_file_location("lint_notes", _LINT_NOTES_PATH)
+assert _spec is not None and _spec.loader is not None
+lint_notes = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_notes)
+
+
+def _rule_names(text: str) -> set[str]:
+    return {f.rule for f in lint_notes.lint_text(text, "fixture")}
+
+
+# ---------------------------------------------------------------------------
+# Positive cases: this exact rule MUST fire on this text.
+# ---------------------------------------------------------------------------
+CATCHES: list[tuple[str, str, str]] = [
+    (
+        "syllable-level (hyphenated) is caught",
+        "MeedyaDL now recognises the difference between syllable-level and standard timing.",
+        "mechanism-syllable-lyrics",
+    ),
+    (
+        "word-level timing is caught",
+        "It preserves word-level timing in a plain-text-editable document.",
+        "mechanism-syllable-lyrics",
+    ),
+    (
+        "Apple-side (hyphenated) is caught",
+        "A known Apple-side bug is now automatically worked around.",
+        "mechanism-apple-side",
+    ),
+    (
+        "retries-without-X-instead-of-Y is caught",
+        "MeedyaDL retries without cover art instead of the whole download failing.",
+        "mechanism-retry-against-service",
+    ),
+    (
+        "timeout-and-retry-when-fetching is caught",
+        "An upstream update adds a proper timeout and automatic retry when fetching artwork.",
+        "mechanism-retry-against-service",
+    ),
+    (
+        "reverse-DNS bundle identifier is caught",
+        "The desktop app's identifier is com.meedyasuite.meedyadl.",
+        "mechanism-bundle-identifier",
+    ),
+    (
+        "CDN is caught",
+        "Assets now load faster from our CDN.",
+        "mechanism-cdn",
+    ),
+    (
+        "named iTunes Lookup service is caught",
+        "MeedyaDL now queries the iTunes Lookup API for extra track details.",
+        "mechanism-lookup-service",
+    ),
+    (
+        "generic lookup-service phrasing is caught",
+        "A new lookup service resolves cross-platform links automatically.",
+        "mechanism-lookup-service",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Negative cases: the named rule must NOT fire on this adjacent, allowed
+# phrasing. This is the false-positive guard — the whole reason these
+# rules are scoped as tightly as they are (see the inline comments next
+# to each rule in lint-notes.py).
+# ---------------------------------------------------------------------------
+STAYS_CLEAN_OF: list[tuple[str, str, str]] = [
+    (
+        "word-by-word is the approved phrasing, not a syllable/word-level leak",
+        "Word-by-word synced lyrics download more reliably.",
+        "mechanism-syllable-lyrics",
+    ),
+    (
+        "'Apple Music-side' is plain adjective use, not the hyphenated Apple-side pattern",
+        "A known Apple Music-side quirk with music-video artwork is fixed.",
+        "mechanism-apple-side",
+    ),
+    (
+        "the literal 'Retry without Wrapper' UI pill label is not a retry-against-service leak",
+        '"Retry without Wrapper" pill is now actually visible when a download fails.',
+        "mechanism-retry-against-service",
+    ),
+    (
+        "an ordinary compare/repo URL is not a bundle identifier",
+        "See github.com/MWBMPartners/MeedyaDL for the full technical changelog.",
+        "mechanism-bundle-identifier",
+    ),
+    (
+        "'MusicBrainz lookups' is allowed capability language (MusicBrainz is allowlisted)",
+        "The activity log now shows more detail while MusicBrainz lookups run.",
+        "mechanism-lookup-service",
+    ),
+    (
+        "plain 'cross-platform lookups' capability language is not the lookup-service pattern",
+        "Cross-region matching for cross-platform lookups now works correctly.",
+        "mechanism-lookup-service",
+    ),
+]
+
+
+def _run_corpus_regression() -> list[str]:
+    """Every committed release-notes file must be error-tier clean — this
+    is the same invariant `release-note-gate.yml` enforces per-file, run
+    here too so a denylist change that regresses the whole corpus fails
+    loudly in the same place as the rule-level fixtures above."""
+    failures: list[str] = []
+    notes_dir = _SCRIPT_DIR.parent.parent / ".github" / "release-notes"
+    for fp in sorted(notes_dir.glob("v*.md")):
+        findings = lint_notes.lint_file(fp)
+        errors = [f for f in findings if f.tier == "error"]
+        if errors:
+            rendered = ", ".join(f"{f.rule}:'{f.text}'" for f in errors)
+            failures.append(f"{fp.name} has error-tier findings: {rendered}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for label, text, expected_rule in CATCHES:
+        found = _rule_names(text)
+        if expected_rule not in found:
+            failures.append(
+                f"CATCHES failed: {label!r} — expected rule {expected_rule!r} "
+                f"in findings, got {sorted(found)!r}"
+            )
+
+    for label, text, forbidden_rule in STAYS_CLEAN_OF:
+        found = _rule_names(text)
+        if forbidden_rule in found:
+            failures.append(
+                f"STAYS_CLEAN_OF failed: {label!r} — rule {forbidden_rule!r} "
+                f"fired on allowed text {text!r}"
+            )
+
+    failures.extend(_run_corpus_regression())
+
+    total_cases = len(CATCHES) + len(STAYS_CLEAN_OF)
+    if failures:
+        print(f"{len(failures)} failure(s) out of {total_cases} rule fixtures + corpus regression:\n")
+        for f in failures:
+            print(f"  • {f}")
+        return 1
+
+    print(f"OK — {total_cases} rule fixtures passed, corpus regression clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src-tauri/src/services/download_queue.rs
+++ b/src-tauri/src/services/download_queue.rs
@@ -5705,7 +5705,7 @@ pub fn process_queue(
             &download_id,
             &format!(
                 "URLs: {:?} | Codec: {} | Native priority: {}",
-                &urls,
+                urls,
                 primary_codec_for_companions,
                 download_options.song_codec_priority.is_some()
             ),


### PR DESCRIPTION
## Summary

Closes the "**release-candidate PRs run no CI**" gap. Promotes alpha's authoritative `ci.yml` and `release-note-gate.yml` to `release-candidate`, which had drifted behind.

Release-Note: none

## The gap

A `pull_request` event uses the **base branch's** workflow files. `release-candidate`'s `ci.yml` only triggered on `pull_request: [main]`, and it had **no** `release-note-gate.yml` — so a PR targeting `release-candidate` matched *nothing* and ran **zero CI**. Anything could merge and its push-triggered `release-candidate-release.yml` would ship an unvalidated build to a channel users can opt into. (This is why #1095 and #1096 merged with no checks.)

## Change

- **`ci.yml`** → alpha's version: `pull_request`/`push` now trigger on `[main, alpha, beta, release-candidate]`. Promoting the *full* file (not just the trigger) also brings alpha's CI-reliability fixes the stale copy lacked:
  - #823 Windows pwsh hardening (`npm ci --no-audit --no-fund --no-progress` + `shell: bash`)
  - macOS upstream-rustup setup that bypasses the Homebrew cargo shim
  - cargo-provenance verification steps

  …so CI on this channel actually **passes**, not just runs.
- **`release-note-gate.yml`** (new) → channel PRs now require a `Release-Note:` line, matching alpha/main.

## Validation

- Both files are byte-identical to alpha's (checked out directly from `origin/alpha`); YAML parses cleanly.
- **Note:** this PR itself runs no CI (base branch `release-candidate` still has the old config until this merges) — inherent to fixing the trigger. Validated by construction (alpha runs these exact files); the first PR to `release-candidate` *after* this merges will exercise the full matrix.

## Scope

- [x] CI / workflows only (`.github/workflows/`)
- [ ] No app/Rust/TS/settings changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_