### PR TITLE
fix(ci): declare cross-compile targets in rust-toolchain.toml (unbreak ARM release builds)

### DIFF
--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -21,7 +21,22 @@
 # To upgrade Rust: bump `channel` (the auto-bump workflow does this for you).
 # Keep `components` in sync with what CI needs — `clippy` for `-D warnings`,
 # `rustfmt` for formatting checks.
+#
+# `targets` MUST list every cross-compile triple `release.yml` builds. Because
+# this pin resolves to the `1.98.0` toolchain — a rustup toolchain distinct
+# from the `stable` alias that release.yml's `dtolnay/rust-toolchain@stable`
+# step installs its `targets:` onto — cargo (which honours this pin) would
+# otherwise only have the host's `x86_64` std and the ARM release builds fail
+# with "Target … is not installed". The host triple installs automatically; the
+# non-host cross targets below must be declared here so rustup installs their
+# `rust-std` onto the pinned toolchain. Add a triple here whenever release.yml's
+# build matrix gains a new cross-compiled platform.
 [toolchain]
 channel = "1.98.0"
 components = ["clippy", "rustfmt"]
+targets = [
+  "aarch64-pc-windows-msvc",       # Windows ARM64 (cross-compiled from x64)
+  "aarch64-unknown-linux-gnu",     # Linux ARM64  (cross-compiled from x64)
+  "armv7-unknown-linux-gnueabihf", # Linux ARMv7  (cross-compiled from x64)
+]
 profile = "minimal"


### PR DESCRIPTION
## What
Adds `targets = [...]` (the three cross-compile triples) to `src-tauri/rust-toolchain.toml`.

## Why — regression from the toolchain pin (#1107)
alpha.52's release build **failed on all three ARM targets** (Linux ARM64, Linux ARMv7, Windows ARM64) with:
```
failed to build app: Target aarch64-unknown-linux-gnu is not installed
(installed targets: x86_64-unknown-linux-gnu).
```
The native targets (macOS, Windows x64, Linux x64) shipped fine.

**Root cause:** the pin `channel = "1.98.0"` resolves to a rustup toolchain **distinct from the `stable` alias**. `release.yml`'s `Setup Rust` step (`dtolnay/rust-toolchain@stable` with `targets: <triple>`) installs each ARM target's `rust-std` onto the **`stable`** toolchain — but cargo, honouring `rust-toolchain.toml`, uses the **`1.98.0`** toolchain, which only had the host `x86_64` std. So the cross-compiled jobs failed immediately at target resolution.

## Fix
Declare the cross-compile triples in `rust-toolchain.toml` so rustup installs their `rust-std` onto the **pinned** toolchain:
```toml
targets = [
  "aarch64-pc-windows-msvc",       # Windows ARM64
  "aarch64-unknown-linux-gnu",     # Linux ARM64
  "armv7-unknown-linux-gnueabihf", # Linux ARMv7
]
```
Host target still auto-installs. Add a triple here whenever `release.yml`'s matrix gains a cross platform.

## Verification note
This PR's `ci.yml` **does not cross-compile** (only `cargo check/clippy/test` on the host), so green CI here confirms the added targets install cleanly + don't regress the host build — but the **real** test is the next release build. After merge, alpha.53's `release.yml` run should show all three ARM jobs green; I'll confirm.

> Note: **alpha.52 shipped without ARM artifacts** (x64 + macOS only). alpha.53 (cut by this merge) will be the first complete build under the pin. Same fix targets `main` in a sibling PR — its `release.yml` cross-compiles identically.

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_