### PR TITLE
fix(rc): stop release-candidate-release self-trigger loop

### DIFF
--- a/.github/workflows/release-candidate-release.yml
+++ b/.github/workflows/release-candidate-release.yml
@@ -37,7 +37,13 @@ jobs:
   rc:
     name: Build release-candidate tag
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]' || github.event_name == 'workflow_dispatch'
+    # Self-trigger guard: the version-bump commit is authored by
+    # github-actions[bot] but PUSHED with RELEASE_PAT, so github.actor is the
+    # PAT owner (a human), NOT github-actions[bot] — the old actor-based guard
+    # never matched and the workflow re-triggered itself on its own bump commit
+    # (chore(rc): X -> push -> run -> bump -> push -> ... runaway loop).
+    # Gate on the commit message instead, which the bot controls directly.
+    if: "${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(rc): ') }}"
     steps:
       - name: Checkout release-candidate
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## URGENT — stops a runaway release loop

`release-candidate-release.yml` is self-triggering in an infinite loop (rc.22 → 23 → 24 → … one release + 6-platform build every ~1 min).

Release-Note: none

## Root cause

The workflow bumps the version, commits as `github-actions[bot]`, and **pushes with `RELEASE_PAT`**. Because the push actor (`github.actor`) is then the PAT owner (a human, `Salem874`) rather than `github-actions[bot]`, the guard `if: github.actor != 'github-actions[bot]'` **never matched the bot's own bump commit** — so each `chore(rc): X` push re-triggered the workflow, which bumped again, forever.

It was dormant only because the workflow always died at `cargo generate-lockfile` (stale `meedya-core` branch ref) before reaching the push step. Fixing that (#1096) released the loop.

I could not cancel the in-flight runs — the integration token lacks `actions: write` (403) — so this guard fix is the stop mechanism.

## Fix

Gate the job on the **commit message** (which the bot sets directly and a PAT can't mask) instead of the actor:

```yaml
if: "${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(rc): ') }}"
```

Any `chore(rc): …` bump push is now skipped; real promotions and `workflow_dispatch` still run. After merge there is **one** final release (from this merge commit, which isn't a `chore(rc):` message), and the loop terminates.

## Follow-ups (not in this PR)

- **Same latent bug exists in the sibling channel release workflows** (`beta-release.yml`, `alpha-release.yml`, `nightly`/`weekly`/`monthly-release.yml`) — they use the identical actor-based guard. `beta-release` should be checked for the same loop.
- The junk `rc.22…rc.N` tags/releases + their `release.yml` builds will need cleanup.

## Scope

- [x] CI workflow only (`release-candidate-release.yml`)
- [ ] No app/dependency changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_