### PR TITLE
ci(rust): pin toolchain to 1.98.0 + weekly auto-bump workflow

### DIFF
--- a/.github/workflows/rust-toolchain-bump.yml
+++ b/.github/workflows/rust-toolchain-bump.yml
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Rust Toolchain Bump Workflow for MeedyaDL
+# =========================================
+#
+# Keeps the pinned Rust toolchain (`src-tauri/rust-toolchain.toml`) from going
+# stale. On a weekly schedule (and on demand) it compares the pinned `channel`
+# against the current published stable and, when a newer stable has shipped,
+# opens a `chore(rust): bump toolchain to X.Y.Z` PR against each covered
+# channel branch. The PR's own CI run is the point: it surfaces any new clippy
+# lints or build changes the upgrade introduces BEFORE the bump lands, turning
+# a Rust upgrade into a deliberate, reviewable event instead of a surprise
+# reddening of some unrelated PR (the failure mode that motivated the pin).
+#
+# The bump PR is opened with RELEASE_PAT (not GITHUB_TOKEN) so that CI actually
+# triggers on it — a GITHUB_TOKEN-authored PR does not fire workflows.
+#
+# Only branches that already carry `src-tauri/rust-toolchain.toml` are bumped;
+# a branch without the pin is skipped (extend the matrix as beta / rc adopt it).
+
+name: Rust Toolchain Bump
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Detect + log only; do not open PRs'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: rust-toolchain-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Check + bump Rust toolchain (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, alpha]
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Detect pinned vs latest stable
+        id: detect
+        run: |
+          set -euo pipefail
+          TOML="src-tauri/rust-toolchain.toml"
+          if [ ! -f "$TOML" ]; then
+            echo "::notice::$TOML absent on ${{ matrix.branch }} — nothing to bump"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PINNED=$(grep -E '^[[:space:]]*channel[[:space:]]*=' "$TOML" | sed -E 's/.*"([^"]+)".*/\1/')
+          LATEST=$(curl -sSf --max-time 30 https://static.rust-lang.org/dist/channel-rust-stable.toml \
+            | awk '/^\[pkg\.rust\]/{f=1} f && /^version = /{print; exit}' \
+            | sed -E 's/version = "([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          if [ -z "$LATEST" ]; then
+            echo "::error::could not parse latest stable Rust version from the channel manifest"
+            exit 1
+          fi
+          echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          if [ "$PINNED" = "$LATEST" ]; then
+            echo "::notice::${{ matrix.branch }} already pinned to latest stable $PINNED"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$(printf '%s\n%s\n' "$PINNED" "$LATEST" | sort -V | tail -1)" = "$LATEST" ]; then
+            echo "::notice::${{ matrix.branch }}: newer stable available: $PINNED -> $LATEST"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::${{ matrix.branch }}: pinned $PINNED is newer than channel-stable $LATEST — leaving as-is"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open bump PR
+        if: ${{ steps.detect.outputs.skip == 'false' && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          PINNED: ${{ steps.detect.outputs.pinned }}
+          LATEST: ${{ steps.detect.outputs.latest }}
+          BASE: ${{ matrix.branch }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/rust-toolchain-bump-${LATEST}-${BASE}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          # Update only the channel line; leave components/profile untouched.
+          sed -i -E "s/^([[:space:]]*channel[[:space:]]*=[[:space:]]*)\"[^\"]+\"/\1\"${LATEST}\"/" src-tauri/rust-toolchain.toml
+          if git diff --quiet -- src-tauri/rust-toolchain.toml; then
+            echo "::warning::channel line unchanged after sed — aborting to avoid an empty PR"
+            exit 0
+          fi
+          git add src-tauri/rust-toolchain.toml
+          # -m paragraphs (not a heredoc) so the YAML block indentation never
+          # leaks into the commit body.
+          git commit \
+            -m "chore(rust): bump toolchain ${PINNED} -> ${LATEST}" \
+            -m "Automated by rust-toolchain-bump.yml. Pins the Rust toolchain to the current published stable ${LATEST}. This PR's CI run reveals any new clippy lints or build changes the upgrade introduces before it lands." \
+            -m "Release-Note: none"
+          # --force-with-lease: an older open bump branch for the same version
+          # is safe to overwrite; different versions use different branch names.
+          git push -u origin "$BRANCH" --force-with-lease
+          BODY=$(printf '## Automated Rust toolchain bump\n\nBumps the pinned Rust toolchain on `%s` from **%s** to **%s** (current published stable), editing only `src-tauri/rust-toolchain.toml`.\n\nOpened by `.github/workflows/rust-toolchain-bump.yml`. **The point of this PR is its CI run** — a new stable clippy can promote lints under `-D warnings`; if this PR is green the upgrade is safe to merge, and if it is red the lints should be fixed here (or the bump held) rather than surfacing on the next unrelated PR.\n\nRelease-Note: none\n' "$BASE" "$PINNED" "$LATEST")
+          gh pr create --base "$BASE" --head "$BRANCH" --title "chore(rust): bump toolchain to ${LATEST}" --body "$BODY"
+          echo "::notice::opened bump PR for ${BASE}: ${PINNED} -> ${LATEST}"

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 MeedyaSuite
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Pinned Rust toolchain — the single source of truth for the Rust version that
+# CI and local builds use. rustup reads this file and applies it as an override
+# for every cargo/rustc command run under `src-tauri/`, so `cargo check`,
+# `cargo clippy -- -D warnings`, and `cargo test` are all evaluated by exactly
+# this toolchain — regardless of what `dtolnay/rust-toolchain@stable` happens to
+# install at the workflow level (that step just bootstraps rustup; this pin wins
+# at cargo-invocation time).
+#
+# Why pin: CI used to float to the newest stable (dtolnay `@stable`, no pin), so
+# a fresh stable release could redden unrelated PRs with newly-promoted clippy
+# lints even though nothing in our code changed — e.g. `clippy::needless_match`
+# was promoted in 1.98 and broke an alpha PR that only touched a JSON file.
+# Pinning turns a Rust upgrade into a deliberate, reviewable PR instead of a
+# surprise. The scheduled `.github/workflows/rust-toolchain-bump.yml` workflow
+# opens that PR automatically when a newer stable ships, so the pin never goes
+# stale — and its CI run reveals any new lints before the bump lands.
+#
+# To upgrade Rust: bump `channel` (the auto-bump workflow does this for you).
+# Keep `components` in sync with what CI needs — `clippy` for `-D warnings`,
+# `rustfmt` for formatting checks.
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## What
Pins the Rust toolchain and adds automation to keep the pin fresh — the "pin + auto-bump" decision from the toolchain-drift discussion. **This is the `main` half** (the auto-bump workflow schedules only from the default branch, so it must live here); the alpha half is #1107.

1. **`src-tauri/rust-toolchain.toml`** — pins `channel = "1.98.0"` (current stable) with `components = ["clippy", "rustfmt"]`, `profile = "minimal"`.
2. **`.github/workflows/rust-toolchain-bump.yml`** — weekly (+ `workflow_dispatch`) job that opens a bump PR when a newer stable ships.

## Why
CI installed Rust via `dtolnay/rust-toolchain@<sha> # stable` — SHA-pinned *action*, floating *toolchain*. A fresh stable could redden **unrelated** PRs with newly-promoted clippy lints (`clippy::needless_match` was promoted in 1.98 and broke an alpha PR that only touched a JSON file). Pinning makes it deterministic; the auto-bump turns an upgrade into a deliberate, reviewable PR whose CI surfaces new lints before they land.

## How it works
- rustup applies `rust-toolchain.toml` as an **override** for cargo under `src-tauri/`, so clippy/check/test run under the pinned toolchain regardless of what `dtolnay@stable` installs. One source of truth for the version; no change to the macOS rustup setup.
- The bump workflow (matrix: `main`, `alpha`) compares the pin to the published stable manifest and, when newer, opens `chore(rust): bump toolchain to X.Y.Z` via **RELEASE_PAT** (so its CI runs). SHA-pinned `actions/checkout` + pre-installed `gh` CLI — no new third-party action.

## Risk / scope
- **Behaviour identical today** (1.98.0 == current stable) — only deterministic.
- beta / release-candidate pin + matrix extension is a fast follow-up.

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_