### PR TITLE
fix(ci): declare cross-compile targets in rust-toolchain.toml (unbreak ARM release builds)

### DIFF
--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -21,7 +21,22 @@
 # To upgrade Rust: bump `channel` (the auto-bump workflow does this for you).
 # Keep `components` in sync with what CI needs — `clippy` for `-D warnings`,
 # `rustfmt` for formatting checks.
+#
+# `targets` MUST list every cross-compile triple `release.yml` builds. Because
+# this pin resolves to the `1.98.0` toolchain — a rustup toolchain distinct
+# from the `stable` alias that release.yml's `dtolnay/rust-toolchain@stable`
+# step installs its `targets:` onto — cargo (which honours this pin) would
+# otherwise only have the host's `x86_64` std and the ARM release builds fail
+# with "Target … is not installed". The host triple installs automatically; the
+# non-host cross targets below must be declared here so rustup installs their
+# `rust-std` onto the pinned toolchain. Add a triple here whenever release.yml's
+# build matrix gains a new cross-compiled platform.
 [toolchain]
 channel = "1.98.0"
 components = ["clippy", "rustfmt"]
+targets = [
+  "aarch64-pc-windows-msvc",       # Windows ARM64 (cross-compiled from x64)
+  "aarch64-unknown-linux-gnu",     # Linux ARM64  (cross-compiled from x64)
+  "armv7-unknown-linux-gnueabihf", # Linux ARMv7  (cross-compiled from x64)
+]
 profile = "minimal"


### PR DESCRIPTION
## What
Adds `targets = [...]` (the three cross-compile triples) to `src-tauri/rust-toolchain.toml` on `main` — the sibling of #1109 (alpha).

## Why — regression from the toolchain pin (#1108)
The pin `channel = "1.98.0"` resolves to a rustup toolchain distinct from the `stable` alias that `release.yml`'s `Setup Rust` step installs its cross-compile `targets:` onto. cargo honours the pin, so the pinned toolchain only had the host `x86_64` std — every ARM release job fails at target resolution (`Target aarch64-unknown-linux-gnu is not installed`). This was observed on alpha.52; `main`'s `release.yml` cross-compiles the same six platforms, so it would fail identically on its next stable release.

## Fix
Declare the cross triples so rustup installs their `rust-std` onto the pinned toolchain:
```toml
targets = [
  "aarch64-pc-windows-msvc",       # Windows ARM64
  "aarch64-unknown-linux-gnu",     # Linux ARM64
  "armv7-unknown-linux-gnueabihf", # Linux ARMv7
]
```

## Verification note
`main` cuts releases via release-please (no immediate installer build on this merge), so this lands preventively — `main`'s next stable release build will be complete. The mechanism is validated on alpha (#1109 → alpha.53 release build).

Release-Note: none

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXLvhP2QYN4yBHwmBwRRUB)_